### PR TITLE
feat: adding docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:alpine as buildenv
+
+RUN mkdir -p /build/bin
+ADD . /build/
+WORKDIR /build
+RUN apk add make
+RUN make
+RUN make install
+
+FROM alpine:3.7
+COPY --from=buildenv /build/nebula /usr/bin/nebula
+COPY --from=buildenv /build/nebula-cert /usr/bin/nebula-cert
+WORKDIR /app
+CMD ["nebula"]


### PR DESCRIPTION
fixes #25 

Use a docker build envrionment and a seperate runtime environment to keep the image size down.

Build environment image size: 359mb
Runtime environment image size: 26.7mb

How to build:
```
$ docker build -t nebula .
```

How to use:
1. Copy (or create) your ca.crt and ca.key file in the CWD
```
$ docker run -it --rm \
  -v $(pwd):/app \
  nebula \
  nebula-cert ca -name "Myorganization, Inc"
```

2. Generate a certificate for the container
```
$ docker run -it --rm \
  -v $(pwd):/app \
  nebula \
  nebula-cert -name "container1" -groups "docker"
```

3. Create your [config.yaml](https://github.com/slackhq/nebula/blob/master/examples/config.yaml) for the container1 node.

4. Create the container and join the nebula
```
$ docker run -it --rm \
  --cap-add=NET_ADMIN --device /dev/net/tun \
  -v $(pwd):/app \
  nebula \
  nebula -config config.yaml
```

5. confirm that the host machine cannot ping another node
```
$ ping 192.168.100.1
PING 192.168.100.1 (192.168.100.1): 56 data bytes
Request timeout for icmp_seq 0
Request timeout for icmp_seq 1
Request timeout for icmp_seq 2
^C
--- 192.168.100.1 ping statistics ---
4 packets transmitted, 0 packets received, 100.0% packet loss
```

6. confirm that your docker container can ping another node
```
$ docker exec -it 5a87 sh
/app # ping 192.168.100.1
PING 192.168.100.1 (192.168.100.1): 56 data bytes
64 bytes from 192.168.100.1: seq=0 ttl=64 time=38.749 ms
64 bytes from 192.168.100.1: seq=1 ttl=64 time=38.388 ms
^C
--- 192.168.100.1 ping statistics ---
2 packets transmitted, 2 packets received, 0% packet loss
round-trip min/avg/max = 38.388/38.568/38.749 ms
```

I don't like that I have to add NET_ADMIN capabilities to the docker container.
I don't like that I have to provide the /dev/net/tun device to the docker container.

Maybe someone with more experience can resolve these two limitations