### PR TITLE
Preserve conntrack table during firewall rules reload (SIGHUP)

### DIFF
--- a/firewall.go
+++ b/firewall.go
@@ -510,8 +510,11 @@ func (f *Firewall) addConn(packet []byte, fp FirewallPacket, incoming bool) {
 		conntrack.TimerWheel.Add(fp, timeout)
 	}
 
-	c.Expires = time.Now().Add(timeout)
+	// Record which rulesHash allowed this connection, so we can retest after
+	// firewall reload
+	c.incoming = incoming
 	c.rulesHash = &f.rulesHash
+	c.Expires = time.Now().Add(timeout)
 	conntrack.Conns[fp] = c
 	conntrack.Unlock()
 }

--- a/firewall.go
+++ b/firewall.go
@@ -416,8 +416,8 @@ func (f *Firewall) EmitStats() {
 	conntrack := f.Conntrack
 	conntrack.Lock()
 	conntrackCount := len(conntrack.Conns)
-	metrics.GetOrRegisterGauge("firewall.conntrack.count", nil).Update(int64(conntrackCount))
 	conntrack.Unlock()
+	metrics.GetOrRegisterGauge("firewall.conntrack.count", nil).Update(int64(conntrackCount))
 }
 
 func (f *Firewall) inConns(packet []byte, fp FirewallPacket, incoming bool, h *HostInfo, caPool *cert.NebulaCAPool) bool {

--- a/firewall.go
+++ b/firewall.go
@@ -455,6 +455,8 @@ func (f *Firewall) inConns(packet []byte, fp FirewallPacket, incoming bool, h *H
 					WithField("oldRulesVersion", c.rulesVersion).
 					Debugln("dropping old conntrack entry, does not match new ruleset")
 			}
+			delete(conntrack.Conns, fp)
+			conntrack.Unlock()
 			return false
 		}
 

