### PR TITLE
Added basic macOS signing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 BUILD_NUMBER ?= dev+$(shell date -u '+%Y%m%d%H%M%S')
 GO111MODULE = on
+TEAMID = BQR82RBBHL
 export GO111MODULE
 
 all:
@@ -42,6 +43,10 @@ bin-darwin:
 	GOARCH=amd64 GOOS=darwin go build -o build/darwin/nebula -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula
 	GOARCH=amd64 GOOS=darwin go build -o build/darwin/nebula-cert -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula-cert
 
+sign-darwin:
+	codesign -s $(TEAMID) --prefix "com.tinyspeck." --options=runtime --timestamp --force build/darwin/nebula
+	codesign -s $(TEAMID) --prefix "com.tinyspeck." --options=runtime --timestamp --force build/darwin/nebula-cert
+	
 bin-windows:
 	mkdir -p build/windows
 	GOARCH=amd64 GOOS=windows go build -o build/windows/nebula.exe -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula


### PR DESCRIPTION
In reference to issue #24 this adds a new make target for signing macOS binaries. I didn't integrate into release because it would seem weird to only have the macOS signing there and I don't have the moment right now to figure out the linux stuff and I don't know the Windows one.

But to my knowledge this is about what it should look like, the default TEAMID is the Slack one (pulled from the signed macOS Slack app) but can be overriden for enterprises deploying their own forks of nebula (or ones with unmerged master changes) with:

```
make TEAMID=<Some other TEAMID> sign-darwin
```