### PR TITLE
enforce the use of goimports

### DIFF
--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -23,10 +23,22 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
 
+    - uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-gofmt-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-gofmt-
+
+    - name: Install goimports
+      run: |
+        go get golang.org/x/tools/cmd/goimports
+        go build golang.org/x/tools/cmd/goimports
+
     - name: gofmt
       run: |
-        if [ "$(find . -iname '*.go' | xargs gofmt -l)" ]
+        if [ "$(find . -iname '*.go' | xargs ./goimports -l)" ]
         then
-          find . -iname '*.go' | xargs gofmt -d
+          find . -iname '*.go' | xargs ./goimports -d
           exit 1
         fi

--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -37,8 +37,8 @@ jobs:
 
     - name: gofmt
       run: |
-        if [ "$(find . -iname '*.go' | xargs ./goimports -l)" ]
+        if [ "$(find . -iname '*.go' | grep -v '\.pb\.go$' | xargs ./goimports -l)" ]
         then
-          find . -iname '*.go' | xargs ./goimports -d
+          find . -iname '*.go' | grep -v '\.pb\.go$' | xargs ./goimports -d
           exit 1
         fi

--- a/cert/cert.go
+++ b/cert/cert.go
@@ -1,18 +1,18 @@
 package cert
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"net"
 	"time"
 
-	"bytes"
-	"encoding/json"
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/crypto/curve25519"
 	"golang.org/x/crypto/ed25519"

--- a/cmd/nebula-cert/main_test.go
+++ b/cmd/nebula-cert/main_test.go
@@ -3,10 +3,11 @@ package main
 import (
 	"bytes"
 	"errors"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 //TODO: all flag parsing continueOnError will print to stderr on its own currently

--- a/cmd/nebula-cert/print.go
+++ b/cmd/nebula-cert/print.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/slackhq/nebula/cert"
 	"io"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"github.com/slackhq/nebula/cert"
 )
 
 type printFlags struct {

--- a/cmd/nebula-cert/print_test.go
+++ b/cmd/nebula-cert/print_test.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"bytes"
-	"github.com/slackhq/nebula/cert"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/slackhq/nebula/cert"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_printSummary(t *testing.T) {

--- a/cmd/nebula-cert/verify.go
+++ b/cmd/nebula-cert/verify.go
@@ -3,12 +3,13 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/slackhq/nebula/cert"
 	"io"
 	"io/ioutil"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/slackhq/nebula/cert"
 )
 
 type verifyFlags struct {

--- a/cmd/nebula-cert/verify_test.go
+++ b/cmd/nebula-cert/verify_test.go
@@ -3,13 +3,14 @@ package main
 import (
 	"bytes"
 	"crypto/rand"
-	"github.com/slackhq/nebula/cert"
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/crypto/ed25519"
 	"io/ioutil"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/slackhq/nebula/cert"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/ed25519"
 )
 
 func Test_verifySummary(t *testing.T) {

--- a/cmd/nebula-service/main.go
+++ b/cmd/nebula-service/main.go
@@ -3,9 +3,10 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
+
 	"github.com/sirupsen/logrus"
 	"github.com/slackhq/nebula"
-	"os"
 )
 
 // A version string that can be set with

--- a/cmd/nebula-service/service.go
+++ b/cmd/nebula-service/service.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"log"
 	"os"
 	"path/filepath"
 
 	"github.com/kardianos/service"
+	"github.com/sirupsen/logrus"
 	"github.com/slackhq/nebula"
 )
 

--- a/cmd/nebula/main.go
+++ b/cmd/nebula/main.go
@@ -3,9 +3,9 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"os"
 
+	"github.com/sirupsen/logrus"
 	"github.com/slackhq/nebula"
 )
 

