### PR TITLE
Align linux UDP performance optimizations with configuration

### DIFF
--- a/udp_linux.go
+++ b/udp_linux.go
@@ -161,37 +161,6 @@ func (u *udpConn) ListenOut(f *Interface) {
 	}
 }
 
-func (u *udpConn) Read(addr *udpAddr, b []byte) ([]byte, error) {
-	var rsa rawSockaddrAny
-	var rLen = unix.SizeofSockaddrAny
-
-	for {
-		n, _, err := unix.Syscall6(
-			unix.SYS_RECVFROM,
-			uintptr(u.sysFd),
-			uintptr(unsafe.Pointer(&b[0])),
-			uintptr(len(b)),
-			uintptr(0),
-			uintptr(unsafe.Pointer(&rsa)),
-			uintptr(unsafe.Pointer(&rLen)),
-		)
-
-		if err != 0 {
-			return nil, &net.OpError{Op: "read", Err: err}
-		}
-
-		if rsa.Addr.Family == unix.AF_INET {
-			addr.Port = uint16(rsa.Addr.Data[0])<<8 + uint16(rsa.Addr.Data[1])
-			addr.IP = uint32(rsa.Addr.Data[2])<<24 + uint32(rsa.Addr.Data[3])<<16 + uint32(rsa.Addr.Data[4])<<8 + uint32(rsa.Addr.Data[5])
-		} else {
-			addr.Port = 0
-			addr.IP = 0
-		}
-
-		return b[:n], nil
-	}
-}
-
 func (u *udpConn) ReadMulti(msgs []rawMessage) (int, error) {
 	for {
 		n, _, err := unix.Syscall6(


### PR DESCRIPTION
While attempting to run nebula on an older Synology NAS, it became
apparent that some of the performance optimizations effectively
block support for older kernels. The `recvmmsg` syscall was added in
linux kernel `2.6.33`, and the Synology ds212j (among other models)
is pinned to `2.6.32.12`.

Similarly, `SO_REUSEPORT` was added to the kernel in the 3.9 cycle.
While this option has been backported into _some_ older trees, it
is missing from the Synology kernel.

This commit allows nebula to be run on linux devices with older
kernels if the config options are set up with a single listener
and a UDP listen batch size of 1 (`listen.batch = 1`).