### PR TITLE
add logging.timestamp_format config option

### DIFF
--- a/config.go
+++ b/config.go
@@ -328,12 +328,23 @@ func configLogger(c *Config) error {
 	}
 	l.SetLevel(logLevel)
 
+	timestampFormat := c.GetString("logging.timestamp_format", "")
+	fullTimestamp := (timestampFormat != "")
+	if timestampFormat == "" {
+		timestampFormat = time.RFC3339
+	}
+
 	logFormat := strings.ToLower(c.GetString("logging.format", "text"))
 	switch logFormat {
 	case "text":
-		l.Formatter = &logrus.TextFormatter{}
+		l.Formatter = &logrus.TextFormatter{
+			TimestampFormat: timestampFormat,
+			FullTimestamp:   fullTimestamp,
+		}
 	case "json":
-		l.Formatter = &logrus.JSONFormatter{}
+		l.Formatter = &logrus.JSONFormatter{
+			TimestampFormat: timestampFormat,
+		}
 	default:
 		return fmt.Errorf("unknown log format `%s`. possible formats: %s", logFormat, []string{"text", "json"})
 	}

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -116,6 +116,12 @@ logging:
   level: info
   # json or text formats currently available. Default is text
   format: text
+  # timestamp format is specified in Go time format, see:
+  #     https://golang.org/pkg/time/#pkg-constants
+  # default when `format: json`: "2006-01-02T15:04:05Z07:00" (RFC3339)
+  # default when `format: text`: seconds since beginning of execution
+  # As an example, to log as RFC3339 with millisecond precision, set to:
+  #timestamp_format: "2006-01-02T15:04:05.000Z07:00"
 
 #stats:
   #type: graphite

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -119,7 +119,9 @@ logging:
   # timestamp format is specified in Go time format, see:
   #     https://golang.org/pkg/time/#pkg-constants
   # default when `format: json`: "2006-01-02T15:04:05Z07:00" (RFC3339)
-  # default when `format: text`: seconds since beginning of execution
+  # default when `format: text`:
+  #     when TTY attached: seconds since beginning of execution
+  #     otherwise: "2006-01-02T15:04:05Z07:00" (RFC3339)
   # As an example, to log as RFC3339 with millisecond precision, set to:
   #timestamp_format: "2006-01-02T15:04:05.000Z07:00"
 


### PR DESCRIPTION
This change introduces logging.timestamp_format, which allows
configuration of the Logrus TimestampFormat setting. The primary purpose
of this change was to allow logging with millisecond precision. The
default for `text` and `json` formats remains the same for backwards
compatibility.

timestamp format is specified in Go time format, see:

 - https://golang.org/pkg/time/#pkg-constants

Default when `format: json`: "2006-01-02T15:04:05Z07:00" (RFC3339)
Default when `format: text`: seconds since beginning of execution

As an example, to log as RFC3339 with millisecond precision, set to:

    logging:
        timestamp_format: "2006-01-02T15:04:05.000Z07:00"