### PR TITLE
Allow configuration of dns listener host/port

### DIFF
--- a/dns_server.go
+++ b/dns_server.go
@@ -106,7 +106,7 @@ func handleDnsRequest(w dns.ResponseWriter, r *dns.Msg) {
 	w.WriteMsg(m)
 }
 
-func dnsMain(hostMap *HostMap) {
+func dnsMain(hostMap *HostMap, c *Config) {
 
 	dnsR = newDnsRecords(hostMap)
 
@@ -114,9 +114,9 @@ func dnsMain(hostMap *HostMap) {
 	dns.HandleFunc(".", handleDnsRequest)
 
 	// start server
-	port := 53
-	server := &dns.Server{Addr: ":" + strconv.Itoa(port), Net: "udp"}
-	l.Debugf("Starting DNS responder at %d\n", port)
+	addr := c.GetString("lighthouse.dns.host", "") + ":" + strconv.Itoa(c.GetInt("lighthouse.dns.port", 53))
+	server := &dns.Server{Addr: addr, Net: "udp"}
+	l.Debugf("Starting DNS responder at %s\n", addr)
 	err := server.ListenAndServe()
 	defer server.Shutdown()
 	if err != nil {

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -27,6 +27,10 @@ lighthouse:
   # serve_dns optionally starts a dns listener that responds to various queries and can even be
   # delegated to for resolution
   #serve_dns: false
+  #dns:
+    # The DNS host defines the IP to bind the dns listener to. This also allows binding to the nebula node IP.
+    #host: 0.0.0.0
+    #port: 53
   # interval is the number of seconds between updates from this node to a lighthouse.
   # during updates, a node sends information about its current IP addresses to each node.
   interval: 60


### PR DESCRIPTION
This allows configuration of the DNS listener host and port.

I had to move the DNS initialization to a later point in nebula startup to allow the node's nebula IP to be used as DNS bind host, as the interface has to be ready for the bind to succeed in that case. I don't think that should cause any side effects.

I've also added documentation of the config options to the example config. This is backwards-compatible, as it only adds config options. I opted to not move `serve_dns` into `lighthouse.dns.` for that reason.

Common usage scenarios would be changing the port in case another resolver is running on :53, or changing the host to localhost/<nebula node IP> should one not want to publish this on all interfaces.

I have tested this.