### PR TITLE
fix: allow macos nodes to ping themselves

### DIFF
--- a/tun_darwin.go
+++ b/tun_darwin.go
@@ -46,6 +46,13 @@ func (c *Tun) Activate() error {
 	if err = exec.Command("route", "-n", "add", "-net", c.Cidr.String(), "-interface", c.Device).Run(); err != nil {
 		return fmt.Errorf("failed to run 'route add': %s", err)
 	}
+	if err = exec.Command("route", "-n", "delete", c.Cidr.IP.String()).Run(); err != nil {
+		return fmt.Errorf("failed to run 'route delete': %s", err)
+	}
+	if err = exec.Command("route", "-n", "add", fmt.Sprintf("%s/32", c.Cidr.IP.String()), "127.0.0.1").Run(); err != nil {
+		return fmt.Errorf("failed to run 'route add': %s", err)
+	}
+
 	if err = exec.Command("ifconfig", c.Device, "mtu", strconv.Itoa(c.MTU)).Run(); err != nil {
 		return fmt.Errorf("failed to run 'ifconfig': %s", err)
 	}


### PR DESCRIPTION
fixes #38 

There is probably a better way to achieve this, but it works..
1. Delete 192.168.100.2 route
2. Create a new 192.168.100.2/32 route with a gateway of 127.0.0.1

What doesn't work?

Because we are creating our own route - it isn't cleaned up when nebula exits.