### PR TITLE
linux: set advmss correctly when route MTU is used

### DIFF
--- a/tun_linux.go
+++ b/tun_linux.go
@@ -270,27 +270,14 @@ func (c Tun) Activate() error {
 }
 
 func (c Tun) advMSS(r route) int {
-	// We only need to set advmss if the MTU varies across routes
-	if c.mtuVaries() {
-		mtu := r.mtu
-		if r.mtu == 0 {
-			mtu = c.DefaultMTU
-		}
+	mtu := r.mtu
+	if r.mtu == 0 {
+		mtu = c.DefaultMTU
+	}
+
+	// We only need to set advmss if the route MTU does not match the device MTU
+	if mtu != c.MaxMTU {
 		return mtu - 40
 	}
 	return 0
-}
-
-func (c Tun) mtuVaries() bool {
-	for _, r := range c.Routes {
-		if r.mtu != 0 && r.mtu != c.DefaultMTU {
-			return true
-		}
-	}
-	for _, r := range c.UnsafeRoutes {
-		if r.mtu != 0 && r.mtu != c.DefaultMTU {
-			return true
-		}
-	}
-	return false
 }

--- a/tun_linux_test.go
+++ b/tun_linux_test.go
@@ -1,0 +1,31 @@
+package nebula
+
+import "testing"
+
+var runAdvMSSTests = []struct {
+	name     string
+	tun      Tun
+	r        route
+	expected int
+}{
+	// Standard case, default MTU is the device max MTU
+	{"default", Tun{DefaultMTU: 1440, MaxMTU: 1440}, route{}, 0},
+	{"default-min", Tun{DefaultMTU: 1440, MaxMTU: 1440}, route{mtu: 1440}, 0},
+	{"default-low", Tun{DefaultMTU: 1440, MaxMTU: 1440}, route{mtu: 1200}, 1160},
+
+	// Case where we have a route MTU set higher than the default
+	{"route", Tun{DefaultMTU: 1440, MaxMTU: 8941}, route{}, 1400},
+	{"route-min", Tun{DefaultMTU: 1440, MaxMTU: 8941}, route{mtu: 1440}, 1400},
+	{"route-high", Tun{DefaultMTU: 1440, MaxMTU: 8941}, route{mtu: 8941}, 0},
+}
+
+func TestTunAdvMSS(t *testing.T) {
+	for _, tt := range runAdvMSSTests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := tt.tun.advMSS(tt.r)
+			if o != tt.expected {
+				t.Errorf("got %d, want %d", o, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
If different MTUs are specified for different routes, we should set
advmss on each route because Linux does a poor job of selecting the
default (from ip-route(8)):

    advmss NUMBER (Linux 2.3.15+ only)
           the MSS ('Maximal Segment Size') to advertise to these destinations when estab‐
           lishing TCP connections. If it is not given, Linux uses a default value calcu‐
           lated from the first hop device MTU.  (If the path to these destination is asym‐
           metric, this guess may be wrong.)

Note that the default value is calculated from the first hop **device
MTU**, not the **route MTU**. In practice this is usually ok as long as the
other side of the tunnel has the MTU configured exactly the same, but we
should probably just set advmss correctly on these routes.

This change goes out of its way to only set advmss if it is necessary (when routes are present with MTU values that don't match the tun default).