### PR TITLE
add meta packet statistics

### DIFF
--- a/connection_manager_test.go
+++ b/connection_manager_test.go
@@ -28,7 +28,7 @@ func Test_NewConnectionManagerTest(t *testing.T) {
 		rawCertificateNoKey: []byte{},
 	}
 
-	lh := NewLightHouse(false, 0, []uint32{}, 1000, 0, &udpConn{}, false, 1)
+	lh := NewLightHouse(false, 0, []uint32{}, 1000, 0, &udpConn{}, false, 1, false)
 	ifce := &Interface{
 		hostMap:          hostMap,
 		inside:           &Tun{},
@@ -91,7 +91,7 @@ func Test_NewConnectionManagerTest2(t *testing.T) {
 		rawCertificateNoKey: []byte{},
 	}
 
-	lh := NewLightHouse(false, 0, []uint32{}, 1000, 0, &udpConn{}, false, 1)
+	lh := NewLightHouse(false, 0, []uint32{}, 1000, 0, &udpConn{}, false, 1, false)
 	ifce := &Interface{
 		hostMap:          hostMap,
 		inside:           &Tun{},

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -177,6 +177,14 @@ logging:
   #subsystem: nebula
   #interval: 10s
 
+  # enables counter metrics for meta packets
+  #   e.g.: `messages.tx.handshake`
+  #message_metrics: false
+
+  # enables detailed counter metrics for lighthouse packets
+  #   e.g.: `lighthouse.rx.HostQuery`
+  #lighthouse_metrics: false
+
 # Handshake Manger Settings
 #handshakes:
   # Total time to try a handshake = sequence of `try_interval * retries`

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -179,6 +179,7 @@ logging:
 
   # enables counter metrics for meta packets
   #   e.g.: `messages.tx.handshake`
+  # NOTE: `message.{tx,rx}.recv_error` is always emitted
   #message_metrics: false
 
   # enables detailed counter metrics for lighthouse packets

--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -98,7 +98,7 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet [
 		hostinfo, _ := f.handshakeManager.pendingHostMap.QueryReverseIndex(hs.Details.InitiatorIndex)
 		if hostinfo != nil && bytes.Equal(hostinfo.HandshakePacket[0], packet[HeaderLen:]) {
 			if msg, ok := hostinfo.HandshakePacket[2]; ok {
-				f.metricMessageTx[handshake].Inc(1)
+				f.metricTx(handshake, 1)
 				err := f.outside.WriteTo(msg, addr)
 				if err != nil {
 					l.WithField("vpnIp", IntIp(hostinfo.hostId)).WithField("udpAddr", addr).
@@ -192,7 +192,7 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet [
 			hostinfo.HandshakePacket[2] = make([]byte, len(msg))
 			copy(hostinfo.HandshakePacket[2], msg)
 
-			f.metricMessageTx[handshake].Inc(1)
+			f.metricTx(handshake, 1)
 			err := f.outside.WriteTo(msg, addr)
 			if err != nil {
 				l.WithField("vpnIp", IntIp(vpnIP)).WithField("udpAddr", addr).

--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -98,7 +98,7 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet [
 		hostinfo, _ := f.handshakeManager.pendingHostMap.QueryReverseIndex(hs.Details.InitiatorIndex)
 		if hostinfo != nil && bytes.Equal(hostinfo.HandshakePacket[0], packet[HeaderLen:]) {
 			if msg, ok := hostinfo.HandshakePacket[2]; ok {
-				f.metricTx(handshake, 1)
+				f.messageMetrics.Tx(handshake, handshakeXXPSK0, 1)
 				err := f.outside.WriteTo(msg, addr)
 				if err != nil {
 					l.WithField("vpnIp", IntIp(hostinfo.hostId)).WithField("udpAddr", addr).
@@ -192,7 +192,7 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet [
 			hostinfo.HandshakePacket[2] = make([]byte, len(msg))
 			copy(hostinfo.HandshakePacket[2], msg)
 
-			f.metricTx(handshake, 1)
+			f.messageMetrics.Tx(handshake, handshakeXXPSK0, 1)
 			err := f.outside.WriteTo(msg, addr)
 			if err != nil {
 				l.WithField("vpnIp", IntIp(vpnIP)).WithField("udpAddr", addr).

--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -98,6 +98,7 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet [
 		hostinfo, _ := f.handshakeManager.pendingHostMap.QueryReverseIndex(hs.Details.InitiatorIndex)
 		if hostinfo != nil && bytes.Equal(hostinfo.HandshakePacket[0], packet[HeaderLen:]) {
 			if msg, ok := hostinfo.HandshakePacket[2]; ok {
+				f.metricMessageTx[handshake].Inc(1)
 				err := f.outside.WriteTo(msg, addr)
 				if err != nil {
 					l.WithField("vpnIp", IntIp(hostinfo.hostId)).WithField("udpAddr", addr).
@@ -191,6 +192,7 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet [
 			hostinfo.HandshakePacket[2] = make([]byte, len(msg))
 			copy(hostinfo.HandshakePacket[2], msg)
 
+			f.metricMessageTx[handshake].Inc(1)
 			err := f.outside.WriteTo(msg, addr)
 			if err != nil {
 				l.WithField("vpnIp", IntIp(vpnIP)).WithField("udpAddr", addr).

--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -98,7 +98,7 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet [
 		hostinfo, _ := f.handshakeManager.pendingHostMap.QueryReverseIndex(hs.Details.InitiatorIndex)
 		if hostinfo != nil && bytes.Equal(hostinfo.HandshakePacket[0], packet[HeaderLen:]) {
 			if msg, ok := hostinfo.HandshakePacket[2]; ok {
-				f.messageMetrics.Tx(handshake, handshakeXXPSK0, 1)
+				f.messageMetrics.Tx(handshake, NebulaMessageSubType(msg[1]), 1)
 				err := f.outside.WriteTo(msg, addr)
 				if err != nil {
 					l.WithField("vpnIp", IntIp(hostinfo.hostId)).WithField("udpAddr", addr).
@@ -192,7 +192,7 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet [
 			hostinfo.HandshakePacket[2] = make([]byte, len(msg))
 			copy(hostinfo.HandshakePacket[2], msg)
 
-			f.messageMetrics.Tx(handshake, handshakeXXPSK0, 1)
+			f.messageMetrics.Tx(handshake, NebulaMessageSubType(msg[1]), 1)
 			err := f.outside.WriteTo(msg, addr)
 			if err != nil {
 				l.WithField("vpnIp", IntIp(vpnIP)).WithField("udpAddr", addr).

--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -117,7 +117,7 @@ func (c *HandshakeManager) NextOutboundHandshakeTimerTick(now time.Time, f EncWr
 
 			// Ensure the handshake is ready to avoid a race in timer tick and stage 0 handshake generation
 			if hostinfo.HandshakeReady && hostinfo.remote != nil {
-				c.messageMetrics.Tx(handshake, handshakeIXPSK0, 1)
+				c.messageMetrics.Tx(handshake, NebulaMessageSubType(hostinfo.HandshakePacket[0][1]), 1)
 				err := c.outside.WriteTo(hostinfo.HandshakePacket[0], hostinfo.remote)
 				if err != nil {
 					hostinfo.logger().WithField("udpAddr", hostinfo.remote).

--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/rcrowley/go-metrics"
 	"github.com/sirupsen/logrus"
 )
 
@@ -42,6 +43,8 @@ type HandshakeManager struct {
 
 	OutboundHandshakeTimer *SystemTimerWheel
 	InboundHandshakeTimer  *SystemTimerWheel
+
+	metricHandshakeTx metrics.Counter
 }
 
 func NewHandshakeManager(tunCidr *net.IPNet, preferredRanges []*net.IPNet, mainHostMap *HostMap, lightHouse *LightHouse, outside *udpConn, config HandshakeConfig) *HandshakeManager {
@@ -55,6 +58,8 @@ func NewHandshakeManager(tunCidr *net.IPNet, preferredRanges []*net.IPNet, mainH
 
 		OutboundHandshakeTimer: NewSystemTimerWheel(config.tryInterval, config.tryInterval*time.Duration(config.retries)),
 		InboundHandshakeTimer:  NewSystemTimerWheel(config.tryInterval, config.tryInterval*time.Duration(config.retries)),
+
+		metricHandshakeTx: metrics.GetOrRegisterCounter("messages.tx.handshake", nil),
 	}
 }
 
@@ -111,6 +116,7 @@ func (c *HandshakeManager) NextOutboundHandshakeTimerTick(now time.Time, f EncWr
 
 			// Ensure the handshake is ready to avoid a race in timer tick and stage 0 handshake generation
 			if hostinfo.HandshakeReady && hostinfo.remote != nil {
+				c.metricHandshakeTx.Inc(1)
 				err := c.outside.WriteTo(hostinfo.HandshakePacket[0], hostinfo.remote)
 				if err != nil {
 					hostinfo.logger().WithField("udpAddr", hostinfo.remote).

--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -49,7 +49,7 @@ type HandshakeManager struct {
 }
 
 func NewHandshakeManager(tunCidr *net.IPNet, preferredRanges []*net.IPNet, mainHostMap *HostMap, lightHouse *LightHouse, outside *udpConn, config HandshakeConfig) *HandshakeManager {
-	h := &HandshakeManager{
+	return &HandshakeManager{
 		pendingHostMap: NewHostMap("pending", tunCidr, preferredRanges),
 		mainHostMap:    mainHostMap,
 		lightHouse:     lightHouse,
@@ -62,8 +62,6 @@ func NewHandshakeManager(tunCidr *net.IPNet, preferredRanges []*net.IPNet, mainH
 
 		messageMetrics: config.messageMetrics,
 	}
-
-	return h
 }
 
 func (c *HandshakeManager) Run(f EncWriter) {

--- a/handshake_manager_test.go
+++ b/handshake_manager_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rcrowley/go-metrics"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,7 +22,7 @@ func Test_NewHandshakeManagerIndex(t *testing.T) {
 	preferredRanges := []*net.IPNet{localrange}
 	mainHM := NewHostMap("test", vpncidr, preferredRanges)
 
-	blah := NewHandshakeManager(tuncidr, preferredRanges, mainHM, &LightHouse{}, &udpConn{}, defaultHandshakeConfig)
+	blah := NewHandshakeManager(tuncidr, preferredRanges, mainHM, newTestLighthouse(), &udpConn{}, defaultHandshakeConfig)
 
 	now := time.Now()
 	blah.NextInboundHandshakeTimerTick(now)
@@ -63,7 +64,7 @@ func Test_NewHandshakeManagerVpnIP(t *testing.T) {
 	mw := &mockEncWriter{}
 	mainHM := NewHostMap("test", vpncidr, preferredRanges)
 
-	blah := NewHandshakeManager(tuncidr, preferredRanges, mainHM, &LightHouse{}, &udpConn{}, defaultHandshakeConfig)
+	blah := NewHandshakeManager(tuncidr, preferredRanges, mainHM, newTestLighthouse(), &udpConn{}, defaultHandshakeConfig)
 
 	now := time.Now()
 	blah.NextOutboundHandshakeTimerTick(now, mw)
@@ -112,7 +113,7 @@ func Test_NewHandshakeManagerVpnIPcleanup(t *testing.T) {
 	mw := &mockEncWriter{}
 	mainHM := NewHostMap("test", vpncidr, preferredRanges)
 
-	blah := NewHandshakeManager(tuncidr, preferredRanges, mainHM, &LightHouse{}, &udpConn{}, defaultHandshakeConfig)
+	blah := NewHandshakeManager(tuncidr, preferredRanges, mainHM, newTestLighthouse(), &udpConn{}, defaultHandshakeConfig)
 
 	now := time.Now()
 	blah.NextOutboundHandshakeTimerTick(now, mw)
@@ -161,7 +162,7 @@ func Test_NewHandshakeManagerIndexcleanup(t *testing.T) {
 	preferredRanges := []*net.IPNet{localrange}
 	mainHM := NewHostMap("test", vpncidr, preferredRanges)
 
-	blah := NewHandshakeManager(tuncidr, preferredRanges, mainHM, &LightHouse{}, &udpConn{}, defaultHandshakeConfig)
+	blah := NewHandshakeManager(tuncidr, preferredRanges, mainHM, newTestLighthouse(), &udpConn{}, defaultHandshakeConfig)
 
 	now := time.Now()
 	blah.NextInboundHandshakeTimerTick(now)
@@ -191,4 +192,13 @@ func (mw *mockEncWriter) SendMessageToVpnIp(t NebulaMessageType, st NebulaMessag
 
 func (mw *mockEncWriter) SendMessageToAll(t NebulaMessageType, st NebulaMessageSubType, vpnIp uint32, p, nb, out []byte) {
 	return
+}
+
+func newTestLighthouse() *LightHouse {
+	l := &LightHouse{}
+	for i := range NebulaMeta_MessageType_name {
+		l.metricLighthouseRx[i] = metrics.NilCounter{}
+		l.metricLighthouseTx[i] = metrics.NilCounter{}
+	}
+	return l
 }

--- a/handshake_manager_test.go
+++ b/handshake_manager_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rcrowley/go-metrics"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,7 +21,7 @@ func Test_NewHandshakeManagerIndex(t *testing.T) {
 	preferredRanges := []*net.IPNet{localrange}
 	mainHM := NewHostMap("test", vpncidr, preferredRanges)
 
-	blah := NewHandshakeManager(tuncidr, preferredRanges, mainHM, newTestLighthouse(), &udpConn{}, defaultHandshakeConfig)
+	blah := NewHandshakeManager(tuncidr, preferredRanges, mainHM, &LightHouse{}, &udpConn{}, defaultHandshakeConfig)
 
 	now := time.Now()
 	blah.NextInboundHandshakeTimerTick(now)
@@ -64,7 +63,7 @@ func Test_NewHandshakeManagerVpnIP(t *testing.T) {
 	mw := &mockEncWriter{}
 	mainHM := NewHostMap("test", vpncidr, preferredRanges)
 
-	blah := NewHandshakeManager(tuncidr, preferredRanges, mainHM, newTestLighthouse(), &udpConn{}, defaultHandshakeConfig)
+	blah := NewHandshakeManager(tuncidr, preferredRanges, mainHM, &LightHouse{}, &udpConn{}, defaultHandshakeConfig)
 
 	now := time.Now()
 	blah.NextOutboundHandshakeTimerTick(now, mw)
@@ -113,7 +112,7 @@ func Test_NewHandshakeManagerVpnIPcleanup(t *testing.T) {
 	mw := &mockEncWriter{}
 	mainHM := NewHostMap("test", vpncidr, preferredRanges)
 
-	blah := NewHandshakeManager(tuncidr, preferredRanges, mainHM, newTestLighthouse(), &udpConn{}, defaultHandshakeConfig)
+	blah := NewHandshakeManager(tuncidr, preferredRanges, mainHM, &LightHouse{}, &udpConn{}, defaultHandshakeConfig)
 
 	now := time.Now()
 	blah.NextOutboundHandshakeTimerTick(now, mw)
@@ -162,7 +161,7 @@ func Test_NewHandshakeManagerIndexcleanup(t *testing.T) {
 	preferredRanges := []*net.IPNet{localrange}
 	mainHM := NewHostMap("test", vpncidr, preferredRanges)
 
-	blah := NewHandshakeManager(tuncidr, preferredRanges, mainHM, newTestLighthouse(), &udpConn{}, defaultHandshakeConfig)
+	blah := NewHandshakeManager(tuncidr, preferredRanges, mainHM, &LightHouse{}, &udpConn{}, defaultHandshakeConfig)
 
 	now := time.Now()
 	blah.NextInboundHandshakeTimerTick(now)
@@ -192,13 +191,4 @@ func (mw *mockEncWriter) SendMessageToVpnIp(t NebulaMessageType, st NebulaMessag
 
 func (mw *mockEncWriter) SendMessageToAll(t NebulaMessageType, st NebulaMessageSubType, vpnIp uint32, p, nb, out []byte) {
 	return
-}
-
-func newTestLighthouse() *LightHouse {
-	l := &LightHouse{}
-	for i := range NebulaMeta_MessageType_name {
-		l.metricLighthouseRx[i] = metrics.NilCounter{}
-		l.metricLighthouseTx[i] = metrics.NilCounter{}
-	}
-	return l
 }

--- a/hostmap.go
+++ b/hostmap.go
@@ -384,8 +384,10 @@ func (hm *HostMap) PunchList() []*udpAddr {
 }
 
 func (hm *HostMap) Punchy(conn *udpConn) {
+	metricsTxPunchy := metrics.GetOrRegisterCounter("messages.tx.punchy", nil)
 	for {
 		for _, addr := range hm.PunchList() {
+			metricsTxPunchy.Inc(1)
 			conn.WriteTo([]byte{1}, addr)
 		}
 		time.Sleep(time.Second * 30)

--- a/hostmap.go
+++ b/hostmap.go
@@ -30,6 +30,7 @@ type HostMap struct {
 	vpnCIDR         *net.IPNet
 	defaultRoute    uint32
 	unsafeRoutes    *CIDRTree
+	metricsEnabled  bool
 }
 
 type HostInfo struct {
@@ -384,7 +385,13 @@ func (hm *HostMap) PunchList() []*udpAddr {
 }
 
 func (hm *HostMap) Punchy(conn *udpConn) {
-	metricsTxPunchy := metrics.GetOrRegisterCounter("messages.tx.punchy", nil)
+	var metricsTxPunchy metrics.Counter
+	if hm.metricsEnabled {
+		metricsTxPunchy = metrics.GetOrRegisterCounter("messages.tx.punchy", nil)
+	} else {
+		metricsTxPunchy = metrics.NilCounter{}
+	}
+
 	for {
 		for _, addr := range hm.PunchList() {
 			metricsTxPunchy.Inc(1)

--- a/inside.go
+++ b/inside.go
@@ -173,7 +173,7 @@ func (f *Interface) sendMessageToAll(t NebulaMessageType, st NebulaMessageSubTyp
 }
 
 func (f *Interface) send(t NebulaMessageType, st NebulaMessageSubType, ci *ConnectionState, hostinfo *HostInfo, remote *udpAddr, p, nb, out []byte) {
-	f.metricTx(t, 1)
+	f.messageMetrics.Tx(t, st, 1)
 	f.sendNoMetrics(t, st, ci, hostinfo, remote, p, nb, out)
 }
 

--- a/inside.go
+++ b/inside.go
@@ -173,7 +173,7 @@ func (f *Interface) sendMessageToAll(t NebulaMessageType, st NebulaMessageSubTyp
 }
 
 func (f *Interface) send(t NebulaMessageType, st NebulaMessageSubType, ci *ConnectionState, hostinfo *HostInfo, remote *udpAddr, p, nb, out []byte) {
-	f.metricMessageTx[t].Inc(1)
+	f.metricTx(t, 1)
 	f.sendNoMetrics(t, st, ci, hostinfo, remote, p, nb, out)
 }
 

--- a/interface.go
+++ b/interface.go
@@ -244,3 +244,14 @@ func (f *Interface) emitStats(i time.Duration) {
 		f.handshakeManager.EmitStats()
 	}
 }
+
+func (f *Interface) metricRx(t NebulaMessageType, i int64) {
+	if t >= 0 && t < 6 {
+		f.metricMessageRx[t].Inc(i)
+	}
+}
+func (f *Interface) metricTx(t NebulaMessageType, i int64) {
+	if t >= 0 && t < 6 {
+		f.metricMessageTx[t].Inc(i)
+	}
+}

--- a/interface.go
+++ b/interface.go
@@ -2,7 +2,6 @@ package nebula
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"time"
 
@@ -225,58 +224,5 @@ func (f *Interface) emitStats(i time.Duration) {
 	for range ticker.C {
 		f.firewall.EmitStats()
 		f.handshakeManager.EmitStats()
-	}
-}
-
-type MessageMetrics struct {
-	rx [][]metrics.Counter
-	tx [][]metrics.Counter
-
-	rxUnknown metrics.Counter
-	txUnknown metrics.Counter
-}
-
-func (f *MessageMetrics) Rx(t NebulaMessageType, s NebulaMessageSubType, i int64) {
-	if f != nil {
-		if t >= 0 && int(t) < len(f.rx) && s >= 0 && int(s) < len(f.rx[t]) {
-			f.rx[t][s].Inc(i)
-		} else {
-			f.rxUnknown.Inc(i)
-		}
-	}
-}
-func (f *MessageMetrics) Tx(t NebulaMessageType, s NebulaMessageSubType, i int64) {
-	if f != nil {
-		if t >= 0 && int(t) < len(f.tx) && s >= 0 && int(s) < len(f.tx[t]) {
-			f.tx[t][s].Inc(i)
-		} else {
-			f.txUnknown.Inc(i)
-		}
-	}
-}
-
-func newMessageMetrics() *MessageMetrics {
-	gen := func(t string) [][]metrics.Counter {
-		return [][]metrics.Counter{
-			{
-				metrics.GetOrRegisterCounter(fmt.Sprintf("messages.%s.handshake_stage1", t), nil),
-				metrics.GetOrRegisterCounter(fmt.Sprintf("messages.%s.handshake_stage2", t), nil),
-			},
-			{metrics.NilCounter{}},
-			{metrics.GetOrRegisterCounter(fmt.Sprintf("messages.%s.recv_error", t), nil)},
-			{metrics.GetOrRegisterCounter(fmt.Sprintf("messages.%s.lighthouse", t), nil)},
-			{
-				metrics.GetOrRegisterCounter(fmt.Sprintf("messages.%s.test_request", t), nil),
-				metrics.GetOrRegisterCounter(fmt.Sprintf("messages.%s.test_response", t), nil),
-			},
-			{metrics.GetOrRegisterCounter(fmt.Sprintf("messages.%s.close_tunnel", t), nil)},
-		}
-	}
-	return &MessageMetrics{
-		rx: gen("rx"),
-		tx: gen("tx"),
-
-		rxUnknown: metrics.GetOrRegisterCounter("messages.rx.other", nil),
-		txUnknown: metrics.GetOrRegisterCounter("messages.tx.other", nil),
 	}
 }

--- a/interface.go
+++ b/interface.go
@@ -47,8 +47,7 @@ type Interface struct {
 	version            string
 
 	metricHandshakes metrics.Histogram
-
-	messageMetrics *MessageMetrics
+	messageMetrics   *MessageMetrics
 }
 
 func NewInterface(c *InterfaceConfig) (*Interface, error) {
@@ -82,8 +81,7 @@ func NewInterface(c *InterfaceConfig) (*Interface, error) {
 		udpBatchSize:       c.UDPBatchSize,
 
 		metricHandshakes: metrics.GetOrRegisterHistogram("handshakes", nil, metrics.NewExpDecaySample(1028, 0.015)),
-
-		messageMetrics: c.MessageMetrics,
+		messageMetrics:   c.MessageMetrics,
 	}
 
 	ifce.connectionManager = newConnectionManager(ifce, c.checkInterval, c.pendingDeletionInterval)

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -41,6 +41,7 @@ type LightHouse struct {
 
 	metricLighthouseRx [10]metrics.Counter
 	metricLighthouseTx [10]metrics.Counter
+	metricHolepunchTx  metrics.Counter
 }
 
 type EncWriter interface {
@@ -66,6 +67,8 @@ func NewLightHouse(amLighthouse bool, myIp uint32, ips []uint32, interval int, n
 		h.metricLighthouseRx[i] = metrics.GetOrRegisterCounter(fmt.Sprintf("messages.rx.lighthouse.%s", name), nil)
 		h.metricLighthouseTx[i] = metrics.GetOrRegisterCounter(fmt.Sprintf("messages.tx.lighthouse.%s", name), nil)
 	}
+
+	h.metricHolepunchTx = metrics.GetOrRegisterCounter("messages.tx.holepunch", nil)
 
 	for _, ip := range ips {
 		h.lighthouses[ip] = struct{}{}
@@ -377,6 +380,7 @@ func (lh *LightHouse) HandleRequest(rAddr *udpAddr, vpnIp uint32, p []byte, c *c
 			vpnPeer := NewUDPAddr(a.Ip, uint16(a.Port))
 			go func() {
 				time.Sleep(lh.punchDelay)
+				lh.metricHolepunchTx.Inc(1)
 				lh.punchConn.WriteTo(empty, vpnPeer)
 
 			}()

--- a/lighthouse_test.go
+++ b/lighthouse_test.go
@@ -52,7 +52,7 @@ func Test_lhStaticMapping(t *testing.T) {
 
 	udpServer, _ := NewListener("0.0.0.0", 0, true)
 
-	meh := NewLightHouse(true, 1, []uint32{ip2int(lh1IP)}, 10, 10003, udpServer, false, 1)
+	meh := NewLightHouse(true, 1, []uint32{ip2int(lh1IP)}, 10, 10003, udpServer, false, 1, false)
 	meh.AddRemote(ip2int(lh1IP), NewUDPAddr(ip2int(lh1IP), uint16(4242)), true)
 	err := meh.ValidateLHStaticEntries()
 	assert.Nil(t, err)
@@ -60,7 +60,7 @@ func Test_lhStaticMapping(t *testing.T) {
 	lh2 := "10.128.0.3"
 	lh2IP := net.ParseIP(lh2)
 
-	meh = NewLightHouse(true, 1, []uint32{ip2int(lh1IP), ip2int(lh2IP)}, 10, 10003, udpServer, false, 1)
+	meh = NewLightHouse(true, 1, []uint32{ip2int(lh1IP), ip2int(lh2IP)}, 10, 10003, udpServer, false, 1, false)
 	meh.AddRemote(ip2int(lh1IP), NewUDPAddr(ip2int(lh1IP), uint16(4242)), true)
 	err = meh.ValidateLHStaticEntries()
 	assert.EqualError(t, err, "Lighthouse 10.128.0.3 does not have a static_host_map entry")

--- a/main.go
+++ b/main.go
@@ -172,6 +172,7 @@ func Main(configPath string, configTest bool, buildVersion string) {
 	hostMap := NewHostMap("main", tunCidr, preferredRanges)
 	hostMap.SetDefaultRoute(ip2int(net.ParseIP(config.GetString("default_route", "0.0.0.0"))))
 	hostMap.addUnsafeRoutes(&unsafeRoutes)
+	hostMap.metricsEnabled = config.GetBool("stats.message_metrics", false)
 
 	l.WithField("network", hostMap.vpnCIDR).WithField("preferredRanges", hostMap.preferredRanges).Info("Main HostMap created")
 
@@ -226,6 +227,7 @@ func Main(configPath string, configTest bool, buildVersion string) {
 		udpServer,
 		punchy.Respond,
 		punchy.Delay,
+		config.GetBool("stats.lighthouse_metrics", false),
 	)
 
 	remoteAllowList, err := config.GetAllowList("lighthouse.remote_allow_list", false)
@@ -284,6 +286,8 @@ func Main(configPath string, configTest bool, buildVersion string) {
 		tryInterval:  config.GetDuration("handshakes.try_interval", DefaultHandshakeTryInterval),
 		retries:      config.GetInt("handshakes.retries", DefaultHandshakeRetries),
 		waitRotation: config.GetInt("handshakes.wait_rotation", DefaultHandshakeWaitRotation),
+
+		metricsEnabled: config.GetBool("stats.message_metrics", false),
 	}
 
 	handshakeManager := NewHandshakeManager(tunCidr, preferredRanges, hostMap, lightHouse, udpServer, handshakeConfig)
@@ -310,6 +314,7 @@ func Main(configPath string, configTest bool, buildVersion string) {
 		DropLocalBroadcast:      config.GetBool("tun.drop_local_broadcast", false),
 		DropMulticast:           config.GetBool("tun.drop_multicast", false),
 		UDPBatchSize:            config.GetInt("listen.batch", 64),
+		MessageMetrics:          config.GetBool("stats.message_metrics", false),
 	}
 
 	switch ifConfig.Cipher {

--- a/main.go
+++ b/main.go
@@ -282,12 +282,17 @@ func Main(configPath string, configTest bool, buildVersion string) {
 		l.WithError(err).Error("Lighthouse unreachable")
 	}
 
+	var messageMetrics *MessageMetrics
+	if config.GetBool("stats.message_metrics", false) {
+		messageMetrics = newMessageMetrics()
+	}
+
 	handshakeConfig := HandshakeConfig{
 		tryInterval:  config.GetDuration("handshakes.try_interval", DefaultHandshakeTryInterval),
 		retries:      config.GetInt("handshakes.retries", DefaultHandshakeRetries),
 		waitRotation: config.GetInt("handshakes.wait_rotation", DefaultHandshakeWaitRotation),
 
-		metricsEnabled: config.GetBool("stats.message_metrics", false),
+		messageMetrics: messageMetrics,
 	}
 
 	handshakeManager := NewHandshakeManager(tunCidr, preferredRanges, hostMap, lightHouse, udpServer, handshakeConfig)
@@ -314,7 +319,7 @@ func Main(configPath string, configTest bool, buildVersion string) {
 		DropLocalBroadcast:      config.GetBool("tun.drop_local_broadcast", false),
 		DropMulticast:           config.GetBool("tun.drop_multicast", false),
 		UDPBatchSize:            config.GetInt("listen.batch", 64),
-		MessageMetrics:          config.GetBool("stats.message_metrics", false),
+		MessageMetrics:          messageMetrics,
 	}
 
 	switch ifConfig.Cipher {

--- a/main.go
+++ b/main.go
@@ -285,6 +285,8 @@ func Main(configPath string, configTest bool, buildVersion string) {
 	var messageMetrics *MessageMetrics
 	if config.GetBool("stats.message_metrics", false) {
 		messageMetrics = newMessageMetrics()
+	} else {
+		messageMetrics = newMessageMetricsOnlyRecvError()
 	}
 
 	handshakeConfig := HandshakeConfig{

--- a/message_metrics.go
+++ b/message_metrics.go
@@ -37,8 +37,7 @@ func newMessageMetrics() *MessageMetrics {
 	gen := func(t string) [][]metrics.Counter {
 		return [][]metrics.Counter{
 			{
-				metrics.GetOrRegisterCounter(fmt.Sprintf("messages.%s.handshake_stage1", t), nil),
-				metrics.GetOrRegisterCounter(fmt.Sprintf("messages.%s.handshake_stage2", t), nil),
+				metrics.GetOrRegisterCounter(fmt.Sprintf("messages.%s.handshake_ixpsk0", t), nil),
 			},
 			nil,
 			{metrics.GetOrRegisterCounter(fmt.Sprintf("messages.%s.recv_error", t), nil)},

--- a/message_metrics.go
+++ b/message_metrics.go
@@ -14,21 +14,21 @@ type MessageMetrics struct {
 	txUnknown metrics.Counter
 }
 
-func (f *MessageMetrics) Rx(t NebulaMessageType, s NebulaMessageSubType, i int64) {
-	if f != nil {
-		if t >= 0 && int(t) < len(f.rx) && s >= 0 && int(s) < len(f.rx[t]) {
-			f.rx[t][s].Inc(i)
-		} else if f.rxUnknown != nil {
-			f.rxUnknown.Inc(i)
+func (m *MessageMetrics) Rx(t NebulaMessageType, s NebulaMessageSubType, i int64) {
+	if m != nil {
+		if t >= 0 && int(t) < len(m.rx) && s >= 0 && int(s) < len(m.rx[t]) {
+			m.rx[t][s].Inc(i)
+		} else if m.rxUnknown != nil {
+			m.rxUnknown.Inc(i)
 		}
 	}
 }
-func (f *MessageMetrics) Tx(t NebulaMessageType, s NebulaMessageSubType, i int64) {
-	if f != nil {
-		if t >= 0 && int(t) < len(f.tx) && s >= 0 && int(s) < len(f.tx[t]) {
-			f.tx[t][s].Inc(i)
-		} else if f.txUnknown != nil {
-			f.txUnknown.Inc(i)
+func (m *MessageMetrics) Tx(t NebulaMessageType, s NebulaMessageSubType, i int64) {
+	if m != nil {
+		if t >= 0 && int(t) < len(m.tx) && s >= 0 && int(s) < len(m.tx[t]) {
+			m.tx[t][s].Inc(i)
+		} else if m.txUnknown != nil {
+			m.txUnknown.Inc(i)
 		}
 	}
 }
@@ -61,17 +61,16 @@ func newMessageMetrics() *MessageMetrics {
 
 // Historically we only recorded recv_error, so this is backwards compat
 func newMessageMetricsOnlyRecvError() *MessageMetrics {
+	gen := func(t string) [][]metrics.Counter {
+		return [][]metrics.Counter{
+			nil,
+			nil,
+			{metrics.GetOrRegisterCounter(fmt.Sprintf("messages.%s.recv_error", t), nil)},
+		}
+	}
 	return &MessageMetrics{
-		rx: [][]metrics.Counter{
-			nil,
-			nil,
-			{metrics.GetOrRegisterCounter("messages.rx.recv_error", nil)},
-		},
-		tx: [][]metrics.Counter{
-			nil,
-			nil,
-			{metrics.GetOrRegisterCounter("messages.tx.recv_error", nil)},
-		},
+		rx: gen("rx"),
+		tx: gen("tx"),
 	}
 }
 

--- a/message_metrics.go
+++ b/message_metrics.go
@@ -1,0 +1,99 @@
+package nebula
+
+import (
+	"fmt"
+
+	"github.com/rcrowley/go-metrics"
+)
+
+type MessageMetrics struct {
+	rx [][]metrics.Counter
+	tx [][]metrics.Counter
+
+	rxUnknown metrics.Counter
+	txUnknown metrics.Counter
+}
+
+func (f *MessageMetrics) Rx(t NebulaMessageType, s NebulaMessageSubType, i int64) {
+	if f != nil {
+		if t >= 0 && int(t) < len(f.rx) && s >= 0 && int(s) < len(f.rx[t]) {
+			f.rx[t][s].Inc(i)
+		} else if f.rxUnknown != nil {
+			f.rxUnknown.Inc(i)
+		}
+	}
+}
+func (f *MessageMetrics) Tx(t NebulaMessageType, s NebulaMessageSubType, i int64) {
+	if f != nil {
+		if t >= 0 && int(t) < len(f.tx) && s >= 0 && int(s) < len(f.tx[t]) {
+			f.tx[t][s].Inc(i)
+		} else if f.txUnknown != nil {
+			f.txUnknown.Inc(i)
+		}
+	}
+}
+
+func newMessageMetrics() *MessageMetrics {
+	gen := func(t string) [][]metrics.Counter {
+		return [][]metrics.Counter{
+			{
+				metrics.GetOrRegisterCounter(fmt.Sprintf("messages.%s.handshake_stage1", t), nil),
+				metrics.GetOrRegisterCounter(fmt.Sprintf("messages.%s.handshake_stage2", t), nil),
+			},
+			nil,
+			{metrics.GetOrRegisterCounter(fmt.Sprintf("messages.%s.recv_error", t), nil)},
+			{metrics.GetOrRegisterCounter(fmt.Sprintf("messages.%s.lighthouse", t), nil)},
+			{
+				metrics.GetOrRegisterCounter(fmt.Sprintf("messages.%s.test_request", t), nil),
+				metrics.GetOrRegisterCounter(fmt.Sprintf("messages.%s.test_response", t), nil),
+			},
+			{metrics.GetOrRegisterCounter(fmt.Sprintf("messages.%s.close_tunnel", t), nil)},
+		}
+	}
+	return &MessageMetrics{
+		rx: gen("rx"),
+		tx: gen("tx"),
+
+		rxUnknown: metrics.GetOrRegisterCounter("messages.rx.other", nil),
+		txUnknown: metrics.GetOrRegisterCounter("messages.tx.other", nil),
+	}
+}
+
+// Historically we only recorded recv_error, so this is backwards compat
+func newMessageMetricsOnlyRecvError() *MessageMetrics {
+	return &MessageMetrics{
+		rx: [][]metrics.Counter{
+			nil,
+			nil,
+			{metrics.GetOrRegisterCounter("messages.rx.recv_error", nil)},
+		},
+		tx: [][]metrics.Counter{
+			nil,
+			nil,
+			{metrics.GetOrRegisterCounter("messages.tx.recv_error", nil)},
+		},
+	}
+}
+
+func newLighthouseMetrics() *MessageMetrics {
+	gen := func(t string) [][]metrics.Counter {
+		h := make([][]metrics.Counter, len(NebulaMeta_MessageType_name))
+		used := []NebulaMeta_MessageType{
+			NebulaMeta_HostQuery,
+			NebulaMeta_HostQueryReply,
+			NebulaMeta_HostUpdateNotification,
+			NebulaMeta_HostPunchNotification,
+		}
+		for _, i := range used {
+			h[i] = []metrics.Counter{metrics.GetOrRegisterCounter(fmt.Sprintf("lighthouse.%s.%s", t, i.String()), nil)}
+		}
+		return h
+	}
+	return &MessageMetrics{
+		rx: gen("rx"),
+		tx: gen("tx"),
+
+		rxUnknown: metrics.GetOrRegisterCounter("lighthouse.rx.other", nil),
+		txUnknown: metrics.GetOrRegisterCounter("lighthouse.tx.other", nil),
+	}
+}

--- a/outside.go
+++ b/outside.go
@@ -54,7 +54,7 @@ func (f *Interface) readOutsidePackets(addr *udpAddr, out []byte, packet []byte,
 		// Fallthrough to the bottom to record incoming traffic
 
 	case lightHouse:
-		f.metricRx(lightHouse, 1)
+		f.messageMetrics.Rx(header.Type, header.Subtype, 1)
 		if !f.handleEncrypted(ci, addr, header) {
 			return
 		}
@@ -75,7 +75,7 @@ func (f *Interface) readOutsidePackets(addr *udpAddr, out []byte, packet []byte,
 		// Fallthrough to the bottom to record incoming traffic
 
 	case test:
-		f.metricRx(test, 1)
+		f.messageMetrics.Rx(header.Type, header.Subtype, 1)
 		if !f.handleEncrypted(ci, addr, header) {
 			return
 		}
@@ -104,18 +104,18 @@ func (f *Interface) readOutsidePackets(addr *udpAddr, out []byte, packet []byte,
 		// are unauthenticated
 
 	case handshake:
-		f.metricRx(handshake, 1)
+		f.messageMetrics.Rx(header.Type, header.Subtype, 1)
 		HandleIncomingHandshake(f, addr, packet, header, hostinfo)
 		return
 
 	case recvError:
-		f.metricRx(recvError, 1)
+		f.messageMetrics.Rx(header.Type, header.Subtype, 1)
 		// TODO: Remove this with recv_error deprecation
 		f.handleRecvError(addr, header)
 		return
 
 	case closeTunnel:
-		f.metricRx(closeTunnel, 1)
+		f.messageMetrics.Rx(header.Type, header.Subtype, 1)
 		if !f.handleEncrypted(ci, addr, header) {
 			return
 		}
@@ -301,7 +301,7 @@ func (f *Interface) decryptToTun(hostinfo *HostInfo, messageCounter uint64, out 
 }
 
 func (f *Interface) sendRecvError(endpoint *udpAddr, index uint32) {
-	f.metricTx(recvError, 1)
+	f.messageMetrics.Tx(recvError, 0, 1)
 
 	//TODO: this should be a signed message so we can trust that we should drop the index
 	b := HeaderEncode(make([]byte, HeaderLen), Version, uint8(recvError), 0, index, 0)

--- a/outside.go
+++ b/outside.go
@@ -127,6 +127,7 @@ func (f *Interface) readOutsidePackets(addr *udpAddr, out []byte, packet []byte,
 		return
 
 	default:
+		f.messageMetrics.Rx(header.Type, header.Subtype, 1)
 		hostinfo.logger().Debugf("Unexpected packet received from %s", addr)
 		return
 	}

--- a/outside.go
+++ b/outside.go
@@ -54,7 +54,7 @@ func (f *Interface) readOutsidePackets(addr *udpAddr, out []byte, packet []byte,
 		// Fallthrough to the bottom to record incoming traffic
 
 	case lightHouse:
-		f.metricMessageRx[lightHouse].Inc(1)
+		f.metricRx(lightHouse, 1)
 		if !f.handleEncrypted(ci, addr, header) {
 			return
 		}
@@ -75,7 +75,7 @@ func (f *Interface) readOutsidePackets(addr *udpAddr, out []byte, packet []byte,
 		// Fallthrough to the bottom to record incoming traffic
 
 	case test:
-		f.metricMessageRx[test].Inc(1)
+		f.metricRx(test, 1)
 		if !f.handleEncrypted(ci, addr, header) {
 			return
 		}
@@ -104,18 +104,18 @@ func (f *Interface) readOutsidePackets(addr *udpAddr, out []byte, packet []byte,
 		// are unauthenticated
 
 	case handshake:
-		f.metricMessageRx[handshake].Inc(1)
+		f.metricRx(handshake, 1)
 		HandleIncomingHandshake(f, addr, packet, header, hostinfo)
 		return
 
 	case recvError:
-		f.metricMessageRx[recvError].Inc(1)
+		f.metricRx(recvError, 1)
 		// TODO: Remove this with recv_error deprecation
 		f.handleRecvError(addr, header)
 		return
 
 	case closeTunnel:
-		f.metricMessageRx[closeTunnel].Inc(1)
+		f.metricRx(closeTunnel, 1)
 		if !f.handleEncrypted(ci, addr, header) {
 			return
 		}
@@ -301,7 +301,7 @@ func (f *Interface) decryptToTun(hostinfo *HostInfo, messageCounter uint64, out 
 }
 
 func (f *Interface) sendRecvError(endpoint *udpAddr, index uint32) {
-	f.metricMessageTx[recvError].Inc(1)
+	f.metricTx(recvError, 1)
 
 	//TODO: this should be a signed message so we can trust that we should drop the index
 	b := HeaderEncode(make([]byte, HeaderLen), Version, uint8(recvError), 0, index, 0)


### PR DESCRIPTION
This change add more metrics around "meta" (non "message" type packets).
For lighthouse packets, we also record statistics around the specific
lighthouse meta type.

We don't keep statistics for the "message" type so that we don't slow
down the fast path (and you can just look at metrics on the tun
interface to find that information).

These have to be enabled by setting the following in your config:

    stats:
        message_metrics: true
        lighthouse_metrics: true