### PR TITLE
Added line to systemd config template to start Nebula before sshd

### DIFF
--- a/examples/service_scripts/nebula.service
+++ b/examples/service_scripts/nebula.service
@@ -2,6 +2,7 @@
 Description=nebula
 Wants=basic.target
 After=basic.target network.target
+Before=sshd.service
 
 [Service]
 SyslogIdentifier=nebula


### PR DESCRIPTION
During shutdown, this will keep Nebula alive until after sshd is finished. This cleanly terminates ssh clients accessing a server over a Nebula tunnel. h/t @nbrownus 

I tested this on Ubuntu 20.04.1 LTS and Raspbian GNU/Linux 10 (buster).