### PR TITLE
Make Interface.Inside an interface type

### DIFF
--- a/tun_android.go
+++ b/tun_android.go
@@ -27,7 +27,7 @@ func newTunFromFd(deviceFd int, cidr *net.IPNet, defaultMTU int, routes []route,
 	ifce = &Tun{
 		ReadWriteCloser: file,
 		fd:              int(file.Fd()),
-		Device:          "tun0",
+		Device:          "android",
 		Cidr:            cidr,
 		DefaultMTU:      defaultMTU,
 		TXQueueLen:      txQueueLen,
@@ -64,6 +64,13 @@ func (c *Tun) WriteRaw(b []byte) error {
 }
 
 func (c Tun) Activate() error {
-	c.Device = "android"
 	return nil
+}
+
+func (c *Tun) CidrNet() *net.IPNet {
+	return c.Cidr
+}
+
+func (c *Tun) DeviceName() string {
+	return c.Device
 }

--- a/tun_darwin.go
+++ b/tun_darwin.go
@@ -68,6 +68,14 @@ func (c *Tun) Activate() error {
 	return nil
 }
 
+func (c *Tun) CidrNet() *net.IPNet {
+	return c.Cidr
+}
+
+func (c *Tun) DeviceName() string {
+	return c.Device
+}
+
 func (c *Tun) WriteRaw(b []byte) error {
 	_, err := c.Write(b)
 	return err

--- a/tun_freebsd.go
+++ b/tun_freebsd.go
@@ -75,6 +75,14 @@ func (c *Tun) Activate() error {
 	return nil
 }
 
+func (c *Tun) CidrNet() *net.IPNet {
+	return c.Cidr
+}
+
+func (c *Tun) DeviceName() string {
+	return c.Device
+}
+
 func (c *Tun) WriteRaw(b []byte) error {
 	_, err := c.Write(b)
 	return err

--- a/tun_ios.go
+++ b/tun_ios.go
@@ -30,13 +30,13 @@ func newTunFromFd(deviceFd int, cidr *net.IPNet, defaultMTU int, routes []route,
 	file := os.NewFile(uintptr(deviceFd), "/dev/tun")
 	ifce = &Tun{
 		Cidr:            cidr,
+		Device:          "iOS",
 		ReadWriteCloser: &tunReadCloser{f: file},
 	}
 	return
 }
 
 func (c *Tun) Activate() error {
-	c.Device = "iOS"
 	return nil
 }
 
@@ -102,4 +102,12 @@ func (t *tunReadCloser) Write(from []byte) (int, error) {
 
 func (t *tunReadCloser) Close() error {
 	return t.f.Close()
+}
+
+func (c *Tun) CidrNet() *net.IPNet {
+	return c.Cidr
+}
+
+func (c *Tun) DeviceName() string {
+	return c.Device
 }

--- a/tun_linux.go
+++ b/tun_linux.go
@@ -288,6 +288,14 @@ func (c Tun) Activate() error {
 	return nil
 }
 
+func (c *Tun) CidrNet() *net.IPNet {
+	return c.Cidr
+}
+
+func (c *Tun) DeviceName() string {
+	return c.Device
+}
+
 func (c Tun) advMSS(r route) int {
 	mtu := r.mtu
 	if r.mtu == 0 {

--- a/tun_windows.go
+++ b/tun_windows.go
@@ -88,6 +88,14 @@ func (c *Tun) Activate() error {
 	return nil
 }
 
+func (c *Tun) CidrNet() *net.IPNet {
+	return c.Cidr
+}
+
+func (c *Tun) DeviceName() string {
+	return c.Device
+}
+
 func (c *Tun) WriteRaw(b []byte) error {
 	_, err := c.Write(b)
 	return err


### PR DESCRIPTION
This commit updates the Interface.Inside type to be a new interface
type instead of a *Tun. This will allow for an inside interface
that does not use a tun device, such as a single-binary client that
can run without elevated privileges.