### PR TITLE
Support Path MTU Discovery

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -96,6 +96,16 @@ tun:
   tx_queue: 500
   # Default MTU for every packet, safe setting is (and the default) 1300 for internet based traffic
   mtu: 1300
+  # NOTE: EXPERIMENTAL
+  # Enable discovery of path MTU. This is meant for situations like on AWS
+  # where you have a default interface with mtu 9001 that only supports 1500 to
+  # internet destinations. This feature will allow the mtu to automatically be
+  # set as high as possible for both local connections and internet
+  # connections. Set `tun.mtu` to the highest mtu supported minus 60 (for AWS,
+  # when using Transit Gateway, use 8440, otherwise use 8941).
+  # Nebula will check for DontFragment on outgoing packets and respond with
+  # ICMP FragmentationNeeded if the packet is too large.
+  path_mtu_discovery: false
   # Route based MTU overrides, you have known vpn ip paths that can support larger MTUs you can increase/decrease them here
   routes:
     #- mtu: 8800

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 // indirect
 	github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6
 	github.com/golang/protobuf v1.3.1
+	github.com/google/gopacket v1.1.17
 	github.com/imdario/mergo v0.3.7
 	github.com/kardianos/service v1.0.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/gopacket v1.1.17 h1:rMrlX2ZY2UbvT+sdz3+6J+pp2z+msCq9MxTU6ymxbBY=
+github.com/google/gopacket v1.1.17/go.mod h1:UdDNZ1OO62aGYVnPhxT1U6aI7ukYtA/kB8vaU0diBUM=
 github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
@@ -101,6 +103,7 @@ golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190204203706-41f3e6584952/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190524152521-dbbf3f1254d4 h1:VSJ45BzqrVgR4clSx415y1rHH7QAGhGt71J0ZmhLYrc=

