### PR TITLE
Github Actions: cache modules and only run when necessary

### DIFF
--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -3,7 +3,13 @@ on:
   push:
     branches:
       - master
+    paths:
+      - '.github/workflows/gofmt.yml'
+      - '**.go'
   pull_request:
+    paths:
+      - '.github/workflows/gofmt.yml'
+      - '**.go'
 jobs:
 
   gofmt:

--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -3,9 +3,6 @@ on:
   push:
     branches:
       - master
-    paths:
-      - '.github/workflows/gofmt.yml'
-      - '**.go'
   pull_request:
     paths:
       - '.github/workflows/gofmt.yml'

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -3,13 +3,6 @@ on:
   push:
     branches:
       - master
-    paths:
-      - '.github/workflows/smoke**'
-      - '**Makefile'
-      - '**.go'
-      - '**.proto'
-      - 'go.mod'
-      - 'go.sum'
   pull_request:
     paths:
       - '.github/workflows/smoke**'

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -20,6 +20,13 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
 
+    - uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
     - name: build
       run: make
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -3,7 +3,21 @@ on:
   push:
     branches:
       - master
+    paths:
+      - '.github/workflows/smoke**'
+      - '**Makefile'
+      - '**.go'
+      - '**.proto'
+      - 'go.mod'
+      - 'go.sum'
   pull_request:
+    paths:
+      - '.github/workflows/smoke**'
+      - '**Makefile'
+      - '**.go'
+      - '**.proto'
+      - 'go.mod'
+      - 'go.sum'
 jobs:
 
   smoke:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,13 +3,6 @@ on:
   push:
     branches:
       - master
-    paths:
-      - '.github/workflows/test.yml'
-      - '**Makefile'
-      - '**.go'
-      - '**.proto'
-      - 'go.mod'
-      - 'go.sum'
   pull_request:
     paths:
       - '.github/workflows/test.yml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,21 @@ on:
   push:
     branches:
       - master
+    paths:
+      - '.github/workflows/test.yml'
+      - '**Makefile'
+      - '**.go'
+      - '**.proto'
+      - 'go.mod'
+      - 'go.sum'
   pull_request:
+    paths:
+      - '.github/workflows/test.yml'
+      - '**Makefile'
+      - '**.go'
+      - '**.proto'
+      - 'go.mod'
+      - 'go.sum'
 jobs:
 
   test-linux:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,13 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
 
+    - uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
     - name: Build
       run: make all
 
@@ -42,6 +49,13 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
+
+    - uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
     - name: Build nebula
       run: go build ./cmd/nebula


### PR DESCRIPTION
This PR does two things:

- Only run the tests when relevant files change.
- Cache the Go Modules directory between runs, so they don't have to redownload everything everytime (go.sum is the cache key). Pretty much straight from the examples: https://github.com/actions/cache/blob/master/examples.md#go---modules