### PR TITLE
fix config name for {remote,local}_allow_list

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -40,14 +40,14 @@ lighthouse:
   hosts:
     - "192.168.100.1"
 
-  # remoteAllowList allows you to control ip ranges that this node will
+  # remote_allow_list allows you to control ip ranges that this node will
   # consider when handshaking to another node. By default, any remote IPs are
   # allowed. You can provide CIDRs here with `true` to allow and `false` to
   # deny. The most specific CIDR rule applies to each remote. If all rules are
   # "allow", the default will be "deny", and vice-versa. If both "allow" and
   # "deny" rules are present, then you MUST set a rule for "0.0.0.0/0" as the
   # default.
-  #remoteAllowList:
+  #remote_allow_list:
     # Example to block IPs from this subnet from being used for remote IPs.
     #"172.16.0.0/12": false
 
@@ -56,14 +56,14 @@ lighthouse:
     #"10.0.0.0/8": false
     #"10.42.42.0/24": true
 
-  # localAllowList allows you to filter which local IP addresses we advertise
-  # to the lighthouses. This uses the same logic as `remoteAllowList`, but
+  # local_allow_list allows you to filter which local IP addresses we advertise
+  # to the lighthouses. This uses the same logic as `remote_allow_list`, but
   # additionally, you can specify an `interfaces` map of regular expressions
   # to match against interface names. The regexp must match the entire name.
   # All interface rules must be either true or false (and the default will be
   # the inverse). CIDR rules are matched after interface name rules.
   # Default is all local IP addresses.
-  #localAllowList:
+  #local_allow_list:
     # Example to blacklist tun0 and all docker interfaces.
     #interfaces:
       #tun0: false

--- a/handshake.go
+++ b/handshake.go
@@ -14,7 +14,7 @@ func HandleIncomingHandshake(f *Interface, addr *udpAddr, packet []byte, h *Head
 	//}
 
 	if !f.lightHouse.remoteAllowList.Allow(udp2ipInt(addr)) {
-		l.WithField("udpAddr", addr).Debug("lighthouse.remoteAllowList denied incoming handshake")
+		l.WithField("udpAddr", addr).Debug("lighthouse.remote_allow_list denied incoming handshake")
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -228,15 +228,15 @@ func Main(configPath string, configTest bool, buildVersion string) {
 		punchy.Delay,
 	)
 
-	remoteAllowList, err := config.GetAllowList("lighthouse.remoteAllowList", false)
+	remoteAllowList, err := config.GetAllowList("lighthouse.remote_allow_list", false)
 	if err != nil {
-		l.WithError(err).Fatal("Invalid lighthouse.remoteAllowList")
+		l.WithError(err).Fatal("Invalid lighthouse.remote_allow_list")
 	}
 	lightHouse.SetRemoteAllowList(remoteAllowList)
 
-	localAllowList, err := config.GetAllowList("lighthouse.localAllowList", true)
+	localAllowList, err := config.GetAllowList("lighthouse.local_allow_list", true)
 	if err != nil {
-		l.WithError(err).Fatal("Invalid lighthouse.localAllowList")
+		l.WithError(err).Fatal("Invalid lighthouse.local_allow_list")
 	}
 	lightHouse.SetLocalAllowList(localAllowList)
 

--- a/outside.go
+++ b/outside.go
@@ -143,7 +143,7 @@ func (f *Interface) closeTunnel(hostInfo *HostInfo) {
 func (f *Interface) handleHostRoaming(hostinfo *HostInfo, addr *udpAddr) {
 	if hostDidRoam(hostinfo.remote, addr) {
 		if !f.lightHouse.remoteAllowList.Allow(udp2ipInt(addr)) {
-			hostinfo.logger().WithField("newAddr", addr).Debug("lighthouse.remoteAllowList denied roaming")
+			hostinfo.logger().WithField("newAddr", addr).Debug("lighthouse.remote_allow_list denied roaming")
 			return
 		}
 		if !hostinfo.lastRoam.IsZero() && addr.Equals(hostinfo.lastRoamRemote) && time.Since(hostinfo.lastRoam) < RoamingSupressSeconds*time.Second {


### PR DESCRIPTION
This config option should be snake_case, not camelCase.