### PR TITLE
Add support for specific Windows TAP adapter.

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -128,6 +128,8 @@ tun:
   disabled: false
   # Name of the device
   dev: nebula1
+  # Toggle this command and label after TUN device. This is a fix for Windows.
+  #interface_name: "nebula1"
   # Toggles forwarding of local broadcast packets, the address of which depends on the ip/mask encoded in pki.cert
   drop_local_broadcast: false
   # Toggles forwarding of multicast packets

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df // indirect
 	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975
 	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553
-	golang.org/x/sys v0.0.0-20191210023423-ac6580df4449
+	golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.2.7
 )

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 h1:gSbV7h1NRL2G1xTg/owz62CST1oJBmxy4QpMMregXVQ=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9 h1:1/DFK4b7JH8DmkqhUk48onnSfrPzImPoVxuomtbT2nk=
+golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/main.go
+++ b/main.go
@@ -125,6 +125,7 @@ func Main(config *Config, configTest bool, block bool, buildVersion string, logg
 				routes,
 				unsafeRoutes,
 				config.GetInt("tun.tx_queue", 500),
+				config.GetString("tun.interface_name", ""),
 			)
 		}
 

--- a/tun_android.go
+++ b/tun_android.go
@@ -37,7 +37,7 @@ func newTunFromFd(deviceFd int, cidr *net.IPNet, defaultMTU int, routes []route,
 	return
 }
 
-func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, unsafeRoutes []route, txQueueLen int) (ifce *Tun, err error) {
+func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, unsafeRoutes []route, txQueueLen int, interfaceName string) (ifce *Tun, err error) {
 	return nil, fmt.Errorf("newTun not supported in Android")
 }
 

--- a/tun_darwin.go
+++ b/tun_darwin.go
@@ -20,7 +20,7 @@ type Tun struct {
 	*water.Interface
 }
 
-func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, unsafeRoutes []route, txQueueLen int) (ifce *Tun, err error) {
+func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, unsafeRoutes []route, txQueueLen int, interfaceName string) (ifce *Tun, err error) {
 	if len(routes) > 0 {
 		return nil, fmt.Errorf("route MTU not supported in Darwin")
 	}

--- a/tun_freebsd.go
+++ b/tun_freebsd.go
@@ -26,7 +26,7 @@ func newTunFromFd(deviceFd int, cidr *net.IPNet, defaultMTU int, routes []route,
 	return nil, fmt.Errorf("newTunFromFd not supported in FreeBSD")
 }
 
-func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, unsafeRoutes []route, txQueueLen int) (ifce *Tun, err error) {
+func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, unsafeRoutes []route, txQueueLen int, interfaceName string) (ifce *Tun, err error) {
 	if len(routes) > 0 {
 		return nil, fmt.Errorf("Route MTU not supported in FreeBSD")
 	}

--- a/tun_ios.go
+++ b/tun_ios.go
@@ -22,7 +22,7 @@ func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, 
 	return nil, fmt.Errorf("newTun not supported in iOS")
 }
 
-func newTunFromFd(deviceFd int, cidr *net.IPNet, defaultMTU int, routes []route, unsafeRoutes []route, txQueueLen int) (ifce *Tun, err error) {
+func newTunFromFd(deviceFd int, cidr *net.IPNet, defaultMTU int, routes []route, unsafeRoutes []route, txQueueLen int, interfaceName string) (ifce *Tun, err error) {
 	if len(routes) > 0 {
 		return nil, fmt.Errorf("route MTU not supported in Darwin")
 	}

--- a/tun_linux.go
+++ b/tun_linux.go
@@ -94,7 +94,7 @@ func newTunFromFd(deviceFd int, cidr *net.IPNet, defaultMTU int, routes []route,
 	return
 }
 
-func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, unsafeRoutes []route, txQueueLen int) (ifce *Tun, err error) {
+func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, unsafeRoutes []route, txQueueLen int, interfaceName string) (ifce *Tun, err error) {
 	fd, err := unix.Open("/dev/net/tun", os.O_RDWR, 0)
 	if err != nil {
 		return nil, err

--- a/tun_windows.go
+++ b/tun_windows.go
@@ -58,7 +58,7 @@ func (c *Tun) Activate() error {
 				InterfaceName: c.InterfaceName,
 			},
 		})
-		if err != nil {
+		if err2 != nil {
 			return fmt.Errorf("Activate failed: \n%v\n%v", err, err2)
 		}
 	}

--- a/tun_windows.go
+++ b/tun_windows.go
@@ -59,7 +59,7 @@ func (c *Tun) Activate() error {
 			},
 		})
 		if err2 != nil {
-			return fmt.Errorf("Activate failed: \n%v\n%v", err, err2)
+			return fmt.Errorf("Activate failed: 1:%v 2:%v", err, err2)
 		}
 	}
 

