### PR TITLE
Added --watch-config flag

### DIFF
--- a/checksum.go
+++ b/checksum.go
@@ -1,0 +1,24 @@
+package nebula
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"io"
+	"os"
+)
+
+// returns the checksum of the file at the filePath
+func md5sum(filePath string) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	hash := md5.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}

--- a/cmd/nebula/main.go
+++ b/cmd/nebula/main.go
@@ -21,6 +21,7 @@ func main() {
 	configTest := flag.Bool("test", false, "Test the config and print the end result. Non zero exit indicates a faulty config")
 	printVersion := flag.Bool("version", false, "Print version")
 	printUsage := flag.Bool("help", false, "Print command line usage")
+	watchConfig := flag.Bool("watch-config", false, "[EXPERIMENTAL] Reload the pki section of the config when the config and cert files change")
 
 	flag.Parse()
 
@@ -46,7 +47,9 @@ func main() {
 		fmt.Printf("failed to load config: %s", err)
 		os.Exit(1)
 	}
-
+	if watchConfig != nil {
+		config.WatchConfig = *watchConfig
+	}
 	l := logrus.New()
 	l.Out = os.Stdout
 	err = nebula.Main(config, *configTest, true, Build, l, nil, nil)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/cyberdelia/go-metrics-graphite v0.0.0-20161219230853-39f87cc3b432
 	github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 // indirect
 	github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6
+	github.com/fsnotify/fsnotify v1.4.9
 	github.com/golang/protobuf v1.3.2
 	github.com/imdario/mergo v0.3.8
 	github.com/kardianos/service v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjr
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6 h1:u/UEqS66A5ckRmS4yNpjmVH56sVtS/RfclBAYocb4as=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe1ma7Lr6yG6/rjvM3emb6yoL7xLFzcVQ=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
+github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
@@ -112,8 +114,6 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
-golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 h1:ULYEB3JvPRE/IfO+9uO7vKV/xzVTO7XPAwm8xbf4w2g=
-golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 h1:/Tl7pH94bvbAAHBdZJT947M/+gp0+CqQXDtMRC0fseo=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -137,6 +137,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 h1:gSbV7h1NRL2G1xTg/owz62CST1oJBmxy4QpMMregXVQ=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/main.go
+++ b/main.go
@@ -104,7 +104,13 @@ func Main(config *Config, configTest bool, block bool, buildVersion string, logg
 	var tun *Tun
 	if !configTest {
 		config.CatchHUP()
-
+		if config.WatchConfig {
+			close, err := config.CatchFileChanges()
+			if err != nil {
+				return NewContextualError("--watch-config error while setup up watchers", nil, err)
+			}
+			defer close()
+		}
 		if tunFd != nil {
 			tun, err = newTunFromFd(
 				*tunFd,


### PR DESCRIPTION
The `--watch-config` flag sets up file watchers within the binary. When a config file or a pki file changes, it reloads the config.

The default is of course false (SIGHUP is then the only update mechanism).

**Things to be discussed:**
I simply call reloadConfig() when a file update is watched. I'm not sure what happens when the `pki.cert` is updated before the `pki.key`. The ideal behavior is to wait for them to update if they do not match, but after a little bit give it out and error out of the program. This is not implemented as for now but let's discuss it.

I have added a bunch of debug logging, feel free to update these.

**Features that may seem strange at first:**
- \[[Source](https://github.com/fsnotify/fsnotify/issues/254)\] Watches the directories instead of the files themselves. If you watch a file it will only trigger an event once. Note that if the file read fails for some reason, I will assume the file has changed, but still write the error to the log. I'm not sure if it's necessary to log this as an error, because this is something that is to be expected to happen sometimes.
- \[[Source](https://github.com/fsnotify/fsnotify/issues/324#issuecomment-601885573)\] Added checksum.go file: I cache the file checksums here, when a file is edited, it will create a lot of notifications: 3 on my machine. 

Resolves #254 
Edits by maintainers are allowed!