### PR TITLE
allow `go test -bench=.` to run

### DIFF
--- a/hostmap_test.go
+++ b/hostmap_test.go
@@ -161,6 +161,4 @@ func BenchmarkHostmappromote2(b *testing.B) {
 		m.AddRemote(ip2int(net.ParseIP("10.128.1.1")), g)
 		m.AddRemote(ip2int(net.ParseIP("10.128.1.1")), y)
 	}
-	b.Errorf("hi")
-
 }


### PR DESCRIPTION
This benchmark had an Errorf at the end, lets remove it so the
benchmarks all run.