### PR TITLE
Build debian packages for nebula

### DIFF
--- a/contrib/deb/Dockerfile
+++ b/contrib/deb/Dockerfile
@@ -1,0 +1,21 @@
+FROM debian:buster
+MAINTAINER Michael Gebetsroither <michael@mgeb.org>
+
+# Create the builder, if you have fpm on your system just execute the script below on the host
+# Used packages:
+#   - make libffi-dev libtool (are needed because of https://github.com/ffi/ffi/issues/611)
+#   - curl/wget for downloading
+#   - jq for parsing json returned by github api
+# /.cpanm is for cpanminus to work as un-named user
+RUN set -ex \
+    && apt-get update -q \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y -q ruby ruby-dev rubygems cpanminus make libffi-dev libtool curl wget jq \
+    && gem install --no-ri --no-rdoc fpm \
+    && install -d -m 777 /.cpanm
+
+COPY . /build
+WORKDIR /build
+
+# execute deb build script, wrapped into docker for portability
+RUN set -ex \
+    && ./build-deb.sh

--- a/contrib/deb/README.md
+++ b/contrib/deb/README.md
@@ -1,0 +1,29 @@
+# Building Debian Packages
+
+If you have `fpm` installed on your host just execute `build-deb.sh`.
+
+If not, execute `build-in-docker.sh`
+
+## Schematics
+
+`build-in-docker.sh` ... wrapper script to execute `build-deb.sh` in docker
+
+`Dockerfile` ... create debian based build system with fpm installed and executes `build-deb.sh`
+
+`build-deb.sh` ... script to downlaod a nebula release and create a debian package using `fpm`
+
+## Call Chain
+
+```
+build-in-docker.sh
+   -> docker build (Dockerfile)
+      -> build-deb.sh
+build-in-docker.sh (copy result to host)
+```
+
+## FAQ
+
+### I want to integrated it into my CI/CD
+
+- look at `build-in-docker.sh` and put the cmds used there into your CI/CD workflow
+- if you put the "build context" where results are collected from your CI/CD to `/out` the nubula deb will be delivered directly into your workflow

--- a/contrib/deb/build-deb.sh
+++ b/contrib/deb/build-deb.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Build slackhq/nebula debian packages
+#
+# Author: Michael Gebetsroither <michael@mgeb.org>
+# This script is published under MIT License
+
+set -e
+
+# override via environment if you want to change it
+VERSION_=${VERSION:-'1.1.0'}   # maybe some tag works too?
+HASH_=${HASH:-'d558403d52d39a725c66362cb3e1fc45adf07adcd740d902db12acfca00dae4d'}
+
+# no need to configure this for now (only if you want to build for other archs)
+NAME_='nebula-linux-amd64.tar.gz'
+
+# jq
+#   .assets[]   ... extract all assets
+#   select(..   ... pipe through "grep" and select all where "name" element matches
+#   .browser..  ... extract element .browser_download_url
+url_=$(curl -sL https://api.github.com/repos/slackhq/nebula/releases/latest | \
+    jq -r ".assets[] |select(.name|test(\"$NAME_\")) |.browser_download_url")
+echo "$HASH_  $NAME_" >shasum
+if shasum --strict --check -a 512256 shasum; then
+    echo "# Checksum matches, using already downloaded file: $NAME_"
+else
+    echo '# Checksum does not match, re-downloading'
+    wget --no-verbose "$url_"
+    echo "$HASH_  $NAME_" >shasum
+    echo '# Checksum validation'
+    shasum --strict --check -a 512256 shasum
+fi
+
+echo '# Building...'
+mkdir -p ../out
+fpm $@ -s tar -t deb --name nebula --package ../out \
+    --url "https://github.com/slackhq/nebula" \
+    --description "A scalable overlay networking tool with a focus on performance, simplicity and security" \
+    --maintainer "Michael Gebetsroither <michael@mgeb.org>" \
+    --vendor "" \
+    --version $VERSION_ \
+    --deb-systemd nebula.service \
+    --prefix /usr/sbin \
+    $NAME_

--- a/contrib/deb/build-in-docker.sh
+++ b/contrib/deb/build-in-docker.sh
@@ -11,3 +11,4 @@ docker build $* -t "$IMAGE_" .
 container_id_=$(docker run -dt "$IMAGE_")
 
 docker cp "$container_id_":/out/ ../
+docker stop "$container_id_"

--- a/contrib/deb/build-in-docker.sh
+++ b/contrib/deb/build-in-docker.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Thin wrapper to build debs with provided Dockerfile and copy results to host
+# execute with --no-cache to make a complete re-build
+#
+# Author: Michael Gebetsroither <michael@mgeb.org>
+# This script is published under MIT License
+
+IMAGE_="nebula_builder"
+
+docker build $* -t "$IMAGE_" .
+container_id_=$(docker run -dt "$IMAGE_")
+
+docker cp "$container_id_":/out/ ../

--- a/contrib/deb/nebula.service
+++ b/contrib/deb/nebula.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=nebula
+Wants=basic.target
+After=basic.target network.target
+ConditionPathExists=/etc/nebula/config.yml
+
+[Service]
+SyslogIdentifier=nebula
+#StandardOutput=syslog
+#StandardError=syslog
+ExecReload=/bin/kill -HUP $MAINPID
+ExecStart=/usr/sbin/nebula -config /etc/nebula/config.yml
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Hi,

As it seems now viable to use nebula with the last hole punching improvements i've polished our debian package building code :)

This can be used to build various distribution package formats (it uses `fpm` at it's core) so building rpm and packages for other distributions is easy.

This should not be thought as throwing something over the fence, i would also be willing to help you maintain that part in the future.
(i've had no time to play with github actions till now, but maybe that can be included directly)