### PR TITLE
fix linting errors

### DIFF
--- a/bits.go
+++ b/bits.go
@@ -18,7 +18,7 @@ type Bits struct {
 func NewBits(bits uint64) *Bits {
 	return &Bits{
 		length:             bits,
-		bits:               make([]bool, bits, bits),
+		bits:               make([]bool, bits),
 		current:            0,
 		lostCounter:        metrics.GetOrRegisterCounter("network.packets.lost", nil),
 		dupeCounter:        metrics.GetOrRegisterCounter("network.packets.duplicate", nil),
@@ -28,7 +28,7 @@ func NewBits(bits uint64) *Bits {
 
 func (b *Bits) Check(i uint64) bool {
 	// If i is the next number, return true.
-	if i > b.current || (i == 0 && b.firstSeen == false && b.current < b.length) {
+	if i > b.current || (i == 0 && !b.firstSeen && b.current < b.length) {
 		return true
 	}
 
@@ -51,7 +51,7 @@ func (b *Bits) Update(i uint64) bool {
 	// If i is the next number, return true and update current.
 	if i == b.current+1 {
 		// Report missed packets, we can only understand what was missed after the first window has been gone through
-		if i > b.length && b.bits[i%b.length] == false {
+		if i > b.length && !b.bits[i%b.length] {
 			b.lostCounter.Inc(1)
 		}
 		b.bits[i%b.length] = true
@@ -104,7 +104,7 @@ func (b *Bits) Update(i uint64) bool {
 	}
 
 	// Allow for the 0 packet to come in within the first window
-	if i == 0 && b.firstSeen == false && b.current < b.length {
+	if i == 0 && !b.firstSeen && b.current < b.length {
 		b.firstSeen = true
 		b.bits[i%b.length] = true
 		return true
@@ -122,7 +122,7 @@ func (b *Bits) Update(i uint64) bool {
 			return false
 		}
 
-		if b.bits[i%b.length] == true {
+		if b.bits[i%b.length] {
 			if l.Level >= logrus.DebugLevel {
 				l.WithField("receiveWindow", m{"accepted": false, "currentCounter": b.current, "incomingCounter": i, "reason": "old duplicate"}).
 					Debug("Receive window")

--- a/bits_test.go
+++ b/bits_test.go
@@ -212,10 +212,10 @@ func TestBitsLostCounter(t *testing.T) {
 func BenchmarkBits(b *testing.B) {
 	z := NewBits(10)
 	for n := 0; n < b.N; n++ {
-		for i, _ := range z.bits {
+		for i := range z.bits {
 			z.bits[i] = true
 		}
-		for i, _ := range z.bits {
+		for i := range z.bits {
 			z.bits[i] = false
 		}
 

--- a/cert/ca.go
+++ b/cert/ca.go
@@ -29,7 +29,7 @@ func NewCAPoolFromBytes(caPEMs []byte) (*NebulaCAPool, error) {
 		if err != nil {
 			return nil, err
 		}
-		if caPEMs == nil || len(caPEMs) == 0 || strings.TrimSpace(string(caPEMs)) == "" {
+		if len(caPEMs) == 0 || strings.TrimSpace(string(caPEMs)) == "" {
 			break
 		}
 	}

--- a/cmd/nebula-cert/ca_test.go
+++ b/cmd/nebula-cert/ca_test.go
@@ -62,7 +62,7 @@ func Test_ca(t *testing.T) {
 
 	// create temp key file
 	keyF, err := ioutil.TempFile("", "test.key")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	os.Remove(keyF.Name())
 
 	// failed cert write
@@ -75,7 +75,7 @@ func Test_ca(t *testing.T) {
 
 	// create temp cert file
 	crtF, err := ioutil.TempFile("", "test.crt")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	os.Remove(crtF.Name())
 	os.Remove(keyF.Name())
 
@@ -83,7 +83,7 @@ func Test_ca(t *testing.T) {
 	ob.Reset()
 	eb.Reset()
 	args = []string{"-name", "test", "-duration", "100m", "-groups", "1,,   2    ,        ,,,3,4,5", "-out-crt", crtF.Name(), "-out-key", keyF.Name()}
-	assert.Nil(t, ca(args, ob, eb))
+	assert.NoError(t, ca(args, ob, eb))
 	assert.Equal(t, "", ob.String())
 	assert.Equal(t, "", eb.String())
 
@@ -91,13 +91,13 @@ func Test_ca(t *testing.T) {
 	rb, _ := ioutil.ReadFile(keyF.Name())
 	lKey, b, err := cert.UnmarshalEd25519PrivateKey(rb)
 	assert.Len(t, b, 0)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, lKey, 64)
 
 	rb, _ = ioutil.ReadFile(crtF.Name())
 	lCrt, b, err := cert.UnmarshalNebulaCertificateFromPEM(rb)
 	assert.Len(t, b, 0)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	assert.Equal(t, "test", lCrt.Details.Name)
 	assert.Len(t, lCrt.Details.Ips, 0)
@@ -115,7 +115,7 @@ func Test_ca(t *testing.T) {
 	ob.Reset()
 	eb.Reset()
 	args = []string{"-name", "test", "-duration", "100m", "-groups", "1,,   2    ,        ,,,3,4,5", "-out-crt", crtF.Name(), "-out-key", keyF.Name()}
-	assert.Nil(t, ca(args, ob, eb))
+	assert.NoError(t, ca(args, ob, eb))
 
 	// test that we won't overwrite existing certificate file
 	ob.Reset()
@@ -134,5 +134,4 @@ func Test_ca(t *testing.T) {
 	assert.Equal(t, "", ob.String())
 	assert.Equal(t, "", eb.String())
 	os.Remove(keyF.Name())
-
 }

--- a/cmd/nebula-cert/keygen_test.go
+++ b/cmd/nebula-cert/keygen_test.go
@@ -53,7 +53,7 @@ func Test_keygen(t *testing.T) {
 
 	// create temp key file
 	keyF, err := ioutil.TempFile("", "test.key")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer os.Remove(keyF.Name())
 
 	// failed pub write
@@ -66,14 +66,14 @@ func Test_keygen(t *testing.T) {
 
 	// create temp pub file
 	pubF, err := ioutil.TempFile("", "test.pub")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer os.Remove(pubF.Name())
 
 	// test proper keygen
 	ob.Reset()
 	eb.Reset()
 	args = []string{"-out-pub", pubF.Name(), "-out-key", keyF.Name()}
-	assert.Nil(t, keygen(args, ob, eb))
+	assert.NoError(t, keygen(args, ob, eb))
 	assert.Equal(t, "", ob.String())
 	assert.Equal(t, "", eb.String())
 
@@ -81,12 +81,12 @@ func Test_keygen(t *testing.T) {
 	rb, _ := ioutil.ReadFile(keyF.Name())
 	lKey, b, err := cert.UnmarshalX25519PrivateKey(rb)
 	assert.Len(t, b, 0)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, lKey, 32)
 
 	rb, _ = ioutil.ReadFile(pubF.Name())
 	lPub, b, err := cert.UnmarshalX25519PublicKey(rb)
 	assert.Len(t, b, 0)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, lPub, 32)
 }

--- a/cmd/nebula-cert/print.go
+++ b/cmd/nebula-cert/print.go
@@ -60,7 +60,7 @@ func printCert(args []string, out io.Writer, errOut io.Writer) error {
 			out.Write([]byte("\n"))
 		}
 
-		if rawCert == nil || len(rawCert) == 0 || strings.TrimSpace(string(rawCert)) == "" {
+		if len(rawCert) == 0 || strings.TrimSpace(string(rawCert)) == "" {
 			break
 		}
 	}

--- a/cmd/nebula-cert/print_test.go
+++ b/cmd/nebula-cert/print_test.go
@@ -29,6 +29,8 @@ func Test_printHelp(t *testing.T) {
 }
 
 func Test_printCert(t *testing.T) {
+	assert := assert.New(t)
+
 	// Orient our local time and avoid headaches
 	time.Local = time.UTC
 	ob := &bytes.Buffer{}
@@ -36,36 +38,38 @@ func Test_printCert(t *testing.T) {
 
 	// no path
 	err := printCert([]string{}, ob, eb)
-	assert.Equal(t, "", ob.String())
-	assert.Equal(t, "", eb.String())
+	assert.Equal("", ob.String())
+	assert.Equal("", eb.String())
 	assertHelpError(t, err, "-path is required")
 
 	// no cert at path
 	ob.Reset()
 	eb.Reset()
 	err = printCert([]string{"-path", "does_not_exist"}, ob, eb)
-	assert.Equal(t, "", ob.String())
-	assert.Equal(t, "", eb.String())
-	assert.EqualError(t, err, "unable to read cert; open does_not_exist: "+NoSuchFileError)
+	assert.Equal("", ob.String())
+	assert.Equal("", eb.String())
+	assert.EqualError(err, "unable to read cert; open does_not_exist: "+NoSuchFileError)
 
 	// invalid cert at path
 	ob.Reset()
 	eb.Reset()
 	tf, err := ioutil.TempFile("", "print-cert")
-	assert.Nil(t, err)
+	assert.NoError(err, "ioutil.TempFile")
 	defer os.Remove(tf.Name())
 
-	tf.WriteString("-----BEGIN NOPE-----")
+	_, err = tf.WriteString("-----BEGIN NOPE-----")
+	assert.NoError(err, "WriteString")
 	err = printCert([]string{"-path", tf.Name()}, ob, eb)
-	assert.Equal(t, "", ob.String())
-	assert.Equal(t, "", eb.String())
-	assert.EqualError(t, err, "error while unmarshaling cert: input did not contain a valid PEM encoded block")
+	assert.Equal("", ob.String())
+	assert.Equal("", eb.String())
+	assert.EqualError(err, "error while unmarshaling cert: input did not contain a valid PEM encoded block")
 
 	// test multiple certs
 	ob.Reset()
 	eb.Reset()
-	tf.Truncate(0)
-	tf.Seek(0, 0)
+	assert.NoError(tf.Truncate(0), "tf.Truncate")
+	_, err = tf.Seek(0, 0)
+	assert.NoError(err, "tf.Seek")
 	c := cert.NebulaCertificate{
 		Details: cert.NebulaCertificateDetails{
 			Name:      "test",
@@ -75,25 +79,27 @@ func Test_printCert(t *testing.T) {
 		Signature: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2},
 	}
 
-	p, _ := c.MarshalToPEM()
-	tf.Write(p)
-	tf.Write(p)
-	tf.Write(p)
+	p, err := c.MarshalToPEM()
+	assert.NoError(err, "MarshalToPEM")
+	for i := 0; i < 3; i++ {
+		_, err = tf.Write(p)
+		assert.NoError(err, "tf.Write")
+	}
 
 	err = printCert([]string{"-path", tf.Name()}, ob, eb)
-	assert.Nil(t, err)
+	assert.NoError(err)
 	assert.Equal(
-		t,
 		"NebulaCertificate {\n\tDetails {\n\t\tName: test\n\t\tIps: []\n\t\tSubnets: []\n\t\tGroups: [\n\t\t\t\"hi\"\n\t\t]\n\t\tNot before: 0001-01-01 00:00:00 +0000 UTC\n\t\tNot After: 0001-01-01 00:00:00 +0000 UTC\n\t\tIs CA: false\n\t\tIssuer: \n\t\tPublic key: 0102030405060708090001020304050607080900010203040506070809000102\n\t}\n\tFingerprint: cc3492c0e9c48f17547f5987ea807462ebb3451e622590a10bb3763c344c82bd\n\tSignature: 0102030405060708090001020304050607080900010203040506070809000102\n}\nNebulaCertificate {\n\tDetails {\n\t\tName: test\n\t\tIps: []\n\t\tSubnets: []\n\t\tGroups: [\n\t\t\t\"hi\"\n\t\t]\n\t\tNot before: 0001-01-01 00:00:00 +0000 UTC\n\t\tNot After: 0001-01-01 00:00:00 +0000 UTC\n\t\tIs CA: false\n\t\tIssuer: \n\t\tPublic key: 0102030405060708090001020304050607080900010203040506070809000102\n\t}\n\tFingerprint: cc3492c0e9c48f17547f5987ea807462ebb3451e622590a10bb3763c344c82bd\n\tSignature: 0102030405060708090001020304050607080900010203040506070809000102\n}\nNebulaCertificate {\n\tDetails {\n\t\tName: test\n\t\tIps: []\n\t\tSubnets: []\n\t\tGroups: [\n\t\t\t\"hi\"\n\t\t]\n\t\tNot before: 0001-01-01 00:00:00 +0000 UTC\n\t\tNot After: 0001-01-01 00:00:00 +0000 UTC\n\t\tIs CA: false\n\t\tIssuer: \n\t\tPublic key: 0102030405060708090001020304050607080900010203040506070809000102\n\t}\n\tFingerprint: cc3492c0e9c48f17547f5987ea807462ebb3451e622590a10bb3763c344c82bd\n\tSignature: 0102030405060708090001020304050607080900010203040506070809000102\n}\n",
 		ob.String(),
 	)
-	assert.Equal(t, "", eb.String())
+	assert.Equal("", eb.String())
 
 	// test json
 	ob.Reset()
 	eb.Reset()
-	tf.Truncate(0)
-	tf.Seek(0, 0)
+	assert.NoError(tf.Truncate(0), "tf.Truncate")
+	_, err = tf.Seek(0, 0)
+	assert.NoError(err, "tf.Seek")
 	c = cert.NebulaCertificate{
 		Details: cert.NebulaCertificateDetails{
 			Name:      "test",
@@ -103,17 +109,18 @@ func Test_printCert(t *testing.T) {
 		Signature: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2},
 	}
 
-	p, _ = c.MarshalToPEM()
-	tf.Write(p)
-	tf.Write(p)
-	tf.Write(p)
+	p, err = c.MarshalToPEM()
+	assert.NoError(err, "MarshalToPEM")
+	for i := 0; i < 3; i++ {
+		_, err = tf.Write(p)
+		assert.NoError(err, "tf.Write")
+	}
 
 	err = printCert([]string{"-json", "-path", tf.Name()}, ob, eb)
-	assert.Nil(t, err)
+	assert.NoError(err)
 	assert.Equal(
-		t,
 		"{\"details\":{\"groups\":[\"hi\"],\"ips\":[],\"isCa\":false,\"issuer\":\"\",\"name\":\"test\",\"notAfter\":\"0001-01-01T00:00:00Z\",\"notBefore\":\"0001-01-01T00:00:00Z\",\"publicKey\":\"0102030405060708090001020304050607080900010203040506070809000102\",\"subnets\":[]},\"fingerprint\":\"cc3492c0e9c48f17547f5987ea807462ebb3451e622590a10bb3763c344c82bd\",\"signature\":\"0102030405060708090001020304050607080900010203040506070809000102\"}\n{\"details\":{\"groups\":[\"hi\"],\"ips\":[],\"isCa\":false,\"issuer\":\"\",\"name\":\"test\",\"notAfter\":\"0001-01-01T00:00:00Z\",\"notBefore\":\"0001-01-01T00:00:00Z\",\"publicKey\":\"0102030405060708090001020304050607080900010203040506070809000102\",\"subnets\":[]},\"fingerprint\":\"cc3492c0e9c48f17547f5987ea807462ebb3451e622590a10bb3763c344c82bd\",\"signature\":\"0102030405060708090001020304050607080900010203040506070809000102\"}\n{\"details\":{\"groups\":[\"hi\"],\"ips\":[],\"isCa\":false,\"issuer\":\"\",\"name\":\"test\",\"notAfter\":\"0001-01-01T00:00:00Z\",\"notBefore\":\"0001-01-01T00:00:00Z\",\"publicKey\":\"0102030405060708090001020304050607080900010203040506070809000102\",\"subnets\":[]},\"fingerprint\":\"cc3492c0e9c48f17547f5987ea807462ebb3451e622590a10bb3763c344c82bd\",\"signature\":\"0102030405060708090001020304050607080900010203040506070809000102\"}\n",
 		ob.String(),
 	)
-	assert.Equal(t, "", eb.String())
+	assert.Equal("", eb.String())
 }

--- a/cmd/nebula-cert/sign_test.go
+++ b/cmd/nebula-cert/sign_test.go
@@ -52,41 +52,43 @@ func Test_signHelp(t *testing.T) {
 }
 
 func Test_signCert(t *testing.T) {
+	assert := assert.New(t)
+
 	ob := &bytes.Buffer{}
 	eb := &bytes.Buffer{}
 
 	// required args
 
 	assertHelpError(t, signCert([]string{"-ca-crt", "./nope", "-ca-key", "./nope", "-ip", "1.1.1.1/24", "-out-key", "nope", "-out-crt", "nope"}, ob, eb), "-name is required")
-	assert.Empty(t, ob.String())
-	assert.Empty(t, eb.String())
+	assert.Empty(ob.String())
+	assert.Empty(eb.String())
 
 	assertHelpError(t, signCert([]string{"-ca-crt", "./nope", "-ca-key", "./nope", "-name", "test", "-out-key", "nope", "-out-crt", "nope"}, ob, eb), "-ip is required")
-	assert.Empty(t, ob.String())
-	assert.Empty(t, eb.String())
+	assert.Empty(ob.String())
+	assert.Empty(eb.String())
 
 	// cannot set -in-pub and -out-key
 	assertHelpError(t, signCert([]string{"-ca-crt", "./nope", "-ca-key", "./nope", "-name", "test", "-in-pub", "nope", "-ip", "1.1.1.1/24", "-out-crt", "nope", "-out-key", "nope"}, ob, eb), "cannot set both -in-pub and -out-key")
-	assert.Empty(t, ob.String())
-	assert.Empty(t, eb.String())
+	assert.Empty(ob.String())
+	assert.Empty(eb.String())
 
 	// failed to read key
 	ob.Reset()
 	eb.Reset()
 	args := []string{"-ca-crt", "./nope", "-ca-key", "./nope", "-name", "test", "-ip", "1.1.1.1/24", "-out-crt", "nope", "-out-key", "nope", "-duration", "100m"}
-	assert.EqualError(t, signCert(args, ob, eb), "error while reading ca-key: open ./nope: "+NoSuchFileError)
+	assert.EqualError(signCert(args, ob, eb), "error while reading ca-key: open ./nope: "+NoSuchFileError)
 
 	// failed to unmarshal key
 	ob.Reset()
 	eb.Reset()
 	caKeyF, err := ioutil.TempFile("", "sign-cert.key")
-	assert.Nil(t, err)
+	assert.NoError(err)
 	defer os.Remove(caKeyF.Name())
 
 	args = []string{"-ca-crt", "./nope", "-ca-key", caKeyF.Name(), "-name", "test", "-ip", "1.1.1.1/24", "-out-crt", "nope", "-out-key", "nope", "-duration", "100m"}
-	assert.EqualError(t, signCert(args, ob, eb), "error while parsing ca-key: input did not contain a valid PEM encoded block")
-	assert.Empty(t, ob.String())
-	assert.Empty(t, eb.String())
+	assert.EqualError(signCert(args, ob, eb), "error while parsing ca-key: input did not contain a valid PEM encoded block")
+	assert.Empty(ob.String())
+	assert.Empty(eb.String())
 
 	// Write a proper ca key for later
 	ob.Reset()
@@ -96,21 +98,21 @@ func Test_signCert(t *testing.T) {
 
 	// failed to read cert
 	args = []string{"-ca-crt", "./nope", "-ca-key", caKeyF.Name(), "-name", "test", "-ip", "1.1.1.1/24", "-out-crt", "nope", "-out-key", "nope", "-duration", "100m"}
-	assert.EqualError(t, signCert(args, ob, eb), "error while reading ca-crt: open ./nope: "+NoSuchFileError)
-	assert.Empty(t, ob.String())
-	assert.Empty(t, eb.String())
+	assert.EqualError(signCert(args, ob, eb), "error while reading ca-crt: open ./nope: "+NoSuchFileError)
+	assert.Empty(ob.String())
+	assert.Empty(eb.String())
 
 	// failed to unmarshal cert
 	ob.Reset()
 	eb.Reset()
 	caCrtF, err := ioutil.TempFile("", "sign-cert.crt")
-	assert.Nil(t, err)
+	assert.NoError(err, "ioutil.TempFile")
 	defer os.Remove(caCrtF.Name())
 
 	args = []string{"-ca-crt", caCrtF.Name(), "-ca-key", caKeyF.Name(), "-name", "test", "-ip", "1.1.1.1/24", "-out-crt", "nope", "-out-key", "nope", "-duration", "100m"}
-	assert.EqualError(t, signCert(args, ob, eb), "error while parsing ca-crt: input did not contain a valid PEM encoded block")
-	assert.Empty(t, ob.String())
-	assert.Empty(t, eb.String())
+	assert.EqualError(signCert(args, ob, eb), "error while parsing ca-crt: input did not contain a valid PEM encoded block")
+	assert.Empty(ob.String())
+	assert.Empty(eb.String())
 
 	// write a proper ca cert for later
 	ca := cert.NebulaCertificate{
@@ -127,21 +129,21 @@ func Test_signCert(t *testing.T) {
 
 	// failed to read pub
 	args = []string{"-ca-crt", caCrtF.Name(), "-ca-key", caKeyF.Name(), "-name", "test", "-ip", "1.1.1.1/24", "-out-crt", "nope", "-in-pub", "./nope", "-duration", "100m"}
-	assert.EqualError(t, signCert(args, ob, eb), "error while reading in-pub: open ./nope: "+NoSuchFileError)
-	assert.Empty(t, ob.String())
-	assert.Empty(t, eb.String())
+	assert.EqualError(signCert(args, ob, eb), "error while reading in-pub: open ./nope: "+NoSuchFileError)
+	assert.Empty(ob.String())
+	assert.Empty(eb.String())
 
 	// failed to unmarshal pub
 	ob.Reset()
 	eb.Reset()
 	inPubF, err := ioutil.TempFile("", "in.pub")
-	assert.Nil(t, err)
+	assert.NoError(err, "ioutil.TempFile")
 	defer os.Remove(inPubF.Name())
 
 	args = []string{"-ca-crt", caCrtF.Name(), "-ca-key", caKeyF.Name(), "-name", "test", "-ip", "1.1.1.1/24", "-out-crt", "nope", "-in-pub", inPubF.Name(), "-duration", "100m"}
-	assert.EqualError(t, signCert(args, ob, eb), "error while parsing in-pub: input did not contain a valid PEM encoded block")
-	assert.Empty(t, ob.String())
-	assert.Empty(t, eb.String())
+	assert.EqualError(signCert(args, ob, eb), "error while parsing in-pub: input did not contain a valid PEM encoded block")
+	assert.Empty(ob.String())
+	assert.Empty(eb.String())
 
 	// write a proper pub for later
 	ob.Reset()
@@ -154,83 +156,83 @@ func Test_signCert(t *testing.T) {
 	eb.Reset()
 	args = []string{"-ca-crt", caCrtF.Name(), "-ca-key", caKeyF.Name(), "-name", "test", "-ip", "a1.1.1.1/24", "-out-crt", "nope", "-out-key", "nope", "-duration", "100m"}
 	assertHelpError(t, signCert(args, ob, eb), "invalid ip definition: invalid CIDR address: a1.1.1.1/24")
-	assert.Empty(t, ob.String())
-	assert.Empty(t, eb.String())
+	assert.Empty(ob.String())
+	assert.Empty(eb.String())
 
 	// bad subnet cidr
 	ob.Reset()
 	eb.Reset()
 	args = []string{"-ca-crt", caCrtF.Name(), "-ca-key", caKeyF.Name(), "-name", "test", "-ip", "1.1.1.1/24", "-out-crt", "nope", "-out-key", "nope", "-duration", "100m", "-subnets", "a"}
 	assertHelpError(t, signCert(args, ob, eb), "invalid subnet definition: invalid CIDR address: a")
-	assert.Empty(t, ob.String())
-	assert.Empty(t, eb.String())
+	assert.Empty(ob.String())
+	assert.Empty(eb.String())
 
 	// failed key write
 	ob.Reset()
 	eb.Reset()
 	args = []string{"-ca-crt", caCrtF.Name(), "-ca-key", caKeyF.Name(), "-name", "test", "-ip", "1.1.1.1/24", "-out-crt", "/do/not/write/pleasecrt", "-out-key", "/do/not/write/pleasekey", "-duration", "100m", "-subnets", "10.1.1.1/32"}
-	assert.EqualError(t, signCert(args, ob, eb), "error while writing out-key: open /do/not/write/pleasekey: "+NoSuchDirError)
-	assert.Empty(t, ob.String())
-	assert.Empty(t, eb.String())
+	assert.EqualError(signCert(args, ob, eb), "error while writing out-key: open /do/not/write/pleasekey: "+NoSuchDirError)
+	assert.Empty(ob.String())
+	assert.Empty(eb.String())
 
 	// create temp key file
 	keyF, err := ioutil.TempFile("", "test.key")
-	assert.Nil(t, err)
+	assert.NoError(err)
 	os.Remove(keyF.Name())
 
 	// failed cert write
 	ob.Reset()
 	eb.Reset()
 	args = []string{"-ca-crt", caCrtF.Name(), "-ca-key", caKeyF.Name(), "-name", "test", "-ip", "1.1.1.1/24", "-out-crt", "/do/not/write/pleasecrt", "-out-key", keyF.Name(), "-duration", "100m", "-subnets", "10.1.1.1/32"}
-	assert.EqualError(t, signCert(args, ob, eb), "error while writing out-crt: open /do/not/write/pleasecrt: "+NoSuchDirError)
-	assert.Empty(t, ob.String())
-	assert.Empty(t, eb.String())
+	assert.EqualError(signCert(args, ob, eb), "error while writing out-crt: open /do/not/write/pleasecrt: "+NoSuchDirError)
+	assert.Empty(ob.String())
+	assert.Empty(eb.String())
 	os.Remove(keyF.Name())
 
 	// create temp cert file
 	crtF, err := ioutil.TempFile("", "test.crt")
-	assert.Nil(t, err)
+	assert.NoError(err)
 	os.Remove(crtF.Name())
 
 	// test proper cert with removed empty groups and subnets
 	ob.Reset()
 	eb.Reset()
 	args = []string{"-ca-crt", caCrtF.Name(), "-ca-key", caKeyF.Name(), "-name", "test", "-ip", "1.1.1.1/24", "-out-crt", crtF.Name(), "-out-key", keyF.Name(), "-duration", "100m", "-subnets", "10.1.1.1/32, ,   10.2.2.2/32   ,   ,  ,, 10.5.5.5/32", "-groups", "1,,   2    ,        ,,,3,4,5"}
-	assert.Nil(t, signCert(args, ob, eb))
-	assert.Empty(t, ob.String())
-	assert.Empty(t, eb.String())
+	assert.NoError(signCert(args, ob, eb))
+	assert.Empty(ob.String())
+	assert.Empty(eb.String())
 
 	// read cert and key files
 	rb, _ := ioutil.ReadFile(keyF.Name())
 	lKey, b, err := cert.UnmarshalX25519PrivateKey(rb)
-	assert.Len(t, b, 0)
-	assert.Nil(t, err)
-	assert.Len(t, lKey, 32)
+	assert.Len(b, 0)
+	assert.NoError(err)
+	assert.Len(lKey, 32)
 
 	rb, _ = ioutil.ReadFile(crtF.Name())
 	lCrt, b, err := cert.UnmarshalNebulaCertificateFromPEM(rb)
-	assert.Len(t, b, 0)
-	assert.Nil(t, err)
+	assert.Len(b, 0)
+	assert.NoError(err)
 
-	assert.Equal(t, "test", lCrt.Details.Name)
-	assert.Equal(t, "1.1.1.1/24", lCrt.Details.Ips[0].String())
-	assert.Len(t, lCrt.Details.Ips, 1)
-	assert.False(t, lCrt.Details.IsCA)
-	assert.Equal(t, []string{"1", "2", "3", "4", "5"}, lCrt.Details.Groups)
-	assert.Len(t, lCrt.Details.Subnets, 3)
-	assert.Len(t, lCrt.Details.PublicKey, 32)
-	assert.Equal(t, time.Duration(time.Minute*100), lCrt.Details.NotAfter.Sub(lCrt.Details.NotBefore))
+	assert.Equal("test", lCrt.Details.Name)
+	assert.Equal("1.1.1.1/24", lCrt.Details.Ips[0].String())
+	assert.Len(lCrt.Details.Ips, 1)
+	assert.False(lCrt.Details.IsCA)
+	assert.Equal([]string{"1", "2", "3", "4", "5"}, lCrt.Details.Groups)
+	assert.Len(lCrt.Details.Subnets, 3)
+	assert.Len(lCrt.Details.PublicKey, 32)
+	assert.Equal(time.Duration(time.Minute*100), lCrt.Details.NotAfter.Sub(lCrt.Details.NotBefore))
 
 	sns := []string{}
 	for _, sn := range lCrt.Details.Subnets {
 		sns = append(sns, sn.String())
 	}
-	assert.Equal(t, []string{"10.1.1.1/32", "10.2.2.2/32", "10.5.5.5/32"}, sns)
+	assert.Equal([]string{"10.1.1.1/32", "10.2.2.2/32", "10.5.5.5/32"}, sns)
 
 	issuer, _ := ca.Sha256Sum()
-	assert.Equal(t, issuer, lCrt.Details.Issuer)
+	assert.Equal(issuer, lCrt.Details.Issuer)
 
-	assert.True(t, lCrt.CheckSignature(caPub))
+	assert.True(lCrt.CheckSignature(caPub))
 
 	// test proper cert with in-pub
 	os.Remove(keyF.Name())
@@ -238,53 +240,52 @@ func Test_signCert(t *testing.T) {
 	ob.Reset()
 	eb.Reset()
 	args = []string{"-ca-crt", caCrtF.Name(), "-ca-key", caKeyF.Name(), "-name", "test", "-ip", "1.1.1.1/24", "-out-crt", crtF.Name(), "-in-pub", inPubF.Name(), "-duration", "100m", "-groups", "1"}
-	assert.Nil(t, signCert(args, ob, eb))
-	assert.Empty(t, ob.String())
-	assert.Empty(t, eb.String())
+	assert.NoError(signCert(args, ob, eb))
+	assert.Empty(ob.String())
+	assert.Empty(eb.String())
 
 	// read cert file and check pub key matches in-pub
 	rb, _ = ioutil.ReadFile(crtF.Name())
 	lCrt, b, err = cert.UnmarshalNebulaCertificateFromPEM(rb)
-	assert.Len(t, b, 0)
-	assert.Nil(t, err)
-	assert.Equal(t, lCrt.Details.PublicKey, inPub)
+	assert.Len(b, 0)
+	assert.NoError(err)
+	assert.Equal(lCrt.Details.PublicKey, inPub)
 
 	// test refuse to sign cert with duration beyond root
 	ob.Reset()
 	eb.Reset()
 	args = []string{"-ca-crt", caCrtF.Name(), "-ca-key", caKeyF.Name(), "-name", "test", "-ip", "1.1.1.1/24", "-out-crt", crtF.Name(), "-out-key", keyF.Name(), "-duration", "1000m", "-subnets", "10.1.1.1/32, ,   10.2.2.2/32   ,   ,  ,, 10.5.5.5/32", "-groups", "1,,   2    ,        ,,,3,4,5"}
-	assert.EqualError(t, signCert(args, ob, eb), "refusing to sign, root certificate constraints violated: certificate expires after signing certificate")
-	assert.Empty(t, ob.String())
-	assert.Empty(t, eb.String())
+	assert.EqualError(signCert(args, ob, eb), "refusing to sign, root certificate constraints violated: certificate expires after signing certificate")
+	assert.Empty(ob.String())
+	assert.Empty(eb.String())
 
 	// create valid cert/key for overwrite tests
 	os.Remove(keyF.Name())
 	os.Remove(crtF.Name())
 	args = []string{"-ca-crt", caCrtF.Name(), "-ca-key", caKeyF.Name(), "-name", "test", "-ip", "1.1.1.1/24", "-out-crt", crtF.Name(), "-out-key", keyF.Name(), "-duration", "100m", "-subnets", "10.1.1.1/32, ,   10.2.2.2/32   ,   ,  ,, 10.5.5.5/32", "-groups", "1,,   2    ,        ,,,3,4,5"}
-	assert.Nil(t, signCert(args, ob, eb))
+	assert.NoError(signCert(args, ob, eb))
 
 	// test that we won't overwrite existing key file
 	os.Remove(crtF.Name())
 	ob.Reset()
 	eb.Reset()
 	args = []string{"-ca-crt", caCrtF.Name(), "-ca-key", caKeyF.Name(), "-name", "test", "-ip", "1.1.1.1/24", "-out-crt", crtF.Name(), "-out-key", keyF.Name(), "-duration", "100m", "-subnets", "10.1.1.1/32, ,   10.2.2.2/32   ,   ,  ,, 10.5.5.5/32", "-groups", "1,,   2    ,        ,,,3,4,5"}
-	assert.EqualError(t, signCert(args, ob, eb), "refusing to overwrite existing key: "+keyF.Name())
-	assert.Empty(t, ob.String())
-	assert.Empty(t, eb.String())
+	assert.EqualError(signCert(args, ob, eb), "refusing to overwrite existing key: "+keyF.Name())
+	assert.Empty(ob.String())
+	assert.Empty(eb.String())
 
 	// create valid cert/key for overwrite tests
 	os.Remove(keyF.Name())
 	os.Remove(crtF.Name())
 	args = []string{"-ca-crt", caCrtF.Name(), "-ca-key", caKeyF.Name(), "-name", "test", "-ip", "1.1.1.1/24", "-out-crt", crtF.Name(), "-out-key", keyF.Name(), "-duration", "100m", "-subnets", "10.1.1.1/32, ,   10.2.2.2/32   ,   ,  ,, 10.5.5.5/32", "-groups", "1,,   2    ,        ,,,3,4,5"}
-	assert.Nil(t, signCert(args, ob, eb))
+	assert.NoError(signCert(args, ob, eb))
 
 	// test that we won't overwrite existing certificate file
 	os.Remove(keyF.Name())
 	ob.Reset()
 	eb.Reset()
 	args = []string{"-ca-crt", caCrtF.Name(), "-ca-key", caKeyF.Name(), "-name", "test", "-ip", "1.1.1.1/24", "-out-crt", crtF.Name(), "-out-key", keyF.Name(), "-duration", "100m", "-subnets", "10.1.1.1/32, ,   10.2.2.2/32   ,   ,  ,, 10.5.5.5/32", "-groups", "1,,   2    ,        ,,,3,4,5"}
-	assert.EqualError(t, signCert(args, ob, eb), "refusing to overwrite existing cert: "+crtF.Name())
-	assert.Empty(t, ob.String())
-	assert.Empty(t, eb.String())
-
+	assert.EqualError(signCert(args, ob, eb), "refusing to overwrite existing cert: "+crtF.Name())
+	assert.Empty(ob.String())
+	assert.Empty(eb.String())
 }

--- a/cmd/nebula-cert/verify.go
+++ b/cmd/nebula-cert/verify.go
@@ -51,7 +51,7 @@ func verify(args []string, out io.Writer, errOut io.Writer) error {
 			return fmt.Errorf("error while adding ca cert to pool: %s", err)
 		}
 
-		if rawCACert == nil || len(rawCACert) == 0 || strings.TrimSpace(string(rawCACert)) == "" {
+		if len(rawCACert) == 0 || strings.TrimSpace(string(rawCACert)) == "" {
 			break
 		}
 	}

--- a/connection_manager.go
+++ b/connection_manager.go
@@ -140,9 +140,10 @@ func (n *connectionManager) Start() {
 }
 
 func (n *connectionManager) Run() {
-	clockSource := time.Tick(500 * time.Millisecond)
+	clockSource := time.NewTicker(500 * time.Millisecond)
+	defer clockSource.Stop()
 
-	for now := range clockSource {
+	for now := range clockSource.C {
 		n.HandleMonitorTick(now)
 		n.HandleDeletionTick(now)
 	}

--- a/connection_manager.go
+++ b/connection_manager.go
@@ -188,7 +188,7 @@ func (n *connectionManager) HandleMonitorTick(now time.Time) {
 
 		if hostinfo != nil && hostinfo.ConnectionState != nil {
 			// Send a test packet to trigger an authenticated tunnel test, this should suss out any lingering tunnel issues
-			n.intf.SendMessageToVpnIp(test, testRequest, vpnIP, []byte(""), make([]byte, 12, 12), make([]byte, mtu))
+			n.intf.SendMessageToVpnIp(test, testRequest, vpnIP, []byte(""), make([]byte, 12), make([]byte, mtu))
 
 		} else {
 			l.Debugf("Hostinfo sadness: %s", IntIp(vpnIP))

--- a/connection_state.go
+++ b/connection_state.go
@@ -21,7 +21,6 @@ type ConnectionState struct {
 	messageCounter *uint64
 	window         *Bits
 	queueLock      sync.Mutex
-	writeLock      sync.Mutex
 	ready          bool
 }
 

--- a/firewall.go
+++ b/firewall.go
@@ -461,7 +461,7 @@ func (f *Firewall) evict(p FirewallPacket) {
 		return
 	}
 
-	newT := t.Expires.Sub(time.Now())
+	newT := time.Until(t.Expires)
 
 	// Timeout is in the future, re-add the timer
 	if newT > 0 {

--- a/firewall.go
+++ b/firewall.go
@@ -63,7 +63,6 @@ type Firewall struct {
 	connMutex sync.Mutex
 	rules     string
 
-	trackTCPRTT  bool
 	metricTCPRTT metrics.Histogram
 }
 

--- a/firewall_test.go
+++ b/firewall_test.go
@@ -63,7 +63,7 @@ func TestFirewall_AddRule(t *testing.T) {
 
 	_, ti, _ := net.ParseCIDR("1.2.3.4/32")
 
-	assert.Nil(t, fw.AddRule(true, fwProtoTCP, 1, 1, []string{}, "", nil, "", ""))
+	assert.NoError(t, fw.AddRule(true, fwProtoTCP, 1, 1, []string{}, "", nil, "", ""))
 	// An empty rule is any
 	assert.True(t, fw.InRules.TCP[1].Any.Any)
 	assert.Empty(t, fw.InRules.TCP[1].Any.Groups)
@@ -73,7 +73,7 @@ func TestFirewall_AddRule(t *testing.T) {
 	assert.Nil(t, fw.InRules.TCP[1].Any.CIDR.root.value)
 
 	fw = NewFirewall(time.Second, time.Minute, time.Hour, c)
-	assert.Nil(t, fw.AddRule(true, fwProtoUDP, 1, 1, []string{"g1"}, "", nil, "", ""))
+	assert.NoError(t, fw.AddRule(true, fwProtoUDP, 1, 1, []string{"g1"}, "", nil, "", ""))
 	assert.False(t, fw.InRules.UDP[1].Any.Any)
 	assert.Contains(t, fw.InRules.UDP[1].Any.Groups[0], "g1")
 	assert.Empty(t, fw.InRules.UDP[1].Any.Hosts)
@@ -82,7 +82,7 @@ func TestFirewall_AddRule(t *testing.T) {
 	assert.Nil(t, fw.InRules.UDP[1].Any.CIDR.root.value)
 
 	fw = NewFirewall(time.Second, time.Minute, time.Hour, c)
-	assert.Nil(t, fw.AddRule(true, fwProtoICMP, 1, 1, []string{}, "h1", nil, "", ""))
+	assert.NoError(t, fw.AddRule(true, fwProtoICMP, 1, 1, []string{}, "h1", nil, "", ""))
 	assert.False(t, fw.InRules.ICMP[1].Any.Any)
 	assert.Empty(t, fw.InRules.ICMP[1].Any.Groups)
 	assert.Contains(t, fw.InRules.ICMP[1].Any.Hosts, "h1")
@@ -91,31 +91,31 @@ func TestFirewall_AddRule(t *testing.T) {
 	assert.Nil(t, fw.InRules.ICMP[1].Any.CIDR.root.value)
 
 	fw = NewFirewall(time.Second, time.Minute, time.Hour, c)
-	assert.Nil(t, fw.AddRule(false, fwProtoAny, 1, 1, []string{}, "", ti, "", ""))
+	assert.NoError(t, fw.AddRule(false, fwProtoAny, 1, 1, []string{}, "", ti, "", ""))
 	assert.False(t, fw.OutRules.AnyProto[1].Any.Any)
 	assert.Empty(t, fw.OutRules.AnyProto[1].Any.Groups)
 	assert.Empty(t, fw.OutRules.AnyProto[1].Any.Hosts)
 	assert.NotNil(t, fw.OutRules.AnyProto[1].Any.CIDR.Match(ip2int(ti.IP)))
 
 	fw = NewFirewall(time.Second, time.Minute, time.Hour, c)
-	assert.Nil(t, fw.AddRule(true, fwProtoUDP, 1, 1, []string{"g1"}, "", nil, "ca-name", ""))
+	assert.NoError(t, fw.AddRule(true, fwProtoUDP, 1, 1, []string{"g1"}, "", nil, "ca-name", ""))
 	assert.Contains(t, fw.InRules.UDP[1].CANames, "ca-name")
 
 	fw = NewFirewall(time.Second, time.Minute, time.Hour, c)
-	assert.Nil(t, fw.AddRule(true, fwProtoUDP, 1, 1, []string{"g1"}, "", nil, "", "ca-sha"))
+	assert.NoError(t, fw.AddRule(true, fwProtoUDP, 1, 1, []string{"g1"}, "", nil, "", "ca-sha"))
 	assert.Contains(t, fw.InRules.UDP[1].CAShas, "ca-sha")
 
 	// Set any and clear fields
 	fw = NewFirewall(time.Second, time.Minute, time.Hour, c)
-	assert.Nil(t, fw.AddRule(false, fwProtoAny, 0, 0, []string{"g1", "g2"}, "h1", ti, "", ""))
+	assert.NoError(t, fw.AddRule(false, fwProtoAny, 0, 0, []string{"g1", "g2"}, "h1", ti, "", ""))
 	assert.Equal(t, []string{"g1", "g2"}, fw.OutRules.AnyProto[0].Any.Groups[0])
 	assert.Contains(t, fw.OutRules.AnyProto[0].Any.Hosts, "h1")
 	assert.NotNil(t, fw.OutRules.AnyProto[0].Any.CIDR.Match(ip2int(ti.IP)))
 
 	// run twice just to make sure
 	//TODO: these ANY rules should clear the CA firewall portion
-	assert.Nil(t, fw.AddRule(false, fwProtoAny, 0, 0, []string{"any"}, "", nil, "", ""))
-	assert.Nil(t, fw.AddRule(false, fwProtoAny, 0, 0, []string{}, "any", nil, "", ""))
+	assert.NoError(t, fw.AddRule(false, fwProtoAny, 0, 0, []string{"any"}, "", nil, "", ""))
+	assert.NoError(t, fw.AddRule(false, fwProtoAny, 0, 0, []string{}, "any", nil, "", ""))
 	assert.True(t, fw.OutRules.AnyProto[0].Any.Any)
 	assert.Empty(t, fw.OutRules.AnyProto[0].Any.Groups)
 	assert.Empty(t, fw.OutRules.AnyProto[0].Any.Hosts)
@@ -124,12 +124,12 @@ func TestFirewall_AddRule(t *testing.T) {
 	assert.Nil(t, fw.OutRules.AnyProto[0].Any.CIDR.root.value)
 
 	fw = NewFirewall(time.Second, time.Minute, time.Hour, c)
-	assert.Nil(t, fw.AddRule(false, fwProtoAny, 0, 0, []string{}, "any", nil, "", ""))
+	assert.NoError(t, fw.AddRule(false, fwProtoAny, 0, 0, []string{}, "any", nil, "", ""))
 	assert.True(t, fw.OutRules.AnyProto[0].Any.Any)
 
 	fw = NewFirewall(time.Second, time.Minute, time.Hour, c)
 	_, anyIp, _ := net.ParseCIDR("0.0.0.0/0")
-	assert.Nil(t, fw.AddRule(false, fwProtoAny, 0, 0, []string{}, "", anyIp, "", ""))
+	assert.NoError(t, fw.AddRule(false, fwProtoAny, 0, 0, []string{}, "", anyIp, "", ""))
 	assert.True(t, fw.OutRules.AnyProto[0].Any.Any)
 
 	// Test error conditions
@@ -175,7 +175,7 @@ func TestFirewall_Drop(t *testing.T) {
 	h.CreateRemoteCIDR(&c)
 
 	fw := NewFirewall(time.Second, time.Minute, time.Hour, &c)
-	assert.Nil(t, fw.AddRule(true, fwProtoAny, 0, 0, []string{"any"}, "", nil, "", ""))
+	assert.NoError(t, fw.AddRule(true, fwProtoAny, 0, 0, []string{"any"}, "", nil, "", ""))
 	cp := cert.NewCAPool()
 
 	// Drop outbound
@@ -194,28 +194,28 @@ func TestFirewall_Drop(t *testing.T) {
 
 	// ensure signer doesn't get in the way of group checks
 	fw = NewFirewall(time.Second, time.Minute, time.Hour, &c)
-	assert.Nil(t, fw.AddRule(true, fwProtoAny, 0, 0, []string{"nope"}, "", nil, "", "signer-shasum"))
-	assert.Nil(t, fw.AddRule(true, fwProtoAny, 0, 0, []string{"default-group"}, "", nil, "", "signer-shasum-bad"))
+	assert.NoError(t, fw.AddRule(true, fwProtoAny, 0, 0, []string{"nope"}, "", nil, "", "signer-shasum"))
+	assert.NoError(t, fw.AddRule(true, fwProtoAny, 0, 0, []string{"default-group"}, "", nil, "", "signer-shasum-bad"))
 	assert.True(t, fw.Drop([]byte{}, p, true, &h, cp))
 
 	// test caSha doesn't drop on match
 	fw = NewFirewall(time.Second, time.Minute, time.Hour, &c)
-	assert.Nil(t, fw.AddRule(true, fwProtoAny, 0, 0, []string{"nope"}, "", nil, "", "signer-shasum-bad"))
-	assert.Nil(t, fw.AddRule(true, fwProtoAny, 0, 0, []string{"default-group"}, "", nil, "", "signer-shasum"))
+	assert.NoError(t, fw.AddRule(true, fwProtoAny, 0, 0, []string{"nope"}, "", nil, "", "signer-shasum-bad"))
+	assert.NoError(t, fw.AddRule(true, fwProtoAny, 0, 0, []string{"default-group"}, "", nil, "", "signer-shasum"))
 	assert.False(t, fw.Drop([]byte{}, p, true, &h, cp))
 
 	// ensure ca name doesn't get in the way of group checks
 	cp.CAs["signer-shasum"] = &cert.NebulaCertificate{Details: cert.NebulaCertificateDetails{Name: "ca-good"}}
 	fw = NewFirewall(time.Second, time.Minute, time.Hour, &c)
-	assert.Nil(t, fw.AddRule(true, fwProtoAny, 0, 0, []string{"nope"}, "", nil, "ca-good", ""))
-	assert.Nil(t, fw.AddRule(true, fwProtoAny, 0, 0, []string{"default-group"}, "", nil, "ca-good-bad", ""))
+	assert.NoError(t, fw.AddRule(true, fwProtoAny, 0, 0, []string{"nope"}, "", nil, "ca-good", ""))
+	assert.NoError(t, fw.AddRule(true, fwProtoAny, 0, 0, []string{"default-group"}, "", nil, "ca-good-bad", ""))
 	assert.True(t, fw.Drop([]byte{}, p, true, &h, cp))
 
 	// test caName doesn't drop on match
 	cp.CAs["signer-shasum"] = &cert.NebulaCertificate{Details: cert.NebulaCertificateDetails{Name: "ca-good"}}
 	fw = NewFirewall(time.Second, time.Minute, time.Hour, &c)
-	assert.Nil(t, fw.AddRule(true, fwProtoAny, 0, 0, []string{"nope"}, "", nil, "ca-good-bad", ""))
-	assert.Nil(t, fw.AddRule(true, fwProtoAny, 0, 0, []string{"default-group"}, "", nil, "ca-good", ""))
+	assert.NoError(t, fw.AddRule(true, fwProtoAny, 0, 0, []string{"nope"}, "", nil, "ca-good-bad", ""))
+	assert.NoError(t, fw.AddRule(true, fwProtoAny, 0, 0, []string{"default-group"}, "", nil, "ca-good", ""))
 	assert.False(t, fw.Drop([]byte{}, p, true, &h, cp))
 }
 
@@ -224,7 +224,8 @@ func BenchmarkFirewallTable_match(b *testing.B) {
 		TCP: firewallPort{},
 	}
 
-	_, n, _ := net.ParseCIDR("172.1.1.1/32")
+	_, n, err := net.ParseCIDR("172.1.1.1/32")
+	assert.NoError(b, err, "ParseCIDR")
 	_ = ft.TCP.addRule(10, 10, []string{"good-group"}, "good-host", n, "", "")
 	_ = ft.TCP.addRule(10, 10, []string{"good-group2"}, "good-host", n, "", "")
 	_ = ft.TCP.addRule(10, 10, []string{"good-group3"}, "good-host", n, "", "")
@@ -247,7 +248,8 @@ func BenchmarkFirewallTable_match(b *testing.B) {
 	})
 
 	b.Run("fail all group, name, and cidr", func(b *testing.B) {
-		_, ip, _ := net.ParseCIDR("9.254.254.254/32")
+		_, ip, err := net.ParseCIDR("9.254.254.254/32")
+		assert.NoError(b, err, "ParseCIDR")
 		c := &cert.NebulaCertificate{
 			Details: cert.NebulaCertificateDetails{
 				InvertedGroups: map[string]struct{}{"nope": {}},
@@ -362,7 +364,7 @@ func TestFirewall_Drop2(t *testing.T) {
 	h1.CreateRemoteCIDR(&c1)
 
 	fw := NewFirewall(time.Second, time.Minute, time.Hour, &c)
-	assert.Nil(t, fw.AddRule(true, fwProtoAny, 0, 0, []string{"default-group", "test-group"}, "", nil, "", ""))
+	assert.NoError(t, fw.AddRule(true, fwProtoAny, 0, 0, []string{"default-group", "test-group"}, "", nil, "", ""))
 	cp := cert.NewCAPool()
 
 	// h1/c1 lacks the proper groups
@@ -442,8 +444,8 @@ func TestFirewall_Drop3(t *testing.T) {
 	h3.CreateRemoteCIDR(&c3)
 
 	fw := NewFirewall(time.Second, time.Minute, time.Hour, &c)
-	assert.Nil(t, fw.AddRule(true, fwProtoAny, 1, 1, []string{}, "host1", nil, "", ""))
-	assert.Nil(t, fw.AddRule(true, fwProtoAny, 1, 1, []string{}, "", nil, "", "signer-sha"))
+	assert.NoError(t, fw.AddRule(true, fwProtoAny, 1, 1, []string{}, "host1", nil, "", ""))
+	assert.NoError(t, fw.AddRule(true, fwProtoAny, 1, 1, []string{}, "", nil, "", "signer-sha"))
 	cp := cert.NewCAPool()
 
 	// c1 should pass because host match
@@ -553,22 +555,22 @@ func Test_parsePort(t *testing.T) {
 	s, e, err := parsePort(" 1 - 2    ")
 	assert.Equal(t, int32(1), s)
 	assert.Equal(t, int32(2), e)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	s, e, err = parsePort("0-1")
 	assert.Equal(t, int32(0), s)
 	assert.Equal(t, int32(0), e)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	s, e, err = parsePort("9919")
 	assert.Equal(t, int32(9919), s)
 	assert.Equal(t, int32(9919), e)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	s, e, err = parsePort("any")
 	assert.Equal(t, int32(0), s)
 	assert.Equal(t, int32(0), e)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestNewFirewallFromConfig(t *testing.T) {
@@ -625,63 +627,63 @@ func TestAddFirewallRulesFromConfig(t *testing.T) {
 	conf := NewConfig()
 	mf := &mockFirewall{}
 	conf.Settings["firewall"] = map[interface{}]interface{}{"outbound": []interface{}{map[interface{}]interface{}{"port": "1", "proto": "tcp", "host": "a"}}}
-	assert.Nil(t, AddFirewallRulesFromConfig(false, conf, mf))
+	assert.NoError(t, AddFirewallRulesFromConfig(false, conf, mf))
 	assert.Equal(t, addRuleCall{incoming: false, proto: fwProtoTCP, startPort: 1, endPort: 1, groups: nil, host: "a", ip: nil}, mf.lastCall)
 
 	// Test adding udp rule
 	conf = NewConfig()
 	mf = &mockFirewall{}
 	conf.Settings["firewall"] = map[interface{}]interface{}{"outbound": []interface{}{map[interface{}]interface{}{"port": "1", "proto": "udp", "host": "a"}}}
-	assert.Nil(t, AddFirewallRulesFromConfig(false, conf, mf))
+	assert.NoError(t, AddFirewallRulesFromConfig(false, conf, mf))
 	assert.Equal(t, addRuleCall{incoming: false, proto: fwProtoUDP, startPort: 1, endPort: 1, groups: nil, host: "a", ip: nil}, mf.lastCall)
 
 	// Test adding icmp rule
 	conf = NewConfig()
 	mf = &mockFirewall{}
 	conf.Settings["firewall"] = map[interface{}]interface{}{"outbound": []interface{}{map[interface{}]interface{}{"port": "1", "proto": "icmp", "host": "a"}}}
-	assert.Nil(t, AddFirewallRulesFromConfig(false, conf, mf))
+	assert.NoError(t, AddFirewallRulesFromConfig(false, conf, mf))
 	assert.Equal(t, addRuleCall{incoming: false, proto: fwProtoICMP, startPort: 1, endPort: 1, groups: nil, host: "a", ip: nil}, mf.lastCall)
 
 	// Test adding any rule
 	conf = NewConfig()
 	mf = &mockFirewall{}
 	conf.Settings["firewall"] = map[interface{}]interface{}{"inbound": []interface{}{map[interface{}]interface{}{"port": "1", "proto": "any", "host": "a"}}}
-	assert.Nil(t, AddFirewallRulesFromConfig(true, conf, mf))
+	assert.NoError(t, AddFirewallRulesFromConfig(true, conf, mf))
 	assert.Equal(t, addRuleCall{incoming: true, proto: fwProtoAny, startPort: 1, endPort: 1, groups: nil, host: "a", ip: nil}, mf.lastCall)
 
 	// Test adding rule with ca_sha
 	conf = NewConfig()
 	mf = &mockFirewall{}
 	conf.Settings["firewall"] = map[interface{}]interface{}{"inbound": []interface{}{map[interface{}]interface{}{"port": "1", "proto": "any", "ca_sha": "12312313123"}}}
-	assert.Nil(t, AddFirewallRulesFromConfig(true, conf, mf))
+	assert.NoError(t, AddFirewallRulesFromConfig(true, conf, mf))
 	assert.Equal(t, addRuleCall{incoming: true, proto: fwProtoAny, startPort: 1, endPort: 1, groups: nil, ip: nil, caSha: "12312313123"}, mf.lastCall)
 
 	// Test adding rule with ca_name
 	conf = NewConfig()
 	mf = &mockFirewall{}
 	conf.Settings["firewall"] = map[interface{}]interface{}{"inbound": []interface{}{map[interface{}]interface{}{"port": "1", "proto": "any", "ca_name": "root01"}}}
-	assert.Nil(t, AddFirewallRulesFromConfig(true, conf, mf))
+	assert.NoError(t, AddFirewallRulesFromConfig(true, conf, mf))
 	assert.Equal(t, addRuleCall{incoming: true, proto: fwProtoAny, startPort: 1, endPort: 1, groups: nil, ip: nil, caName: "root01"}, mf.lastCall)
 
 	// Test single group
 	conf = NewConfig()
 	mf = &mockFirewall{}
 	conf.Settings["firewall"] = map[interface{}]interface{}{"inbound": []interface{}{map[interface{}]interface{}{"port": "1", "proto": "any", "group": "a"}}}
-	assert.Nil(t, AddFirewallRulesFromConfig(true, conf, mf))
+	assert.NoError(t, AddFirewallRulesFromConfig(true, conf, mf))
 	assert.Equal(t, addRuleCall{incoming: true, proto: fwProtoAny, startPort: 1, endPort: 1, groups: []string{"a"}, ip: nil}, mf.lastCall)
 
 	// Test single groups
 	conf = NewConfig()
 	mf = &mockFirewall{}
 	conf.Settings["firewall"] = map[interface{}]interface{}{"inbound": []interface{}{map[interface{}]interface{}{"port": "1", "proto": "any", "groups": "a"}}}
-	assert.Nil(t, AddFirewallRulesFromConfig(true, conf, mf))
+	assert.NoError(t, AddFirewallRulesFromConfig(true, conf, mf))
 	assert.Equal(t, addRuleCall{incoming: true, proto: fwProtoAny, startPort: 1, endPort: 1, groups: []string{"a"}, ip: nil}, mf.lastCall)
 
 	// Test multiple AND groups
 	conf = NewConfig()
 	mf = &mockFirewall{}
 	conf.Settings["firewall"] = map[interface{}]interface{}{"inbound": []interface{}{map[interface{}]interface{}{"port": "1", "proto": "any", "groups": []string{"a", "b"}}}}
-	assert.Nil(t, AddFirewallRulesFromConfig(true, conf, mf))
+	assert.NoError(t, AddFirewallRulesFromConfig(true, conf, mf))
 	assert.Equal(t, addRuleCall{incoming: true, proto: fwProtoAny, startPort: 1, endPort: 1, groups: []string{"a", "b"}, ip: nil}, mf.lastCall)
 
 	// Test Add error
@@ -796,7 +798,7 @@ func TestFirewall_convertRule(t *testing.T) {
 
 	r, err := convertRule(c, "test", 1)
 	assert.Contains(t, ob.String(), "test rule #1; group was an array with a single value, converting to simple value")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "group1", r.Group)
 
 	// Ensure group array of > 1 is errord
@@ -816,7 +818,7 @@ func TestFirewall_convertRule(t *testing.T) {
 	}
 
 	r, err = convertRule(c, "test", 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "group1", r.Group)
 }
 

--- a/handshake.go
+++ b/handshake.go
@@ -2,7 +2,6 @@ package nebula
 
 const (
 	handshakeIXPSK0 = 0
-	handshakeXXPSK0 = 1
 )
 
 func HandleIncomingHandshake(f *Interface, addr *udpAddr, packet []byte, h *Header, hostinfo *HostInfo) {

--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -171,7 +171,7 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet [
 				Info("Prevented a handshake race")
 
 			// Send a test packet to trigger an authenticated tunnel test, this should suss out any lingering tunnel issues
-			f.SendMessageToVpnIp(test, testRequest, vpnIP, []byte(""), make([]byte, 12, 12), make([]byte, mtu))
+			f.SendMessageToVpnIp(test, testRequest, vpnIP, []byte(""), make([]byte, 12), make([]byte, mtu))
 			return true
 		}
 

--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -41,13 +41,10 @@ func ixHandshakeStage0(f *Interface, vpnIp uint32, hostinfo *HostInfo) {
 		Cert:           ci.certState.rawCertificateNoKey,
 	}
 
-	hsBytes := []byte{}
-
 	hs := &NebulaHandshake{
 		Details: hsProto,
 	}
-	hsBytes, err = proto.Marshal(hs)
-
+	hsBytes, err := proto.Marshal(hs)
 	if err != nil {
 		l.WithError(err).WithField("vpnIp", IntIp(vpnIp)).
 			WithField("handshake", m{"stage": 0, "style": "ix_psk0"}).Error("Failed to marshal handshake message")

--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -42,8 +42,10 @@ func NewHandshakeManager(tunCidr *net.IPNet, preferredRanges []*net.IPNet, mainH
 }
 
 func (c *HandshakeManager) Run(f EncWriter) {
-	clockSource := time.Tick(HandshakeTryInterval)
-	for now := range clockSource {
+	clockSource := time.NewTicker(HandshakeTryInterval)
+	defer clockSource.Stop()
+
+	for now := range clockSource.C {
 		c.NextOutboundHandshakeTimerTick(now, f)
 		c.NextInboundHandshakeTimerTick(now)
 	}

--- a/handshake_manager_test.go
+++ b/handshake_manager_test.go
@@ -28,7 +28,8 @@ func Test_NewHandshakeManagerIndex(t *testing.T) {
 
 	// Add four indexes
 	for _, v := range indexes {
-		blah.AddIndex(v, &ConnectionState{})
+		_, err := blah.AddIndex(v, &ConnectionState{})
+		assert.NoError(t, err, "AddIndex")
 	}
 	// Confirm they are in the pending index list
 	for _, v := range indexes {

--- a/handshake_manager_test.go
+++ b/handshake_manager_test.go
@@ -186,9 +186,7 @@ type mockEncWriter struct {
 }
 
 func (mw *mockEncWriter) SendMessageToVpnIp(t NebulaMessageType, st NebulaMessageSubType, vpnIp uint32, p, nb, out []byte) {
-	return
 }
 
 func (mw *mockEncWriter) SendMessageToAll(t NebulaMessageType, st NebulaMessageSubType, vpnIp uint32, p, nb, out []byte) {
-	return
 }

--- a/header.go
+++ b/header.go
@@ -19,10 +19,8 @@ import (
 // |-----------------------------------------------------------------------|
 // |                               payload...                              |
 
-const (
-	Version   uint8 = 1
-	HeaderLen       = 16
-)
+const Version uint8 = 1
+const HeaderLen = 16
 
 type NebulaMessageType uint8
 type NebulaMessageSubType uint8

--- a/header_test.go
+++ b/header_test.go
@@ -42,7 +42,7 @@ func TestParse(t *testing.T) {
 	for _, tt := range headerBigEndianTests {
 		b := tt.expectedBytes
 		parsedHeader := &Header{}
-		parsedHeader.Parse(b)
+		assert.NoError(t, parsedHeader.Parse(b), "Header.Parse")
 
 		if !reflect.DeepEqual(tt.Header, parsedHeader) {
 			t.Fatalf("got %#v; want %#v", parsedHeader, tt.Header)
@@ -109,7 +109,7 @@ func TestHeader_String(t *testing.T) {
 
 func TestHeader_MarshalJSON(t *testing.T) {
 	b, err := (&Header{100, test, testRequest, 99, 98, 97}).MarshalJSON()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(
 		t,
 		"{\"messageCounter\":97,\"remoteIndex\":98,\"reserved\":99,\"subType\":\"testRequest\",\"type\":\"test\",\"version\":100}",

--- a/inside.go
+++ b/inside.go
@@ -27,7 +27,7 @@ func (f *Interface) consumeInsidePacket(packet []byte, fwPacket *FirewallPacket,
 	hostinfo := f.getOrHandshake(fwPacket.RemoteIP)
 	ci := hostinfo.ConnectionState
 
-	if ci.ready == false {
+	if !ci.ready {
 		// Because we might be sending stored packets, lock here to stop new things going to
 		// the packet queue.
 		ci.queueLock.Lock()
@@ -52,7 +52,7 @@ func (f *Interface) consumeInsidePacket(packet []byte, fwPacket *FirewallPacket,
 }
 
 func (f *Interface) getOrHandshake(vpnIp uint32) *HostInfo {
-	if f.hostMap.vpnCIDR.Contains(int2ip(vpnIp)) == false {
+	if !f.hostMap.vpnCIDR.Contains(int2ip(vpnIp)) {
 		vpnIp = f.hostMap.queryUnsafeRoute(vpnIp)
 	}
 	hostinfo, err := f.hostMap.PromoteBestQueryVpnIP(vpnIp, f)
@@ -128,7 +128,6 @@ func (f *Interface) SendMessageToVpnIp(t NebulaMessageType, st NebulaMessageSubT
 	}
 
 	f.sendMessageToVpnIp(t, st, hostInfo, p, nb, out)
-	return
 }
 
 func (f *Interface) sendMessageToVpnIp(t NebulaMessageType, st NebulaMessageSubType, hostInfo *HostInfo, p, nb, out []byte) {
@@ -139,7 +138,7 @@ func (f *Interface) sendMessageToVpnIp(t NebulaMessageType, st NebulaMessageSubT
 func (f *Interface) SendMessageToAll(t NebulaMessageType, st NebulaMessageSubType, vpnIp uint32, p, nb, out []byte) {
 	hostInfo := f.getOrHandshake(vpnIp)
 
-	if hostInfo.ConnectionState.ready == false {
+	if !hostInfo.ConnectionState.ready {
 		// Because we might be sending stored packets, lock here to stop new things going to
 		// the packet queue.
 		hostInfo.ConnectionState.queueLock.Lock()
@@ -152,7 +151,6 @@ func (f *Interface) SendMessageToAll(t NebulaMessageType, st NebulaMessageSubTyp
 	}
 
 	f.sendMessageToAll(t, st, hostInfo, p, nb, out)
-	return
 }
 
 func (f *Interface) sendMessageToAll(t NebulaMessageType, st NebulaMessageSubType, hostInfo *HostInfo, p, nb, b []byte) {
@@ -196,9 +194,5 @@ func (f *Interface) send(t NebulaMessageType, st NebulaMessageSubType, ci *Conne
 
 func isMulticast(ip uint32) bool {
 	// Class D multicast
-	if (((ip >> 24) & 0xff) & 0xf0) == 0xe0 {
-		return true
-	}
-
-	return false
+	return (((ip >> 24) & 0xff) & 0xf0) == 0xe0
 }

--- a/interface.go
+++ b/interface.go
@@ -142,7 +142,7 @@ func (f *Interface) listenIn(i int) {
 	packet := make([]byte, mtu)
 	out := make([]byte, mtu)
 	fwPacket := &FirewallPacket{}
-	nb := make([]byte, 12, 12)
+	nb := make([]byte, 12)
 
 	for {
 		n, err := f.inside.Read(packet)
@@ -198,7 +198,7 @@ func (f *Interface) reloadCertKey(c *Config) {
 
 func (f *Interface) reloadFirewall(c *Config) {
 	//TODO: need to trigger/detect if the certificate changed too
-	if c.HasChanged("firewall") == false {
+	if !c.HasChanged("firewall") {
 		l.Debug("No firewall config change detected")
 		return
 	}

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -54,7 +54,7 @@ func NewLightHouse(amLighthouse bool, myIp uint32, ips []uint32, interval int, n
 }
 
 func (lh *LightHouse) ValidateLHStaticEntries() error {
-	for lhIP, _ := range lh.lighthouses {
+	for lhIP := range lh.lighthouses {
 		if _, ok := lh.staticList[lhIP]; !ok {
 			return fmt.Errorf("Lighthouse %s does not have a static_host_map entry", IntIp(lhIP))
 		}
@@ -85,7 +85,7 @@ func (lh *LightHouse) QueryServer(ip uint32, f EncWriter) {
 			return
 		}
 
-		nb := make([]byte, 12, 12)
+		nb := make([]byte, 12)
 		out := make([]byte, mtu)
 		for n := range lh.lighthouses {
 			f.SendMessageToVpnIp(lightHouse, 0, n, query, nb, out)
@@ -120,7 +120,7 @@ func (lh *LightHouse) DeleteVpnIP(vpnIP uint32) {
 func (lh *LightHouse) AddRemote(vpnIP uint32, toIp *udpAddr, static bool) {
 	// First we check if the sender thinks this is a static entry
 	// and do nothing if it is not, but should be considered static
-	if static == false {
+	if !static {
 		if _, ok := lh.staticList[vpnIP]; ok {
 			return
 		}
@@ -216,7 +216,7 @@ func (lh *LightHouse) LhUpdateWorker(f EncWriter) {
 			},
 		}
 
-		nb := make([]byte, 12, 12)
+		nb := make([]byte, 12)
 		out := make([]byte, mtu)
 		for vpnIp := range lh.lighthouses {
 			mm, err := proto.Marshal(m)
@@ -275,7 +275,7 @@ func (lh *LightHouse) HandleRequest(rAddr *udpAddr, vpnIp uint32, p []byte, c *c
 				l.WithError(err).WithField("vpnIp", IntIp(vpnIp)).Error("Failed to marshal lighthouse host query reply")
 				return
 			}
-			f.SendMessageToVpnIp(lightHouse, 0, vpnIp, reply, make([]byte, 12, 12), make([]byte, mtu))
+			f.SendMessageToVpnIp(lightHouse, 0, vpnIp, reply, make([]byte, 12), make([]byte, mtu))
 
 			// This signals the other side to punch some zero byte udp packets
 			ips, err = lh.Query(vpnIp, f)
@@ -293,7 +293,7 @@ func (lh *LightHouse) HandleRequest(rAddr *udpAddr, vpnIp uint32, p []byte, c *c
 					},
 				}
 				reply, _ := proto.Marshal(answer)
-				f.SendMessageToVpnIp(lightHouse, 0, n.Details.VpnIp, reply, make([]byte, 12, 12), make([]byte, mtu))
+				f.SendMessageToVpnIp(lightHouse, 0, n.Details.VpnIp, reply, make([]byte, 12), make([]byte, mtu))
 			}
 			//fmt.Println(reply, remoteaddr)
 		}
@@ -343,7 +343,7 @@ func (lh *LightHouse) HandleRequest(rAddr *udpAddr, vpnIp uint32, p []byte, c *c
 			go func() {
 				time.Sleep(time.Second * 5)
 				l.Debugf("Sending a nebula test packet to vpn ip %s", IntIp(n.Details.VpnIp))
-				f.SendMessageToVpnIp(test, testRequest, n.Details.VpnIp, []byte(""), make([]byte, 12, 12), make([]byte, mtu))
+				f.SendMessageToVpnIp(test, testRequest, n.Details.VpnIp, []byte(""), make([]byte, 12), make([]byte, mtu))
 			}()
 		}
 	}

--- a/lighthouse_test.go
+++ b/lighthouse_test.go
@@ -20,12 +20,12 @@ func TestNewLhQuery(t *testing.T) {
 
 	// It should also Marshal fine
 	b, err := proto.Marshal(a)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// and then Unmarshal fine
 	n := &NebulaMeta{}
 	err = proto.Unmarshal(b, n)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 }
 
@@ -55,7 +55,7 @@ func Test_lhStaticMapping(t *testing.T) {
 	meh := NewLightHouse(true, 1, []uint32{ip2int(lh1IP)}, 10, 10003, udpServer, false)
 	meh.AddRemote(ip2int(lh1IP), NewUDPAddr(ip2int(lh1IP), uint16(4242)), true)
 	err := meh.ValidateLHStaticEntries()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	lh2 := "10.128.0.3"
 	lh2IP := net.ParseIP(lh2)

--- a/main.go
+++ b/main.go
@@ -178,7 +178,7 @@ func Main(configPath string, configTest bool, buildVersion string) {
 	*/
 
 	punchy := config.GetBool("punchy", false)
-	if punchy == true {
+	if punchy {
 		l.Info("UDP hole punching enabled")
 		go hostMap.Punchy(udpServer)
 	}
@@ -344,7 +344,7 @@ func shutdownBlock(ifce *Interface) {
 	ifce.hostMap.Lock()
 	for _, h := range ifce.hostMap.Hosts {
 		if h.ConnectionState.ready {
-			ifce.send(closeTunnel, 0, h.ConnectionState, h, h.remote, []byte{}, make([]byte, 12, 12), make([]byte, mtu))
+			ifce.send(closeTunnel, 0, h.ConnectionState, h, h.remote, []byte{}, make([]byte, 12), make([]byte, mtu))
 			l.WithField("vpnIp", IntIp(h.hostId)).WithField("udpAddr", h.remote).
 				Debug("Sending close tunnel message")
 		}

--- a/main.go
+++ b/main.go
@@ -332,7 +332,7 @@ func Main(configPath string, configTest bool, buildVersion string) {
 }
 
 func shutdownBlock(ifce *Interface) {
-	var sigChan = make(chan os.Signal)
+	var sigChan = make(chan os.Signal, 8)
 	signal.Notify(sigChan, syscall.SIGTERM)
 	signal.Notify(sigChan, syscall.SIGINT)
 

--- a/outside_test.go
+++ b/outside_test.go
@@ -50,7 +50,7 @@ func Test_newPacket(t *testing.T) {
 	b = append(b, []byte{0, 3, 0, 4}...)
 	err = newPacket(b, true, p)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, p.Protocol, uint8(fwProtoTCP))
 	assert.Equal(t, p.LocalIP, ip2int(net.IPv4(10, 0, 0, 2)))
 	assert.Equal(t, p.RemoteIP, ip2int(net.IPv4(10, 0, 0, 1)))
@@ -71,7 +71,7 @@ func Test_newPacket(t *testing.T) {
 	b = append(b, []byte{0, 5, 0, 6}...)
 	err = newPacket(b, false, p)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, p.Protocol, uint8(2))
 	assert.Equal(t, p.LocalIP, ip2int(net.IPv4(10, 0, 0, 1)))
 	assert.Equal(t, p.RemoteIP, ip2int(net.IPv4(10, 0, 0, 2)))

--- a/ssh.go
+++ b/ssh.go
@@ -453,7 +453,7 @@ func sshStartCpuProfile(fs interface{}, a []string, w sshd.StringWriter) error {
 }
 
 func sshVersion(ifce *Interface, fs interface{}, a []string, w sshd.StringWriter) error {
-	return w.WriteLine(fmt.Sprintf("%s", ifce.version))
+	return w.WriteLine(ifce.version)
 }
 
 func sshQueryLighthouse(ifce *Interface, fs interface{}, a []string, w sshd.StringWriter) error {
@@ -499,7 +499,7 @@ func sshCloseTunnel(ifce *Interface, fs interface{}, a []string, w sshd.StringWr
 			hostInfo,
 			hostInfo.remote,
 			[]byte{},
-			make([]byte, 12, 12),
+			make([]byte, 12),
 			make([]byte, mtu),
 		)
 	}

--- a/sshd/server.go
+++ b/sshd/server.go
@@ -16,11 +16,10 @@ type SSHServer struct {
 	trustedKeys map[string]map[string]bool
 
 	// List of available commands
-	helpCommand *Command
-	commands    *radix.Tree
-	listener    net.Listener
-	conns       map[int]*session
-	counter     int
+	commands *radix.Tree
+	listener net.Listener
+	conns    map[int]*session
+	counter  int
 }
 
 // NewSSHServer creates a new ssh server rigged with default commands and prepares to listen

--- a/sshd/server.go
+++ b/sshd/server.go
@@ -155,11 +155,10 @@ func (s *SSHServer) Stop() {
 	}
 
 	s.l.Info("SSH server stopped listening")
-	return
 }
 
 func (s *SSHServer) matchPubKey(c ssh.ConnMetadata, pubKey ssh.PublicKey) (*ssh.Permissions, error) {
-	pk := string(pubKey.Marshal())
+	pk := pubKey.Marshal()
 	fp := ssh.FingerprintSHA256(pubKey)
 
 	tk, ok := s.trustedKeys[c.User()]
@@ -167,8 +166,7 @@ func (s *SSHServer) matchPubKey(c ssh.ConnMetadata, pubKey ssh.PublicKey) (*ssh.
 		return nil, fmt.Errorf("unknown user %s", c.User())
 	}
 
-	_, ok = tk[pk]
-	if !ok {
+	if _, ok := tk[string(pk)]; !ok {
 		return nil, fmt.Errorf("unknown public key for %s (%s)", c.User(), fp)
 	}
 

--- a/sshd/session.go
+++ b/sshd/session.go
@@ -173,7 +173,6 @@ func (s *session) dispatchCommand(line string, w StringWriter) {
 	if err != nil {
 		//TODO: log the error
 	}
-	return
 }
 
 func (s *session) Close() {

--- a/tun_common.go
+++ b/tun_common.go
@@ -188,9 +188,5 @@ func ipWithin(o *net.IPNet, i *net.IPNet) bool {
 	}
 
 	// Make sure o contains the max
-	if !o.Contains(last) {
-		return false
-	}
-
-	return true
+	return o.Contains(last)
 }

--- a/tun_test.go
+++ b/tun_test.go
@@ -12,7 +12,7 @@ func Test_parseRoutes(t *testing.T) {
 
 	// test no routes config
 	routes, err := parseRoutes(c, n)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, routes, 0)
 
 	// not an array
@@ -24,7 +24,7 @@ func Test_parseRoutes(t *testing.T) {
 	// no routes
 	c.Settings["tun"] = map[interface{}]interface{}{"routes": []interface{}{}}
 	routes, err = parseRoutes(c, n)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, routes, 0)
 
 	// weird route
@@ -81,7 +81,7 @@ func Test_parseRoutes(t *testing.T) {
 		map[interface{}]interface{}{"mtu": "8000", "route": "10.0.0.1/32"},
 	}}
 	routes, err = parseRoutes(c, n)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Len(t, routes, 2)
 
 	tested := 0

--- a/udp_generic.go
+++ b/udp_generic.go
@@ -85,10 +85,6 @@ func (u *udpConn) reloadConfig(c *Config) {
 	// TODO
 }
 
-type rawMessage struct {
-	Len uint32
-}
-
 func (u *udpConn) ListenOut(f *Interface) {
 	plaintext := make([]byte, mtu)
 	buffer := make([]byte, mtu)

--- a/udp_generic.go
+++ b/udp_generic.go
@@ -95,7 +95,7 @@ func (u *udpConn) ListenOut(f *Interface) {
 	header := &Header{}
 	fwPacket := &FirewallPacket{}
 	udpAddr := &udpAddr{}
-	nb := make([]byte, 12, 12)
+	nb := make([]byte, 12)
 
 	for {
 		// Just read one packet at a time


### PR DESCRIPTION
This pull request currently contains 4 commits:

**1. simplify code**

This change removes unnecessary complicated constructs. For example                                                                                                                                                                                    ``if x == true {`` is changed to ``if x {``, and                                                                                                                                                                                                           ``if x == true { return true } else { return false }`` is changed                                                                                                                                                                                        to ``return x``.

No behavioral changes have been made in this commit. 

**2. 'safe' changes**

This change replaces ``timer.Tick`` with ``timer.NewTicker`` (and defers                                                                                                                                                                                       a call to ``timer.Stop`` to avoid theoretically leaking goroutines).                                                                                                                                                                                        The current code seems to be fine as is, because the loops are                                                                                                                                                                                         long running and can not be exited at the moment, but I think it is                                                                                                                                                                                    still good habit to write well-behaving code.

Additionally a small buffer is added to the ``os.Signal`` channel                                                                                                                                                                                          (according to the docs, those channels must be buffered because                                                                                                                                                                                        the signal handler can not block and can not do a synchronized                                                                                                                                                                                         send).

Neither of those changes should change the behavior in any way.   

**3. removed unused code**

Those variables are currently unused and its properly safe to                                                                                                                                                                                          remove them. They might indicate some other bugs though, so **please                                                                                                                                                                                     review**. 

**4. improve test error handling**

This change adds lots of error checks to the existing test cases.

I have also rewritten all usages of ``assert.Nil(err)`` to                                                                                                                                                                                               ``assert.NoError(err)``. The later gives a clear indent what the assertion is about (especially if its written like                                                                                                                                                                                           ``assert.Nil(createCA())``) and the error messages in the case of                                                                                                                                                                                        an failure are much clearer ("unexpected error").

No behavoral changes are introduced. This change only adds additional checks to the existing test cases.

---

There is also a 5th commit which is currently not part of this pull request. It adds missing error handling to the remaining program. Since those changes will affect the behavior, those should be reviewed more carefully. I will prepare another pull request for them in the future.