### PR TITLE
Delay starting nebula systemd unit until after a network is up

### DIFF
--- a/dist/arch/nebula.service
+++ b/dist/arch/nebula.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=nebula
-Wants=basic.target
-After=basic.target network.target
+Wants=basic.target network-online.target
+After=basic.target network.target network-online.target
 
 [Service]
 SyslogIdentifier=nebula


### PR DESCRIPTION
The provided systemd unit fails to start on systems where the network interface comes up slowly (like wifi) and the lighthouse's `static_host_map` setting uses a domain name rather than an IP address.  This appears to be caused by the network not being up in time to make a DNS lookup.

The proposed changes alter the systemd unit to wait until a network comes up before starting nebula.