### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,94 +3,45 @@ BUILD_NUMBER ?= dev+$(shell date -u '+%Y%m%d%H%M%S')
 GO111MODULE = on
 export GO111MODULE
 
-all: bin-linux bin-linux-386 bin-linux-ppc64le bin-arm bin-arm6 bin-arm64 bin-darwin bin-windows bin-mips bin-mipsle bin-mips64 bin-mips64le
+ALL = linux-amd64 \
+	  linux-386 \
+	  linux-ppc64le \
+	  linux-arm \
+	  linux-arm-6 \
+	  linux-arm64 \
+	  linux-mips \
+	  linux-mipsle \
+	  linux-mips64 \
+	  linux-mips64le \
+	  darwin-amd64 \
+	  windows-amd64
+
+all: $(ALL:%=build/%/nebula) $(ALL:%=build/%/nebula-cert)
+
+release: $(ALL:%=build/nebula-%.tar.gz)
 
 bin:
-	go build -ldflags "-X main.Build=$(BUILD_NUMBER)" -o ./nebula ${NEBULA_CMD_PATH}
-	go build -ldflags "-X main.Build=$(BUILD_NUMBER)" -o ./nebula-cert ./cmd/nebula-cert
+	go build -trimpath -ldflags "-X main.Build=$(BUILD_NUMBER)" -o ./nebula ${NEBULA_CMD_PATH}
+	go build -trimpath -ldflags "-X main.Build=$(BUILD_NUMBER)" -o ./nebula-cert ./cmd/nebula-cert
 
 install:
-	go install -ldflags "-X main.Build=$(BUILD_NUMBER)" ${NEBULA_CMD_PATH}
-	go install -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula-cert
+	go install -trimpath -ldflags "-X main.Build=$(BUILD_NUMBER)" ${NEBULA_CMD_PATH}
+	go install -trimpath -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula-cert
 
-bin-arm:
-	mkdir -p build/arm
-	GOARCH=arm GOOS=linux go build -o build/arm/nebula -ldflags "-X main.Build=$(BUILD_NUMBER)" ${NEBULA_CMD_PATH}
-	GOARCH=arm GOOS=linux go build -o build/arm/nebula-cert -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula-cert
+build/%/nebula: .FORCE
+	GOOS=$(firstword $(subst -, , $*)) \
+		 GOARCH=$(word 2, $(subst -, ,$*)) \
+		 GOARM=$(word 3, $(subst -, ,$*)) \
+		 go build -trimpath -o $@ -ldflags "-X main.Build=$(BUILD_NUMBER)" ${NEBULA_CMD_PATH}
 
-bin-arm6:
-	mkdir -p build/arm6
-	GOARCH=arm GOARM=6 GOOS=linux go build -o build/arm6/nebula -ldflags "-X main.Build=$(BUILD_NUMBER)" ${NEBULA_CMD_PATH}
-	GOARCH=arm GOARM=6 GOOS=linux go build -o build/arm6/nebula-cert -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula-cert
+build/%/nebula-cert: .FORCE
+	GOOS=$(firstword $(subst -, , $*)) \
+		 GOARCH=$(word 2, $(subst -, ,$*)) \
+		 GOARM=$(word 3, $(subst -, ,$*)) \
+		 go build -trimpath -o $@ -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula-cert
 
