### PR TITLE
use a buffered channel for signal.Notify

### DIFF
--- a/control.go
+++ b/control.go
@@ -52,9 +52,8 @@ func (c *Control) Stop() {
 
 // ShutdownBlock will listen for and block on term and interrupt signals, calling Control.Stop() once signalled
 func (c *Control) ShutdownBlock() {
-	sigChan := make(chan os.Signal)
-	signal.Notify(sigChan, syscall.SIGTERM)
-	signal.Notify(sigChan, syscall.SIGINT)
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)
 
 	rawSig := <-sigChan
 	sig := rawSig.String()


### PR DESCRIPTION
To avoid missing signals, the channel should be buffered and of the appropriate size. 
For a channel used for notification of just one signal value, a buffer of size 1 is sufficient, as per https://golang.org/pkg/os/signal/#Notify