--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -94,9 +94,9 @@ func (c *HandshakeManager) NextOutboundHandshakeTimerTick(now time.Time, f EncWr
 
 			// Ensure the handshake is ready to avoid a race in timer tick and stage 0 handshake generation
 			if hostinfo.HandshakeReady && hostinfo.remote != nil {
-				err := c.outside.WriteTo(hostinfo.HandshakePacket[0], hostinfo.remote)
+				err := c.outside.WriteTo(hostinfo.HandshakePacket[0], hostinfo.remote.addr)
 				if err != nil {
-					l.WithField("vpnIp", IntIp(vpnIP)).WithField("udpAddr", hostinfo.remote).
+					l.WithField("vpnIp", IntIp(vpnIP)).WithField("udpAddr", hostinfo.remote.addr).
 						WithField("initiatorIndex", hostinfo.localIndexId).
 						WithField("remoteIndex", hostinfo.remoteIndexId).
 						WithField("handshake", m{"stage": 1, "style": "ix_psk0"}).
@@ -104,7 +104,7 @@ func (c *HandshakeManager) NextOutboundHandshakeTimerTick(now time.Time, f EncWr
 				} else {
 					//TODO: this log line is assuming a lot of stuff around the cached stage 0 handshake packet, we should
 					// keep the real packet struct around for logging purposes
-					l.WithField("vpnIp", IntIp(vpnIP)).WithField("udpAddr", hostinfo.remote).
+					l.WithField("vpnIp", IntIp(vpnIP)).WithField("udpAddr", hostinfo.remote.addr).
 						WithField("initiatorIndex", hostinfo.localIndexId).
 						WithField("remoteIndex", hostinfo.remoteIndexId).
 						WithField("handshake", m{"stage": 1, "style": "ix_psk0"}).

--- a/hostmap_test.go
+++ b/hostmap_test.go
@@ -98,7 +98,7 @@ func TestHostmap(t *testing.T) {
 
 	// Promotion should ensure that the best remote is chosen (y)
 	info.ForcePromoteBest(myNets)
-	assert.True(t, myNet.Contains(udp2ip(info.remote)))
+	assert.True(t, myNet.Contains(udp2ip(info.remote.addr)))
 
 }
 
@@ -127,7 +127,7 @@ func TestHostMap_rotateRemote(t *testing.T) {
 	// 1 remote, no panic
 	h.AddRemote(*NewUDPAddr(ip2int(net.IP{1, 1, 1, 1}), 0))
 	h.rotateRemote()
-	assert.Equal(t, udp2ipInt(h.remote), ip2int(net.IP{1, 1, 1, 1}))
+	assert.Equal(t, udp2ipInt(h.remote.addr), ip2int(net.IP{1, 1, 1, 1}))
 
 	h.AddRemote(*NewUDPAddr(ip2int(net.IP{1, 1, 1, 2}), 0))
 	h.AddRemote(*NewUDPAddr(ip2int(net.IP{1, 1, 1, 3}), 0))
@@ -135,17 +135,17 @@ func TestHostMap_rotateRemote(t *testing.T) {
 
 	// Rotate through those 3
 	h.rotateRemote()
-	assert.Equal(t, udp2ipInt(h.remote), ip2int(net.IP{1, 1, 1, 2}))
+	assert.Equal(t, udp2ipInt(h.remote.addr), ip2int(net.IP{1, 1, 1, 2}))
 
 	h.rotateRemote()
-	assert.Equal(t, udp2ipInt(h.remote), ip2int(net.IP{1, 1, 1, 3}))
+	assert.Equal(t, udp2ipInt(h.remote.addr), ip2int(net.IP{1, 1, 1, 3}))
 
 	h.rotateRemote()
-	assert.Equal(t, udp2ipInt(h.remote), ip2int(net.IP{1, 1, 1, 4}))
+	assert.Equal(t, udp2ipInt(h.remote.addr), ip2int(net.IP{1, 1, 1, 4}))
 
 	// Finally, we should start over
 	h.rotateRemote()
-	assert.Equal(t, udp2ipInt(h.remote), ip2int(net.IP{1, 1, 1, 1}))
+	assert.Equal(t, udp2ipInt(h.remote.addr), ip2int(net.IP{1, 1, 1, 1}))
 }
 
 func BenchmarkHostmappromote2(b *testing.B) {

--- a/inside.go
+++ b/inside.go
@@ -4,6 +4,8 @@ import (
 	"sync/atomic"
 
 	"github.com/flynn/noise"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
 	"github.com/sirupsen/logrus"
 )
 
@@ -40,7 +42,34 @@ func (f *Interface) consumeInsidePacket(packet []byte, fwPacket *FirewallPacket,
 	}
 
 	if !f.firewall.Drop(packet, *fwPacket, false, ci.peerCert, trustedCAs) {
-		f.send(message, 0, ci, hostinfo, hostinfo.remote, packet, nb, out)
+		remote := hostinfo.CurrentRemote()
+
+		if f.pathMTUDiscovery {
+			dontFragment := packet[6]&(byte(layers.IPv4DontFragment)<<5) != 0
+			if dontFragment {
+				remoteMTU := remote.GetMTU()
+				if remoteMTU > 0 && len(packet) > remoteMTU {
+					icmpResponse, err := createICMPFragmentationNeeded(packet, fwPacket, remoteMTU)
+					if err != nil {
+						l.WithField("vpnIp", IntIp(hostinfo.hostId)).
+							WithError(err).
+							Error("Failed to create ICMP Destination Unreachable response")
+						return
+					}
+
+					err = f.inside.WriteRaw(icmpResponse)
+					if err != nil {
+						l.WithField("vpnIp", IntIp(hostinfo.hostId)).
+							WithError(err).
+							Error("Failed to send ICMP Destination Unreachable response")
+					}
+					return
+				}
+			}
+		}
+
+		f.send(message, 0, ci, hostinfo, remote, packet, nb, out)
+
 		if f.lightHouse != nil && *ci.messageCounter%5000 == 0 {
 			f.lightHouse.Query(fwPacket.RemoteIP, f)
 		}
@@ -153,12 +182,12 @@ func (f *Interface) SendMessageToAll(t NebulaMessageType, st NebulaMessageSubTyp
 }
 
 func (f *Interface) sendMessageToAll(t NebulaMessageType, st NebulaMessageSubType, hostInfo *HostInfo, p, nb, b []byte) {
-	for _, r := range hostInfo.RemoteUDPAddrs() {
+	for _, r := range hostInfo.Remotes {
 		f.send(t, st, hostInfo.ConnectionState, hostInfo, r, p, nb, b)
 	}
 }
 
-func (f *Interface) send(t NebulaMessageType, st NebulaMessageSubType, ci *ConnectionState, hostinfo *HostInfo, remote *udpAddr, p, nb, out []byte) {
+func (f *Interface) send(t NebulaMessageType, st NebulaMessageSubType, ci *ConnectionState, hostinfo *HostInfo, remote *HostInfoDest, p, nb, out []byte) {
 	if ci.eKey == nil {
 		//TODO: log warning
 		return
@@ -178,17 +207,58 @@ func (f *Interface) send(t NebulaMessageType, st NebulaMessageSubType, ci *Conne
 	//ci.writeLock.Unlock()
 	if err != nil {
 		l.WithError(err).WithField("vpnIp", IntIp(hostinfo.hostId)).
-			WithField("udpAddr", remote).WithField("counter", c).
+			WithField("udpAddr", remote.addr).WithField("counter", c).
 			WithField("attemptedCounter", ci.messageCounter).
 			Error("Failed to encrypt outgoing packet")
 		return
 	}
 
-	err = f.outside.WriteTo(out, remote)
+	err = f.outside.WriteTo(out, remote.addr)
 	if err != nil {
 		l.WithError(err).WithField("vpnIp", IntIp(hostinfo.hostId)).
-			WithField("udpAddr", remote).Error("Failed to write outgoing packet")
+			WithField("udpAddr", remote.addr).Error("Failed to write outgoing packet")
 	}
+}
+
+// NOTE: This is only used when the experimental `tun.path_mtu_discovery`
+// feature is enabled.
+func createICMPFragmentationNeeded(packet []byte, fwPacket *FirewallPacket, mtu int) ([]byte, error) {
+	// https://tools.ietf.org/html/rfc1191#section-4
+	ipLayer := &layers.IPv4{
+		Version:  4,
+		TTL:      255,
+		Flags:    layers.IPv4DontFragment,
+		Protocol: layers.IPProtocolICMPv4,
+		SrcIP:    int2ip(fwPacket.RemoteIP),
+		DstIP:    int2ip(fwPacket.LocalIP),
+	}
+	icmpLayer := &layers.ICMPv4{
+		TypeCode: layers.CreateICMPv4TypeCode(
+			layers.ICMPv4TypeDestinationUnreachable,
+			layers.ICMPv4CodeFragmentationNeeded,
+		),
+		// Next-Hop MTU
+		Seq: uint16(mtu),
+	}
+	buffer := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{
+		FixLengths:       true,
+		ComputeChecksums: true,
+	}
+	// IP header + first 8 bytes of the original datagram's data
+	ihl := int(packet[0]&0x0f) << 2
+	payload := gopacket.Payload(packet[:ihl+8])
+
+	err := gopacket.SerializeLayers(buffer, opts,
+		ipLayer,
+		icmpLayer,
+		payload,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
 }
 
 func isMulticast(ip uint32) bool {

--- a/lighthouse_test.go
+++ b/lighthouse_test.go
@@ -50,7 +50,7 @@ func Test_lhStaticMapping(t *testing.T) {
 	lh1 := "10.128.0.2"
 	lh1IP := net.ParseIP(lh1)
 
-	udpServer, _ := NewListener("0.0.0.0", 0, true)
+	udpServer, _ := NewListener("0.0.0.0", 0, true, false)
 
 	meh := NewLightHouse(true, 1, []uint32{ip2int(lh1IP)}, 10, 10003, udpServer, false)
 	meh.AddRemote(ip2int(lh1IP), NewUDPAddr(ip2int(lh1IP), uint16(4242)), true)

--- a/outside.go
+++ b/outside.go
@@ -141,16 +141,16 @@ func (f *Interface) closeTunnel(hostInfo *HostInfo) {
 }
 
 func (f *Interface) handleHostRoaming(hostinfo *HostInfo, addr *udpAddr) {
-	if hostDidRoam(hostinfo.remote, addr) {
-		if !hostinfo.lastRoam.IsZero() && addr.Equals(hostinfo.lastRoamRemote) && time.Since(hostinfo.lastRoam) < RoamingSupressSeconds*time.Second {
+	if hostDidRoam(hostinfo.remote.addr, addr) {
+		if !hostinfo.lastRoam.IsZero() && addr.Equals(hostinfo.lastRoamRemote.addr) && time.Since(hostinfo.lastRoam) < RoamingSupressSeconds*time.Second {
 			if l.Level >= logrus.DebugLevel {
-				l.WithField("vpnIp", IntIp(hostinfo.hostId)).WithField("udpAddr", hostinfo.remote).WithField("newAddr", addr).
+				l.WithField("vpnIp", IntIp(hostinfo.hostId)).WithField("udpAddr", hostinfo.remote.addr).WithField("newAddr", addr).
 					Debugf("Supressing roam back to previous remote for %d seconds", RoamingSupressSeconds)
 			}
 			return
 		}
 
-		l.WithField("vpnIp", IntIp(hostinfo.hostId)).WithField("udpAddr", hostinfo.remote).WithField("newAddr", addr).
+		l.WithField("vpnIp", IntIp(hostinfo.hostId)).WithField("udpAddr", hostinfo.remote.addr).WithField("newAddr", addr).
 			Info("Host roamed to new udp ip/port.")
 		hostinfo.lastRoam = time.Now()
 		remoteCopy := *hostinfo.remote
@@ -329,8 +329,8 @@ func (f *Interface) handleRecvError(addr *udpAddr, h *Header) {
 	if !hostinfo.RecvErrorExceeded() {
 		return
 	}
-	if hostinfo.remote != nil && hostinfo.remote.String() != addr.String() {
-		l.Infoln("Someone spoofing recv_errors? ", addr, hostinfo.remote)
+	if hostinfo.remote != nil && !hostinfo.remote.addr.Equals(addr) {
+		l.Infoln("Someone spoofing recv_errors? ", addr, hostinfo.remote.addr)
 		return
 	}
 

--- a/ssh.go
+++ b/ssh.go
@@ -345,9 +345,18 @@ func sshListHostMap(hostMap *HostMap, a interface{}, w sshd.StringWriter) error 
 				"vpnIp":         int2ip(v.hostId),
 				"localIndex":    v.localIndexId,
 				"remoteIndex":   v.remoteIndexId,
-				"remoteAddrs":   v.RemoteUDPAddrs(),
+				"remotes":       v.Remotes,
 				"cachedPackets": len(v.packetStore),
 				"cert":          v.GetCert(),
+			}
+			if r := v.lastRoam; !v.lastRoam.IsZero() {
+				h["lastRoam"] = r
+			}
+			if r := v.lastRoamRemote; r != nil {
+				h["lastRoamRemote"] = r.addr.String()
+			}
+			if r := v.remote; r != nil {
+				h["remote"] = r.addr.String()
 			}
 
 			if v.ConnectionState != nil {

--- a/udp_generic.go
+++ b/udp_generic.go
@@ -46,7 +46,10 @@ func NewUDPAddrFromString(s string) *udpAddr {
 	}
 }
 
-func NewListener(ip string, port int, multi bool) (*udpConn, error) {
+func NewListener(ip string, port int, multi, pathMTUDiscovery bool) (*udpConn, error) {
+	if pathMTUDiscovery {
+		return nil, fmt.Errorf("path_mtu_discovery is not supported on this os")
+	}
 	lc := NewListenConfig(multi)
 	pc, err := lc.ListenPacket(context.TODO(), "udp4", fmt.Sprintf("%s:%d", ip, port))
 	if err != nil {
@@ -63,6 +66,10 @@ func (ua *udpAddr) Equals(t *udpAddr) bool {
 		return t == nil && ua == nil
 	}
 	return ua.IP.Equal(t.IP) && ua.Port == t.Port
+}
+
+func (ua *udpAddr) IPEquals(t *udpAddr) bool {
+	return ua.IP.Equal(t.IP)
 }
 
 func (uc *udpConn) WriteTo(b []byte, addr *udpAddr) error {
@@ -108,6 +115,13 @@ func (u *udpConn) ListenOut(f *Interface) {
 		udpAddr.UDPAddr = *rua
 		f.readOutsidePackets(udpAddr, plaintext[:0], buffer[:n], header, fwPacket, nb)
 	}
+}
+
+func GetKnownMTU(target net.IP) (int, error) {
+	return 0, nil
+}
+
+func (u *udpConn) HandleErrQueue(f *Interface) {
 }
 
 func udp2ip(addr *udpAddr) net.IP {


### PR DESCRIPTION
Overview
--------

This change allows the discovery and propagation of the path MTU. Until further
testing in the wild is done, you must set `tun.path_mtu_discovery = true` to
enable it.

This is change meant for situations like on AWS where you have a default
interface with MTU 9001 that only supports 1500 to internet destinations. It is
not anticipated to be used to discover the MTU over the internet, only to
the local gateway (although it should work in all cases)

Set `tun.mtu` to the highest mtu supported minus 60. Nebula will check for
DontFragment on outgoing packets and respond with ICMP "Destination Unreachable
Fragmentation Needed" if the packet is too large, which allows TCP
connections to the tun device to automatically set MSS (see RFC 1191).

An example config that could be used:

    preferred_ranges:
      - 10.0.0.0/9
    tun:
      path_mtu_discovery: true
      mtu: 8941 # (9001 - 60)

This would advertise a high MTU on the tun device, and use path MTU
discovery to reduce the MTU on any paths that end up over the internet.

Design
------

The initial implementation is only for Linux.

There are multiple ways to implement this, each with their own trade
offs:

1) Use IP_PMTUDISC_WANT on the outside socket.

- Pros: simple support for sending packets that want fragmentation.
- Cons: Need cache invalidation. There could be a race between checking
  the current MTU and the OS discovering the actual MTU if other
  processes are connecting to the same remote.

2) Use IP_PMTUDISC_DO and manualy fragment large packets.

- Pros: Don't need cache invalidation.
- Cons: Nebula meta packets would need fragmentation support,
  complicating the implementation.

3) Use IP_PMTUDISC_DO and use raw sockets to send large packets.

- Pros: Don't have to deal with fragmentation logic in Nebula.
- Cons: Two code paths for sending, and requires raw socket support.

4) Use IP_PMTUDISC_DO and use SO_REUSEPORT with a second socket to send
   large packets.

- Pros: Same as (3) but you don't need raw sockets.
- Cons: Using SO_REUSEPORT allows weird things to happen if you
  accidentally start two Nebula processes or something else listening on
  the same port.

After reviewing these options, (1) was selected for the first
implementation because it is fairly easy and the race conditions should
be rare. Switching to (2) or (3) in the future might be a good idea if
we review the trade offs more.

Implementation
--------------

`IP_RECVERR` is set on the outside UDP socket so that we can receive the
FragmentationNeeded packets that come from upstream. We set up
a goroutine to poll for these events and update our cache of the route MTU.

When a new route is attempted, we first look up IP_MTU on the socket to
see what the OS has currently cached as the MTU for the route. Because
we are using IP_PMTUDISC_WANT we will only receive error events when
the OS cached IP_MTU is wrong, so we need to ensure we check it before
sending packets. We internally cache the MTU for 1 minute before checking
IP_MTU again.