-bin-arm64:
-	mkdir -p build/arm64
-	GOARCH=arm64 GOOS=linux go build -o build/arm64/nebula -ldflags "-X main.Build=$(BUILD_NUMBER)" ${NEBULA_CMD_PATH}
-	GOARCH=arm64 GOOS=linux go build -o build/arm64/nebula-cert -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula-cert
-
-bin-vagrant:
-	GOARCH=amd64 GOOS=linux go build -o nebula -ldflags "-X main.Build=$(BUILD_NUMBER)" ${NEBULA_CMD_PATH}
-	GOARCH=amd64 GOOS=linux go build -ldflags "-X main.Build=$(BUILD_NUMBER)" -o ./nebula-cert ./cmd/nebula-cert
-
-bin-darwin:
-	mkdir -p build/darwin
-	GOARCH=amd64 GOOS=darwin go build -o build/darwin/nebula -ldflags "-X main.Build=$(BUILD_NUMBER)" ${NEBULA_CMD_PATH}
-	GOARCH=amd64 GOOS=darwin go build -o build/darwin/nebula-cert -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula-cert
-
-bin-windows:
-	mkdir -p build/windows
-	GOARCH=amd64 GOOS=windows go build -o build/windows/nebula.exe -ldflags "-X main.Build=$(BUILD_NUMBER)" ${NEBULA_CMD_PATH}
-	GOARCH=amd64 GOOS=windows go build -o build/windows/nebula-cert.exe -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula-cert
-
-bin-linux:
-	mkdir -p build/linux
-	GOARCH=amd64 GOOS=linux go build -o build/linux/nebula -ldflags "-X main.Build=$(BUILD_NUMBER)" ${NEBULA_CMD_PATH}
-	GOARCH=amd64 GOOS=linux go build -o build/linux/nebula-cert -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula-cert
-
-bin-linux-386:
-	mkdir -p build/linux-386
-	GOARCH=386 GOOS=linux go build -o build/linux-386/nebula -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula
-	GOARCH=386 GOOS=linux go build -o build/linux-386/nebula-cert -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula-cert
-
-bin-linux-ppc64le:
-	mkdir -p build/linux-ppc64le
-	GOARCH=ppc64le GOOS=linux go build -o build/linux-ppc64le/nebula -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula
-	GOARCH=ppc64le GOOS=linux go build -o build/linux-ppc64le/nebula-cert -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula-cert
-
-bin-mips:
-	mkdir -p build/mips
-	GOARCH=mips GOOS=linux go build -o build/mips/nebula -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula
-	GOARCH=mips GOOS=linux go build -o build/mips/nebula-cert -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula-cert
-
-
-bin-mipsle:
-	mkdir -p build/mipsle
-	GOARCH=mipsle GOOS=linux go build -o build/mipsle/nebula -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula
-	GOARCH=mipsle GOOS=linux go build -o build/mipsle/nebula-cert -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula-cert
-
-bin-mips64:
-	mkdir -p build/mips64
-	GOARCH=mips64 GOOS=linux go build -o build/mips64/nebula -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula
-	GOARCH=mips64 GOOS=linux go build -o build/mips64/nebula-cert -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula-cert
-
-bin-mips64le:
-	mkdir -p build/mips64le
-	GOARCH=mips64le GOOS=linux go build -o build/mips64le/nebula -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula
-	GOARCH=mips64le GOOS=linux go build -o build/mips64le/nebula-cert -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula-cert
-
-release: all
-	tar -zcv -C build/arm/ -f nebula-linux-arm.tar.gz nebula nebula-cert
-	tar -zcv -C build/arm6/ -f nebula-linux-arm6.tar.gz nebula nebula-cert
-	tar -zcv -C build/arm64/ -f nebula-linux-arm64.tar.gz nebula nebula-cert
-	tar -zcv -C build/darwin/ -f nebula-darwin-amd64.tar.gz nebula nebula-cert
-	tar -zcv -C build/windows/ -f nebula-windows-amd64.tar.gz nebula.exe nebula-cert.exe
-	tar -zcv -C build/linux/ -f nebula-linux-amd64.tar.gz nebula nebula-cert
-	tar -zcv -C build/linux-386/ -f nebula-linux-386.tar.gz nebula nebula-cert
-	tar -zcv -C build/linux-ppc64le/ -f nebula-linux-ppc64le.tar.gz nebula nebula-cert
-	tar -zcv -C build/mips/ -f nebula-linux-mips.tar.gz nebula nebula-cert
-	tar -zcv -C build/mipsle/ -f nebula-linux-mipsle.tar.gz nebula nebula-cert
-	tar -zcv -C build/mips64/ -f nebula-linux-mips64.tar.gz nebula nebula-cert
-	tar -zcv -C build/mips64le/ -f nebula-linux-mips64le.tar.gz nebula nebula-cert
+build/nebula-%.tar.gz: build/%/nebula build/%/nebula-cert
+	tar -zcv -C build/$* -f $@ nebula nebula-cert
 
 vet:
 	go vet -v ./...

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@ export GO111MODULE
 ALL = linux-amd64 \
 	linux-386 \
 	linux-ppc64le \
-	linux-arm \
+	linux-arm-5 \
 	linux-arm-6 \
+	linux-arm-7 \
 	linux-arm64 \
 	linux-mips \
 	linux-mipsle \

--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,17 @@ GO111MODULE = on
 export GO111MODULE
 
 ALL = linux-amd64 \
-	  linux-386 \
-	  linux-ppc64le \
-	  linux-arm \
-	  linux-arm-6 \
-	  linux-arm64 \
-	  linux-mips \
-	  linux-mipsle \
-	  linux-mips64 \
-	  linux-mips64le \
-	  darwin-amd64 \
-	  windows-amd64
+	linux-386 \
+	linux-ppc64le \
+	linux-arm \
+	linux-arm-6 \
+	linux-arm64 \
+	linux-mips \
+	linux-mipsle \
+	linux-mips64 \
+	linux-mips64le \
+	darwin-amd64 \
+	windows-amd64
 
 all: $(ALL:%=build/%/nebula) $(ALL:%=build/%/nebula-cert)
 
@@ -30,15 +30,15 @@ install:
 
 build/%/nebula: .FORCE
 	GOOS=$(firstword $(subst -, , $*)) \
-		 GOARCH=$(word 2, $(subst -, ,$*)) \
-		 GOARM=$(word 3, $(subst -, ,$*)) \
-		 go build -trimpath -o $@ -ldflags "-X main.Build=$(BUILD_NUMBER)" ${NEBULA_CMD_PATH}
+		GOARCH=$(word 2, $(subst -, ,$*)) \
+		GOARM=$(word 3, $(subst -, ,$*)) \
+		go build -trimpath -o $@ -ldflags "-X main.Build=$(BUILD_NUMBER)" ${NEBULA_CMD_PATH}
 
 build/%/nebula-cert: .FORCE
 	GOOS=$(firstword $(subst -, , $*)) \
-		 GOARCH=$(word 2, $(subst -, ,$*)) \
-		 GOARM=$(word 3, $(subst -, ,$*)) \
-		 go build -trimpath -o $@ -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula-cert
+		GOARCH=$(word 2, $(subst -, ,$*)) \
+		GOARM=$(word 3, $(subst -, ,$*)) \
+		go build -trimpath -o $@ -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula-cert
 
 build/nebula-%.tar.gz: build/%/nebula build/%/nebula-cert
 	tar -zcv -C build/$* -f $@ nebula nebula-cert


### PR DESCRIPTION
Simplify the makefile by using implicit rules. The new structure for the
build directory when using `make all` or `make release` is:

    build/$GOOS-$GOARCH-$GOARM/nebula

(The GOARM part is optional, and only used for linux-arm-6)

So, releases end up like `nebula-linux-amd64.tar.gz` or
`nebula-linux-arm-6.tar.gz`

This change also adds `-trimpath` to the build, to make the pathnames
more generic in our releases.