### PR TITLE
Add a configuration option to change the DNS server listen port.

### DIFF
--- a/dns_server.go
+++ b/dns_server.go
@@ -106,7 +106,7 @@ func handleDnsRequest(w dns.ResponseWriter, r *dns.Msg) {
 	w.WriteMsg(m)
 }
 
-func dnsMain(hostMap *HostMap) {
+func dnsMain(listenPort int, hostMap *HostMap) {
 
 	dnsR = newDnsRecords(hostMap)
 
@@ -114,7 +114,7 @@ func dnsMain(hostMap *HostMap) {
 	dns.HandleFunc(".", handleDnsRequest)
 
 	// start server
-	port := 53
+	port := listenPort
 	server := &dns.Server{Addr: ":" + strconv.Itoa(port), Net: "udp"}
 	l.Debugf("Starting DNS responder at %d\n", port)
 	err := server.ListenAndServe()

--- a/main.go
+++ b/main.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 	"github.com/slackhq/nebula/sshd"
+	"gopkg.in/yaml.v2"
 )
 
 var l = logrus.New()
@@ -189,6 +189,7 @@ func Main(configPath string, configTest bool, buildVersion string) {
 	punchBack := config.GetBool("punch_back", false)
 	amLighthouse := config.GetBool("lighthouse.am_lighthouse", false)
 	serveDns := config.GetBool("lighthouse.serve_dns", false)
+	dnsListenPort := config.GetInt("lighthouse.dns_listen_port", 53)
 	lightHouse := NewLightHouse(
 		amLighthouse,
 		ip2int(tunCidr.IP),
@@ -202,7 +203,7 @@ func Main(configPath string, configTest bool, buildVersion string) {
 
 	if amLighthouse && serveDns {
 		l.Debugln("Starting dns server")
-		go dnsMain(hostMap)
+		go dnsMain(dnsListenPort, hostMap)
 	}
 
 	for k, v := range config.GetMap("static_host_map", map[interface{}]interface{}{}) {


### PR DESCRIPTION
Allowing the specification of a custom port for the embedded DNS server would allow nebula to integrate onto servers where a DNS server is already running.