### PR TITLE
alert in logs if nebula certificate is close to expiry

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -14,8 +14,10 @@ pki:
   expiry_check:
     enabled: true
     # time remaining on the nebula certificate before expiry alerts appear in logs
+    # default is 5d
     time_left: 72h
     # how often the alerting will appear in logs
+    # default is 60m
     log_interval: 60m
 
 # The static host map defines a set of hosts with fixed IP addresses on the internet (or any network).

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -10,6 +10,13 @@ pki:
   #blacklist is a list of certificate fingerprints that we will refuse to talk to
   #blacklist:
   #  - c99d4e650533b92061b09918e838a5a0a6aaee21eed1d12fd937682865936c72
+  #expiry_check looks at the in-memory cert and will begin alerting in logs if the host nebula certificate is close to expiry
+  expiry_check:
+    enabled: true
+    # time remaining on the nebula certificate before expiry alerts appear in logs
+    time_left: 72h
+    # how often the alerting will appear in logs
+    log_interval: 60m
 
 # The static host map defines a set of hosts with fixed IP addresses on the internet (or any network).
 # A host can have multiple fixed IP addresses defined here, and nebula will try each when establishing a tunnel.

--- a/expiry_check.go
+++ b/expiry_check.go
@@ -35,7 +35,7 @@ func (e *CertExpiryCheck) logExpiryCert() {
 			select {
 			case <-e.Ticker.C:
 				if CertTTLInvalid(e.Interface.certState.certificate, e.TimeLeft) {
-					ttl:=e.Interface.certState.certificate.Details.NotAfter.Sub(time.Now()).String()
+					ttl := e.Interface.certState.certificate.Details.NotAfter.Sub(time.Now()).String()
 					l.WithField("cert", e.Interface.certState.certificate).WithField("time_left", ttl).Info("nebula certificate is close to expiry")
 				}
 			case <-e.EndCheckInterval:

--- a/expiry_check.go
+++ b/expiry_check.go
@@ -1,0 +1,68 @@
+package nebula
+
+import (
+	"github.com/slackhq/nebula/cert"
+	"time"
+)
+
+type CertExpiryCheck struct {
+	Enabled          bool
+	Interface        *Interface
+	Ticker           *time.Ticker
+	CheckInterval    time.Duration
+	TimeLeft         time.Duration
+	EndCheckInterval chan bool
+}
+
+func NewCertExpiryCheck(c *Config, ifce *Interface) *CertExpiryCheck {
+	e := &CertExpiryCheck{
+		Enabled:          c.GetBool("pki.expiry_check.enabled", true),
+		EndCheckInterval: make(chan bool),
+		CheckInterval:    c.GetDuration("pki.expiry_check.log_interval", time.Hour),
+		Ticker:           time.NewTicker(c.GetDuration("pki.expiry_check.log_interval", time.Hour)),
+		TimeLeft:         c.GetDuration("pki.expiry_check.time_left", 120*time.Hour),
+		Interface:        ifce,
+	}
+	return e
+}
+func CertTTLInvalid(cert *cert.NebulaCertificate, timeLeft time.Duration) bool {
+	return cert.Details.NotAfter.Before(time.Now().Add(timeLeft))
+}
+
+func (e *CertExpiryCheck) logExpiryCert() {
+	go func() {
+		for {
+			select {
+			case <-e.Ticker.C:
+				if CertTTLInvalid(e.Interface.certState.certificate, e.TimeLeft) {
+					l.WithField("cert", e.Interface.certState.certificate).Info("nebula certificate is close to expiry")
+				}
+			case <-e.EndCheckInterval:
+				e.Ticker.Stop()
+				return
+			}
+		}
+	}()
+}
+
+func (e *CertExpiryCheck) RegisterConfigChangeCallbacks(c *Config) {
+	c.RegisterReloadCallback(e.reloadConfig)
+}
+
+func (e *CertExpiryCheck) reloadConfig(c *Config) {
+	oldConfigEnabled := e.Enabled
+	e.Enabled = c.GetBool("pki.expiry_check.enabled", true)
+	e.CheckInterval = c.GetDuration("pki.expiry_check.log_interval", time.Hour)
+	e.TimeLeft = c.GetDuration("pki.expiry_check.time_left", 120*time.Hour)
+	e.Ticker = time.NewTicker(e.CheckInterval)
+	l.WithField("cert", e.Interface.certState.certificate.Details).Info("reloaded pki.expiry_check configs")
+	if e.Enabled && !oldConfigEnabled {
+		l.WithField("pki.expiry_cert.enabled", e.Enabled).Info("cert expiry logging is enabled")
+		e.EndCheckInterval = make(chan bool)
+		e.logExpiryCert()
+	}
+	if !e.Enabled && oldConfigEnabled {
+		l.WithField("pki.expiry_cert.enabled", e.Enabled).Info("cert expiry logging is disabled")
+		e.EndCheckInterval <- true
+	}
+}

--- a/expiry_check.go
+++ b/expiry_check.go
@@ -35,7 +35,8 @@ func (e *CertExpiryCheck) logExpiryCert() {
 			select {
 			case <-e.Ticker.C:
 				if CertTTLInvalid(e.Interface.certState.certificate, e.TimeLeft) {
-					l.WithField("cert", e.Interface.certState.certificate).Info("nebula certificate is close to expiry")
+					ttl:=e.Interface.certState.certificate.Details.NotAfter.Sub(time.Now()).String()
+					l.WithField("cert", e.Interface.certState.certificate).WithField("time_left", ttl).Info("nebula certificate is close to expiry")
 				}
 			case <-e.EndCheckInterval:
 				e.Ticker.Stop()

--- a/main.go
+++ b/main.go
@@ -299,6 +299,12 @@ func Main(configPath string, configTest bool, buildVersion string) {
 		l.WithError(err).Fatal("Failed to initialize interface")
 	}
 
+	expiryCheck := NewCertExpiryCheck(config, ifce)
+	if expiryCheck.Enabled {
+		expiryCheck.logExpiryCert()
+	}
+
+	expiryCheck.RegisterConfigChangeCallbacks(config)
 	ifce.RegisterConfigChangeCallbacks(config)
 
 	go handshakeManager.Run(ifce)


### PR DESCRIPTION
* Check whether the in-memory nebula certificate is about to expire. 
* Write/alert in logs based on time left (`expiry_check.time_left`) on certificate and based on interval (`expiry_check.log_interval`) defined in nebula configs. 