### PR TITLE
better windows targets in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,10 @@ release: $(ALL:%=build/nebula-%.tar.gz)
 release-linux: $(ALL_LINUX:%=build/nebula-%.tar.gz)
 
 bin-windows: build/windows-amd64/nebula.exe build/windows-amd64/nebula-cert.exe
+	mv $? .
 
 bin-darwin: build/darwin-amd64/nebula build/darwin-amd64/nebula-cert
+	mv $? .
 
 bin:
 	go build -trimpath -ldflags "-X main.Build=$(BUILD_NUMBER)" -o ./nebula ${NEBULA_CMD_PATH}

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ release: $(ALL:%=build/nebula-%.tar.gz)
 
 release-linux: $(ALL_LINUX:%=build/nebula-%.tar.gz)
 
+bin-windows: build/windows-amd64/nebula.exe build/windows-amd64/nebula-cert.exe
+
+bin-darwin: build/darwin-amd64/nebula build/darwin-amd64/nebula-cert
+
 bin:
 	go build -trimpath -ldflags "-X main.Build=$(BUILD_NUMBER)" -o ./nebula ${NEBULA_CMD_PATH}
 	go build -trimpath -ldflags "-X main.Build=$(BUILD_NUMBER)" -o ./nebula-cert ./cmd/nebula-cert
@@ -45,8 +49,17 @@ build/%/nebula-cert: .FORCE
 		GOARM=$(word 3, $(subst -, ,$*)) \
 		go build -trimpath -o $@ -ldflags "-X main.Build=$(BUILD_NUMBER)" ./cmd/nebula-cert
 
+build/%/nebula.exe: build/%/nebula
+	mv $< $@
+
+build/%/nebula-cert.exe: build/%/nebula-cert
+	mv $< $@
+
 build/nebula-%.tar.gz: build/%/nebula build/%/nebula-cert
 	tar -zcv -C build/$* -f $@ nebula nebula-cert
+
+build/nebula-%.zip: build/%/nebula.exe build/%/nebula-cert.exe
+	cd build/$* && zip ../nebula-$*.zip nebula.exe nebula-cert.exe
 
 vet:
 	go vet -v ./...


### PR DESCRIPTION
This restores `make bin-windows` and also adds `make
build/nebula-windows-amd64.zip` to build the zip file.