--- a/firewall.go
+++ b/firewall.go
@@ -418,6 +418,7 @@ func (f *Firewall) EmitStats() {
 	conntrackCount := len(conntrack.Conns)
 	conntrack.Unlock()
 	metrics.GetOrRegisterGauge("firewall.conntrack.count", nil).Update(int64(conntrackCount))
+	metrics.GetOrRegisterGauge("firewall.rules.version", nil).Update(int64(f.rulesVersion))
 }
 
 func (f *Firewall) inConns(packet []byte, fp FirewallPacket, incoming bool, h *HostInfo, caPool *cert.NebulaCAPool) bool {

--- a/firewall.go
+++ b/firewall.go
@@ -451,6 +451,7 @@ func (f *Firewall) inConns(packet []byte, fp FirewallPacket, incoming bool, h *H
 			if l.Level >= logrus.DebugLevel {
 				h.logger().
 					WithField("fwPacket", fp).
+					WithField("incoming", c.incoming).
 					WithField("firewallHash", f.rulesHash).
 					WithField("oldFirewallHash", *c.rulesHash).
 					Debugln("dropping old conntrack entry, does not match new ruleset")
@@ -461,6 +462,7 @@ func (f *Firewall) inConns(packet []byte, fp FirewallPacket, incoming bool, h *H
 		if l.Level >= logrus.DebugLevel {
 			h.logger().
 				WithField("fwPacket", fp).
+				WithField("incoming", c.incoming).
 				WithField("firewallHash", f.rulesHash).
 				WithField("oldFirewallHash", *c.rulesHash).
 				Debugln("keeping old conntrack entry, does match new ruleset")

--- a/firewall_test.go
+++ b/firewall_test.go
@@ -17,37 +17,39 @@ import (
 func TestNewFirewall(t *testing.T) {
 	c := &cert.NebulaCertificate{}
 	fw := NewFirewall(time.Second, time.Minute, time.Hour, c)
-	assert.NotNil(t, fw.Conns)
+	conntrack := fw.Conntrack
+	assert.NotNil(t, conntrack)
+	assert.NotNil(t, conntrack.Conns)
+	assert.NotNil(t, conntrack.TimerWheel)
 	assert.NotNil(t, fw.InRules)
 	assert.NotNil(t, fw.OutRules)
-	assert.NotNil(t, fw.TimerWheel)
 	assert.Equal(t, time.Second, fw.TCPTimeout)
 	assert.Equal(t, time.Minute, fw.UDPTimeout)
 	assert.Equal(t, time.Hour, fw.DefaultTimeout)
 
-	assert.Equal(t, time.Hour, fw.TimerWheel.wheelDuration)
-	assert.Equal(t, time.Hour, fw.TimerWheel.wheelDuration)
-	assert.Equal(t, 3601, fw.TimerWheel.wheelLen)
+	assert.Equal(t, time.Hour, conntrack.TimerWheel.wheelDuration)
+	assert.Equal(t, time.Hour, conntrack.TimerWheel.wheelDuration)
+	assert.Equal(t, 3601, conntrack.TimerWheel.wheelLen)
 
 	fw = NewFirewall(time.Second, time.Hour, time.Minute, c)
-	assert.Equal(t, time.Hour, fw.TimerWheel.wheelDuration)
-	assert.Equal(t, 3601, fw.TimerWheel.wheelLen)
+	assert.Equal(t, time.Hour, conntrack.TimerWheel.wheelDuration)
+	assert.Equal(t, 3601, conntrack.TimerWheel.wheelLen)
 
 	fw = NewFirewall(time.Hour, time.Second, time.Minute, c)
-	assert.Equal(t, time.Hour, fw.TimerWheel.wheelDuration)
-	assert.Equal(t, 3601, fw.TimerWheel.wheelLen)
+	assert.Equal(t, time.Hour, conntrack.TimerWheel.wheelDuration)
+	assert.Equal(t, 3601, conntrack.TimerWheel.wheelLen)
 
 	fw = NewFirewall(time.Hour, time.Minute, time.Second, c)
-	assert.Equal(t, time.Hour, fw.TimerWheel.wheelDuration)
-	assert.Equal(t, 3601, fw.TimerWheel.wheelLen)
+	assert.Equal(t, time.Hour, conntrack.TimerWheel.wheelDuration)
+	assert.Equal(t, 3601, conntrack.TimerWheel.wheelLen)
 
 	fw = NewFirewall(time.Minute, time.Hour, time.Second, c)
-	assert.Equal(t, time.Hour, fw.TimerWheel.wheelDuration)
-	assert.Equal(t, 3601, fw.TimerWheel.wheelLen)
+	assert.Equal(t, time.Hour, conntrack.TimerWheel.wheelDuration)
+	assert.Equal(t, 3601, conntrack.TimerWheel.wheelLen)
 
 	fw = NewFirewall(time.Minute, time.Second, time.Hour, c)
-	assert.Equal(t, time.Hour, fw.TimerWheel.wheelDuration)
-	assert.Equal(t, 3601, fw.TimerWheel.wheelLen)
+	assert.Equal(t, time.Hour, conntrack.TimerWheel.wheelDuration)
+	assert.Equal(t, 3601, conntrack.TimerWheel.wheelLen)
 }
 
 func TestFirewall_AddRule(t *testing.T) {
@@ -861,7 +863,7 @@ func (mf *mockFirewall) AddRule(incoming bool, proto uint8, startPort int32, end
 }
 
 func resetConntrack(fw *Firewall) {
-	fw.connMutex.Lock()
-	fw.Conns = map[FirewallPacket]*conn{}
-	fw.connMutex.Unlock()
+	fw.Conntrack.Lock()
+	fw.Conntrack.Conns = map[FirewallPacket]*conn{}
+	fw.Conntrack.Unlock()
 }

--- a/firewall_test.go
+++ b/firewall_test.go
@@ -516,6 +516,7 @@ func TestFirewall_DropConntrackReload(t *testing.T) {
 	fw = NewFirewall(time.Second, time.Minute, time.Hour, &c)
 	assert.Nil(t, fw.AddRule(true, fwProtoAny, 10, 10, []string{"any"}, "", nil, "", ""))
 	fw.Conntrack = oldFw.Conntrack
+	fw.rulesVersion = oldFw.rulesVersion + 1
 
 	// Allow outbound because conntrack and new rules allow port 10
 	assert.NoError(t, fw.Drop([]byte{}, p, false, &h, cp))
@@ -524,6 +525,7 @@ func TestFirewall_DropConntrackReload(t *testing.T) {
 	fw = NewFirewall(time.Second, time.Minute, time.Hour, &c)
 	assert.Nil(t, fw.AddRule(true, fwProtoAny, 11, 11, []string{"any"}, "", nil, "", ""))
 	fw.Conntrack = oldFw.Conntrack
+	fw.rulesVersion = oldFw.rulesVersion + 1
 
 	// Drop outbound because conntrack doesn't match new ruleset
 	assert.Equal(t, fw.Drop([]byte{}, p, false, &h, cp), ErrNoMatchingRule)

--- a/interface.go
+++ b/interface.go
@@ -215,12 +215,14 @@ func (f *Interface) reloadFirewall(c *Config) {
 	defer conntrack.Unlock()
 
 	fw.Conntrack = conntrack
+	fw.rulesVersion = oldFw.rulesVersion + 1
 
 	f.firewall = fw
 
 	oldFw.Destroy()
 	l.WithField("firewallHash", fw.GetRuleHash()).
 		WithField("oldFirewallHash", oldFw.GetRuleHash()).
+		WithField("rulesVersion", fw.rulesVersion).
 		Info("New firewall has been installed")
 }
 

--- a/interface.go
+++ b/interface.go
@@ -210,6 +210,13 @@ func (f *Interface) reloadFirewall(c *Config) {
 	}
 
 	oldFw := f.firewall
+	oldFw.connMutex.Lock()
+	defer oldFw.connMutex.Unlock()
+
+	fw.Conns = oldFw.Conns
+	fw.TimerWheel = oldFw.TimerWheel
+	fw.connMutex = oldFw.connMutex
+
 	f.firewall = fw
 
 	oldFw.Destroy()

--- a/interface.go
+++ b/interface.go
@@ -210,12 +210,11 @@ func (f *Interface) reloadFirewall(c *Config) {
 	}
 
 	oldFw := f.firewall
-	oldFw.connMutex.Lock()
-	defer oldFw.connMutex.Unlock()
+	conntrack := oldFw.Conntrack
+	conntrack.Lock()
+	defer conntrack.Unlock()
 
-	fw.Conns = oldFw.Conns
-	fw.TimerWheel = oldFw.TimerWheel
-	fw.connMutex = oldFw.connMutex
+	fw.Conntrack = conntrack
 
 	f.firewall = fw
 

--- a/interface.go
+++ b/interface.go
@@ -214,8 +214,17 @@ func (f *Interface) reloadFirewall(c *Config) {
 	conntrack.Lock()
 	defer conntrack.Unlock()
 
-	fw.Conntrack = conntrack
 	fw.rulesVersion = oldFw.rulesVersion + 1
+	// If rulesVersion is back to zero, we have wrapped all the way around. Be
+	// safe and just reset conntrack in this case.
+	if fw.rulesVersion == 0 {
+		l.WithField("firewallHash", fw.GetRuleHash()).
+			WithField("oldFirewallHash", oldFw.GetRuleHash()).
+			WithField("rulesVersion", fw.rulesVersion).
+			Warn("firewall rulesVersion has overflowed, resetting conntrack")
+	} else {
+		fw.Conntrack = conntrack
+	}
 
 	f.firewall = fw
 


### PR DESCRIPTION
Currently, we drop the conntrack table when firewall rules change during a SIGHUP reload. This means responses to inflight HTTP requests can be dropped, among other issues. This change copies the conntrack table over to the new firewall (it holds the conntrack mutex lock during this process, to be safe).

This change also records which firewall rules hash each conntrack entry used, so that we can re-verify the rules after the new firewall has been loaded. This adds one pointer equality check to the hot path, which I think should be okay.