### PR TITLE
Move tun mtu failing to an error log instead of fatal

### DIFF
--- a/tun_linux.go
+++ b/tun_linux.go
@@ -187,7 +187,8 @@ func (c Tun) Activate() error {
 	// Set the MTU on the device
 	ifm := ifreqMTU{Name: devName, MTU: int32(c.MaxMTU)}
 	if err = ioctl(fd, unix.SIOCSIFMTU, uintptr(unsafe.Pointer(&ifm))); err != nil {
-		return fmt.Errorf("failed to set tun mtu: %s", err)
+		// This is currently a non fatal condition because the route table must have the MTU set appropriately as well
+		l.WithError(err).Error("Failed to set tun mtu")
 	}
 
 	// Set the transmit queue length


### PR DESCRIPTION
As noted in the comment, the route table should have the MTU set as well. Failing to establish the route is a fatal.

closes #112 