### PR TITLE
fix listen.host

### DIFF
--- a/udp_linux.go
+++ b/udp_linux.go
@@ -73,7 +73,7 @@ func NewListener(ip string, port int, multi bool) (*udpConn, error) {
 		return nil, fmt.Errorf("unable to set SO_REUSEPORT: %s", err)
 	}
 
-	if err = unix.Bind(fd, &unix.SockaddrInet4{Port: port}); err != nil {
+	if err = unix.Bind(fd, &unix.SockaddrInet4{Addr: lip, Port: port}); err != nil {
 		return nil, fmt.Errorf("unable to bind to socket: %s", err)
 	}
 


### PR DESCRIPTION
We were parsing `listen.host`, but not actually using it in the `bind`
call, so we were always binding to `0.0.0.0`.