### PR TITLE
Handle panic when invalid IP entered in sshd

### DIFF
--- a/ssh.go
+++ b/ssh.go
@@ -463,7 +463,12 @@ func sshQueryLighthouse(ifce *Interface, fs interface{}, a []string, w sshd.Stri
 		return w.WriteLine("No vpn ip was provided")
 	}
 
-	vpnIp := ip2int(net.ParseIP(a[0]))
+	parsedIp := net.ParseIP(a[0])
+	if parsedIp == nil {
+		return w.WriteLine(fmt.Sprintf("The provided vpn ip could not be parsed: %s", a[0]))
+	}
+
+	vpnIp := ip2int(parsedIp)
 	if vpnIp == 0 {
 		return w.WriteLine(fmt.Sprintf("The provided vpn ip could not be parsed: %s", a[0]))
 	}
@@ -483,7 +488,12 @@ func sshCloseTunnel(ifce *Interface, fs interface{}, a []string, w sshd.StringWr
 		return w.WriteLine("No vpn ip was provided")
 	}
 
-	vpnIp := ip2int(net.ParseIP(a[0]))
+	parsedIp := net.ParseIP(a[0])
+	if parsedIp == nil {
+		return w.WriteLine(fmt.Sprintf("The provided vpn ip could not be parsed: %s", a[0]))
+	}
+
+	vpnIp := ip2int(parsedIp)
 	if vpnIp == 0 {
 		return w.WriteLine(fmt.Sprintf("The provided vpn ip could not be parsed: %s", a[0]))
 	}
@@ -521,7 +531,12 @@ func sshCreateTunnel(ifce *Interface, fs interface{}, a []string, w sshd.StringW
 		return w.WriteLine("No vpn ip was provided")
 	}
 
-	vpnIp := ip2int(net.ParseIP(a[0]))
+	parsedIp := net.ParseIP(a[0])
+	if parsedIp == nil {
+		return w.WriteLine(fmt.Sprintf("The provided vpn ip could not be parsed: %s", a[0]))
+	}
+
+	vpnIp := ip2int(parsedIp)
 	if vpnIp == 0 {
 		return w.WriteLine(fmt.Sprintf("The provided vpn ip could not be parsed: %s", a[0]))
 	}
@@ -573,7 +588,12 @@ func sshChangeRemote(ifce *Interface, fs interface{}, a []string, w sshd.StringW
 		return w.WriteLine("Address could not be parsed")
 	}
 
-	vpnIp := ip2int(net.ParseIP(a[0]))
+	parsedIp := net.ParseIP(a[0])
+	if parsedIp == nil {
+		return w.WriteLine(fmt.Sprintf("The provided vpn ip could not be parsed: %s", a[0]))
+	}
+
+	vpnIp := ip2int(parsedIp)
 	if vpnIp == 0 {
 		return w.WriteLine(fmt.Sprintf("The provided vpn ip could not be parsed: %s", a[0]))
 	}