--- a/config.go
+++ b/config.go
@@ -3,9 +3,6 @@ package nebula
 import (
 	"errors"
 	"fmt"
-	"github.com/imdario/mergo"
-	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"net"
 	"os"
@@ -17,6 +14,10 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/imdario/mergo"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 )
 
 type Config struct {

--- a/config_test.go
+++ b/config_test.go
@@ -1,12 +1,13 @@
 package nebula
 
 import (
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConfig_Load(t *testing.T) {

--- a/firewall.go
+++ b/firewall.go
@@ -1,19 +1,18 @@
 package nebula
 
 import (
+	"crypto/sha256"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
-	"sync"
-	"time"
-
-	"crypto/sha256"
-	"encoding/hex"
-	"errors"
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/rcrowley/go-metrics"
 	"github.com/slackhq/nebula/cert"

--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -1,10 +1,9 @@
 package nebula
 
 import (
+	"bytes"
 	"sync/atomic"
 	"time"
-
-	"bytes"
 
 	"github.com/flynn/noise"
 	"github.com/golang/protobuf/proto"

--- a/header_test.go
+++ b/header_test.go
@@ -1,9 +1,10 @@
 package nebula
 
 import (
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type headerTest struct {

--- a/lighthouse_test.go
+++ b/lighthouse_test.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"testing"
 
-	proto "github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -2,9 +2,10 @@ package nebula
 
 import (
 	"errors"
+	"testing"
+
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 type TestLogWriter struct {

--- a/main.go
+++ b/main.go
@@ -3,9 +3,6 @@ package nebula
 import (
 	"encoding/binary"
 	"fmt"
-	"github.com/sirupsen/logrus"
-	"github.com/slackhq/nebula/sshd"
-	"gopkg.in/yaml.v2"
 	"net"
 	"os"
 	"os/signal"
@@ -13,6 +10,10 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/slackhq/nebula/sshd"
+	"gopkg.in/yaml.v2"
 )
 
 // The caller should provide a real logger, we have one just in case

--- a/outside.go
+++ b/outside.go
@@ -2,18 +2,14 @@ package nebula
 
 import (
 	"encoding/binary"
+	"errors"
+	"fmt"
+	"time"
 
 	"github.com/flynn/noise"
 	"github.com/golang/protobuf/proto"
 	"github.com/sirupsen/logrus"
 	"github.com/slackhq/nebula/cert"
-	// "github.com/google/gopacket"
-	// "github.com/google/gopacket/layers"
-	// 	"encoding/binary"
-	"errors"
-	"fmt"
-	"time"
-
 	"golang.org/x/net/ipv4"
 )
 

--- a/outside_test.go
+++ b/outside_test.go
@@ -1,10 +1,11 @@
 package nebula
 
 import (
-	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/ipv4"
 	"net"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/ipv4"
 )
 
 func Test_newPacket(t *testing.T) {

--- a/punchy_test.go
+++ b/punchy_test.go
@@ -1,9 +1,10 @@
 package nebula
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewPunchyFromConfig(t *testing.T) {

--- a/ssh.go
+++ b/ssh.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/sirupsen/logrus"
-	"github.com/slackhq/nebula/sshd"
 	"io/ioutil"
 	"net"
 	"os"
@@ -14,6 +12,9 @@ import (
 	"runtime/pprof"
 	"strings"
 	"syscall"
+
+	"github.com/sirupsen/logrus"
+	"github.com/slackhq/nebula/sshd"
 )
 
 type sshListHostMapFlags struct {

--- a/sshd/command.go
+++ b/sshd/command.go
@@ -4,9 +4,10 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/armon/go-radix"
 	"sort"
 	"strings"
+
+	"github.com/armon/go-radix"
 )
 
 // CommandFlags is a function called before help or command execution to parse command line flags

--- a/sshd/server.go
+++ b/sshd/server.go
@@ -2,10 +2,11 @@ package sshd
 
 import (
 	"fmt"
+	"net"
+
 	"github.com/armon/go-radix"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
-	"net"
 )
 
 type SSHServer struct {

--- a/sshd/session.go
+++ b/sshd/session.go
@@ -2,13 +2,14 @@ package sshd
 
 import (
 	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/anmitsu/go-shlex"
 	"github.com/armon/go-radix"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/terminal"
-	"sort"
-	"strings"
 )
 
 type session struct {

--- a/stats.go
+++ b/stats.go
@@ -3,15 +3,16 @@ package nebula
 import (
 	"errors"
 	"fmt"
-	"github.com/cyberdelia/go-metrics-graphite"
-	mp "github.com/nbrownus/go-metrics-prometheus"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/rcrowley/go-metrics"
 	"log"
 	"net"
 	"net/http"
 	"time"
+
+	graphite "github.com/cyberdelia/go-metrics-graphite"
+	mp "github.com/nbrownus/go-metrics-prometheus"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/rcrowley/go-metrics"
 )
 
 func startStats(c *Config, configTest bool) error {

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -1,9 +1,10 @@
 package nebula
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewTimerWheel(t *testing.T) {

--- a/tun_darwin.go
+++ b/tun_darwin.go
@@ -4,10 +4,11 @@ package nebula
 
 import (
 	"fmt"
-	"github.com/songgao/water"
 	"net"
 	"os/exec"
 	"strconv"
+
+	"github.com/songgao/water"
 )
 
 type Tun struct {


### PR DESCRIPTION
Instead of enforcing `gofmt`, enforce `goimports`, which also asserts a separate section for non-builtin packages. We also skip running the check on *.pb.go files, since they are generated by protoc.