--- a/tun_windows.go
+++ b/tun_windows.go
@@ -10,10 +10,11 @@ import (
 )
 
 type Tun struct {
-	Device       string
-	Cidr         *net.IPNet
-	MTU          int
-	UnsafeRoutes []route
+	Device        string
+	Cidr          *net.IPNet
+	MTU           int
+	InterfaceName string
+	UnsafeRoutes  []route
 
 	*water.Interface
 }
@@ -22,16 +23,17 @@ func newTunFromFd(deviceFd int, cidr *net.IPNet, defaultMTU int, routes []route,
 	return nil, fmt.Errorf("newTunFromFd not supported in Windows")
 }
 
-func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, unsafeRoutes []route, txQueueLen int) (ifce *Tun, err error) {
+func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, unsafeRoutes []route, txQueueLen int, interfaceName string) (ifce *Tun, err error) {
 	if len(routes) > 0 {
 		return nil, fmt.Errorf("route MTU not supported in Windows")
 	}
 
 	// NOTE: You cannot set the deviceName under Windows, so you must check tun.Device after calling .Activate()
 	return &Tun{
-		Cidr:         cidr,
-		MTU:          defaultMTU,
-		UnsafeRoutes: unsafeRoutes,
+		Cidr:          cidr,
+		MTU:           defaultMTU,
+		InterfaceName: interfaceName,
+		UnsafeRoutes:  unsafeRoutes,
 	}, nil
 }
 
@@ -40,8 +42,9 @@ func (c *Tun) Activate() error {
 	c.Interface, err = water.New(water.Config{
 		DeviceType: water.TUN,
 		PlatformSpecificParams: water.PlatformSpecificParams{
-			ComponentID: "tap0901",
-			Network:     c.Cidr.String(),
+			ComponentID:   "tap0901",
+			Network:       c.Cidr.String(),
+			InterfaceName: c.InterfaceName,
 		},
 	})
 	if err != nil {
@@ -60,7 +63,7 @@ func (c *Tun) Activate() error {
 		"gateway=none",
 	).Run()
 	if err != nil {
-		return fmt.Errorf("failed to run 'netsh' to set address: %s", err)
+		return fmt.Errorf("failed to run 'netsh' to set address: %s %s %s %s", err, c.Device, c.Cidr.IP, net.IP(c.Cidr.Mask))
 	}
 	err = exec.Command(
 		`C:\Windows\System32\netsh.exe`, "interface", "ipv4", "set", "interface",

--- a/tun_windows.go
+++ b/tun_windows.go
@@ -48,7 +48,18 @@ func (c *Tun) Activate() error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("Activate failed: %v", err)
+		// NOTE: OpenVPN creates TUN adapters with ComponentId "root/tap0901" which causes the previous check to fail. This should work.
+		c.Interface, err = water.New(water.Config{
+			DeviceType: water.TUN,
+			PlatformSpecificParams: water.PlatformSpecificParams{
+				ComponentID:   "root/tap0901",
+				Network:       c.Cidr.String(),
+				InterfaceName: c.InterfaceName,
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("Activate failed: %v", err)
+		}
 	}
 
 	c.Device = c.Interface.Name()

--- a/tun_windows.go
+++ b/tun_windows.go
@@ -48,17 +48,18 @@ func (c *Tun) Activate() error {
 		},
 	})
 	if err != nil {
+		var err2 error
 		// NOTE: OpenVPN creates TUN adapters with ComponentId "root/tap0901" which causes the previous check to fail. This should work.
-		c.Interface, err = water.New(water.Config{
+		c.Interface, err2 = water.New(water.Config{
 			DeviceType: water.TUN,
 			PlatformSpecificParams: water.PlatformSpecificParams{
-				ComponentID:   "root/tap0901",
+				ComponentID:   "root\\tap0901",
 				Network:       c.Cidr.String(),
 				InterfaceName: c.InterfaceName,
 			},
 		})
 		if err != nil {
-			return fmt.Errorf("Activate failed: %v", err)
+			return fmt.Errorf("Activate failed: \n%v\n%v", err, err2)
 		}
 	}
 


### PR DESCRIPTION
Based on rpooley's work, I added his modification to the most recent Nebula source. It creates a new entry in `config.yml` for `tun.interface_name` where the value is the name of the TAP adapter.

I also added a conditional for using a TAP adapter under ComponentId "root\0901" because adapters created by OpenVPN may label adapters as such instead of ComponentId "0901".

Creating an error message with newlines wasn't an option, so I created label "1:" and "2:" under `tun_windows.go` if there are no available adapters. There might be a better option available?