### PR TITLE
validate lighthouses and static hosts are in our subnet

### DIFF
--- a/main.go
+++ b/main.go
@@ -208,6 +208,9 @@ func Main(configPath string, configTest bool, buildVersion string) {
 		if ip == nil {
 			l.WithField("host", host).Fatalf("Unable to parse lighthouse host entry %v", i+1)
 		}
+		if !tunCidr.Contains(ip) {
+			l.WithField("vpnIp", ip).WithField("network", tunCidr.String()).Fatalf("lighthouse host is not in our subnet, invalid")
+		}
 		lighthouseHosts[i] = ip2int(ip)
 	}
 
@@ -225,6 +228,9 @@ func Main(configPath string, configTest bool, buildVersion string) {
 	//TODO: Move all of this inside functions in lighthouse.go
 	for k, v := range config.GetMap("static_host_map", map[interface{}]interface{}{}) {
 		vpnIp := net.ParseIP(fmt.Sprintf("%v", k))
+		if !tunCidr.Contains(vpnIp) {
+			l.WithField("vpnIp", vpnIp).WithField("network", tunCidr.String()).Fatalf("static_host_map key is not in our subnet, invalid")
+		}
 		vals, ok := v.([]interface{})
 		if ok {
 			for _, v := range vals {


### PR DESCRIPTION
Validate all lighthouse.hosts and static_host_map VPN IPs are in the
subnet defined in our cert. Exit with a fatal error if they are not in
our subnet, as this is an invalid configuration (we will not have the
proper routes set up to communicate with these hosts).

This error case could occur for the following invalid example:

    nebula-cert sign -name "lighthouse" -ip "10.0.1.1/24"
    nebula-cert sign -name "host" -ip "10.0.2.1/24"

    config.yaml:

        static_host_map:
            "10.0.1.1": ["lighthouse.local:4242"]
        lighthouse:
          hosts:
            - "10.0.1.1"

We will now return a fatal error for this config, since `10.0.1.1` is
not in the host cert's subnet of `10.0.2.1/24`