@@ -649,7 +669,12 @@ func sshPrintCert(ifce *Interface, fs interface{}, a []string, w sshd.StringWrit
 
 	cert := ifce.certState.certificate
 	if len(a) > 0 {
-		vpnIp := ip2int(net.ParseIP(a[0]))
+		parsedIp := net.ParseIP(a[0])
+		if parsedIp == nil {
+			return w.WriteLine(fmt.Sprintf("The provided vpn ip could not be parsed: %s", a[0]))
+		}
+
+		vpnIp := ip2int(parsedIp)
 		if vpnIp == 0 {
 			return w.WriteLine(fmt.Sprintf("The provided vpn ip could not be parsed: %s", a[0]))
 		}
@@ -696,7 +721,12 @@ func sshPrintTunnel(ifce *Interface, fs interface{}, a []string, w sshd.StringWr
 		return w.WriteLine("No vpn ip was provided")
 	}
 
-	vpnIp := ip2int(net.ParseIP(a[0]))
+	parsedIp := net.ParseIP(a[0])
+	if parsedIp == nil {
+		return w.WriteLine(fmt.Sprintf("The provided vpn ip could not be parsed: %s", a[0]))
+	}
+
+	vpnIp := ip2int(parsedIp)
 	if vpnIp == 0 {
 		return w.WriteLine(fmt.Sprintf("The provided vpn ip could not be parsed: %s", a[0]))
 	}


### PR DESCRIPTION
# Issue
Invalid IPs passed as arguments in several `sshd` commands crashes the process.

```
bluong@nebula > print-tunnel 10.0.3
Connection to localhost closed by remote host.
Connection to localhost closed.
...
...
...
bluong@nebula > print-cert hi
Connection to localhost closed by remote host.
Connection to localhost closed.
```

```
Aug 31 13:59:21 mako4-app.b1-prv.qops.net nebula[16947]: panic: runtime error: index out of range [3] with length 0
Aug 31 13:59:21 mako4-app.b1-prv.qops.net nebula[16947]: goroutine 27661 [running]:
Aug 31 13:59:21 mako4-app.b1-prv.qops.net nebula[16947]: encoding/binary.bigEndian.Uint32(...)
Aug 31 13:59:21 mako4-app.b1-prv.qops.net nebula[16947]: encoding/binary/binary.go:112
Aug 31 13:59:21 mako4-app.b1-prv.qops.net nebula[16947]: github.com/slackhq/nebula.ip2int(...)
Aug 31 13:59:21 mako4-app.b1-prv.qops.net nebula[16947]: github.com/slackhq/nebula/cidr_radix.go:163
Aug 31 13:59:21 mako4-app.b1-prv.qops.net nebula[16947]: github.com/slackhq/nebula.sshPrintTunnel(0xc0000fc780, 0x9f90e0, 0xc000244394, 0xc00000fd10, 0x1, 0x1, 0xc0fb00, 0xc0002d8
Aug 31 13:59:21 mako4-app.b1-prv.qops.net nebula[16947]: github.com/slackhq/nebula/ssh.go:697 +0x3ef
Aug 31 13:59:21 mako4-app.b1-prv.qops.net nebula[16947]: github.com/slackhq/nebula.attachCommands.func12(0x9f90e0, 0xc000244394, 0xc00000fd10, 0x1, 0x1, 0xc0fb00, 0xc0002d8140, 0x
Aug 31 13:59:21 mako4-app.b1-prv.qops.net nebula[16947]: github.com/slackhq/nebula/ssh.go:267 +0x7d
Aug 31 13:59:21 mako4-app.b1-prv.qops.net nebula[16947]: github.com/slackhq/nebula/sshd.execCommand(0xc0000d5580, 0xc00000fd10, 0x1, 0x1, 0xc0fb00, 0xc0002d8140, 0x0, 0x0)
Aug 31 13:59:21 mako4-app.b1-prv.qops.net nebula[16947]: github.com/slackhq/nebula/sshd/command.go:48 +0x86
Aug 31 13:59:21 mako4-app.b1-prv.qops.net nebula[16947]: github.com/slackhq/nebula/sshd.(*session).dispatchCommand(0xc0002e44e0, 0xc0000284c0, 0x11, 0xc0fb00, 0xc0002d8140)
Aug 31 13:59:21 mako4-app.b1-prv.qops.net nebula[16947]: github.com/slackhq/nebula/sshd/session.go:172 +0x22f
Aug 31 13:59:21 mako4-app.b1-prv.qops.net nebula[16947]: github.com/slackhq/nebula/sshd.(*session).handleInput(0xc0002e44e0, 0xc12860, 0xc0000fc000)
Aug 31 13:59:21 mako4-app.b1-prv.qops.net nebula[16947]: github.com/slackhq/nebula/sshd/session.go:136 +0xa9
Aug 31 13:59:21 mako4-app.b1-prv.qops.net nebula[16947]: created by github.com/slackhq/nebula/sshd.(*session).createTerm
Aug 31 13:59:21 mako4-app.b1-prv.qops.net nebula[16947]: github.com/slackhq/nebula/sshd/session.go:122 +0x228
Aug 31 13:59:21 mako4-app.b1-prv.qops.net systemd[1]: nebula.service: main process exited, code=exited, status=2/INVALIDARGUMENT
```


After the fix:
```
bluong@nebula > print-tunnel 10.0.3
The provided vpn ip could not be parsed: 10.0.3
bluong@nebula > print-cert hi
The provided vpn ip could not be parsed: hi
```