### PR TITLE
fix typo in conntrack section in examples/config.yml

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -189,7 +189,7 @@ logging:
 # Nebula security group configuration
 firewall:
   conntrack:
-    tcp_timeout: 120h
+    tcp_timeout: 12m
     udp_timeout: 3m
     default_timeout: 10m
     max_connections: 100000


### PR DESCRIPTION
the rest of the conntrack values match the default