### PR TITLE
Add note to example about support for multiple CAs

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -3,6 +3,7 @@
 
 # PKI defines the location of credentials for this node. Each of these can also be inlined by using the yaml ": |" syntax.
 pki:
+  # The CAs that are accepted by this node. Must contain one or more certificates created by 'nebula-cert ca'
   ca: /etc/nebula/ca.crt
   cert: /etc/nebula/host.crt
   key: /etc/nebula/host.key


### PR DESCRIPTION
I was a bit confused by the `-groups` flag on the `nebula-cert ca` command and how to use it (as well as how to rotate the CAs since they expire after a year).

Took me some time (and reading) to connect the dots that the `pki.ca` can contain multiple CAs.
Maybe this a good first hint for others that this possible.