### PR TITLE
Fix a data race found while read and write of HostInfo.localIndexId

### DIFF
--- a/hostmap.go
+++ b/hostmap.go
@@ -34,6 +34,7 @@ type HostMap struct {
 }
 
 type HostInfo struct {
+	sync.RWMutex
 	remote            *udpAddr
 	Remotes           []*HostInfoDest
 	promoteCounter    uint32
@@ -104,7 +105,9 @@ func (hm *HostMap) EmitStats(name string) {
 func (hm *HostMap) GetIndexByVpnIP(vpnIP uint32) (uint32, error) {
 	hm.RLock()
 	if i, ok := hm.Hosts[vpnIP]; ok {
+		i.RLock()
 		index := i.localIndexId
+		i.RUnlock()
 		hm.RUnlock()
 		return index, nil
 	}
@@ -188,7 +191,9 @@ func (hm *HostMap) AddIndex(index uint32, ci *ConnectionState) (*HostInfo, error
 
 func (hm *HostMap) AddIndexHostInfo(index uint32, h *HostInfo) {
 	hm.Lock()
+	h.Lock()
 	h.localIndexId = index
+	h.Unlock()
 	hm.Indexes[index] = h
 	hm.Unlock()
 


### PR DESCRIPTION
data race originally found issue #283 case 5

```go
5. ==================
WARNING: DATA RACE
Read at 0x00c0001b8684 by goroutine 14:
  github.com/slackhq/nebula.(*HostMap).GetIndexByVpnIP()
      github.com/slackhq/nebula/hostmap.go:107 +0x14a
  github.com/slackhq/nebula.(*HandshakeManager).handleOutbound()
      github.com/slackhq/nebula/handshake_manager.go:102 +0x76
  github.com/slackhq/nebula.(*HandshakeManager).NextOutboundHandshakeTimerTick()
      github.com/slackhq/nebula/handshake_manager.go:97 +0xb9
  github.com/slackhq/nebula.(*HandshakeManager).Run()
      github.com/slackhq/nebula/handshake_manager.go:83 +0x1ea

Previous write at 0x00c0001b8684 by goroutine 17:
  github.com/slackhq/nebula.(*HostMap).AddIndexHostInfo()
      github.com/slackhq/nebula/hostmap.go:191 +0x76
  github.com/slackhq/nebula.ixHandshakeStage2()
      github.com/slackhq/nebula/handshake_ix.go:363 +0x3791
  github.com/slackhq/nebula.HandleIncomingHandshake()
      github.com/slackhq/nebula/handshake.go:28 +0x2f8
  github.com/slackhq/nebula.(*Interface).readOutsidePackets()
      github.com/slackhq/nebula/outside.go:104 +0x679
  github.com/slackhq/nebula.(*udpConn).ListenOut()
      github.com/slackhq/nebula/udp_generic.go:109 +0x3b5
  github.com/slackhq/nebula.(*Interface).listenOut()
      github.com/slackhq/nebula/interface.go:147 +0x15e
```