### PR TITLE
patch for packaging

### DIFF
--- a/examples/service_scripts/nebula.service
+++ b/examples/service_scripts/nebula.service
@@ -8,7 +8,7 @@ SyslogIdentifier=nebula
 StandardOutput=syslog
 StandardError=syslog
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/local/bin/nebula -config /etc/nebula/config.yml
+ExecStart=/usr/bin/nebula -config /etc/nebula/config.yml
 Restart=always
 
 [Install]


### PR DESCRIPTION
This systemd service file could be directly used in Arch packages if it referenced nebula at /usr/bin instead of /usr/local/bin. Would there be a problem with defaulting to that? 

What's the use case for /usr/local/bin? Manual installation location?