### PR TITLE
Lighthouse handler optimizations

### DIFF
--- a/lighthouse.go
+++ b/lighthouse.go
@@ -12,7 +12,7 @@ import (
 	"github.com/slackhq/nebula/cert"
 )
 
-var ErrQueryHostNotFound = errors.New("No host found")
+var ErrHostNotKnown = errors.New("host not known")
 
 type LightHouse struct {
 	sync.RWMutex //Because we concurrently read and write to our maps
@@ -116,7 +116,7 @@ func (lh *LightHouse) Query(ip uint32, f EncWriter) ([]udpAddr, error) {
 		return v, nil
 	}
 	lh.RUnlock()
-	return nil, ErrQueryHostNotFound
+	return nil, ErrHostNotKnown
 }
 
 // This is asynchronous so no reply should be expected
@@ -320,7 +320,7 @@ func (lhh *LightHouseHandler) resetMeta() *NebulaMeta {
 }
 
 func (lhh *LightHouseHandler) resetIpAndPorts(n int) []*IpAndPort {
-	if len(lhh.iap) < n {
+	if cap(lhh.iap) < n {
 		lhh.iap = make([]IpAndPort, n)
 		lhh.iapp = make([]*IpAndPort, n)
 

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -295,7 +295,7 @@ func (lh *LightHouse) NewRequestHandler() *LightHouseHandler {
 		},
 	}
 
-	lhh.resetIpAndPorts(10)
+	lhh.resizeIpAndPorts(10)
 
 	return lhh
 }
@@ -312,7 +312,7 @@ func (lhh *LightHouseHandler) resetMeta() *NebulaMeta {
 	return lhh.meta
 }
 
-func (lhh *LightHouseHandler) resetIpAndPorts(n int) []*IpAndPort {
+func (lhh *LightHouseHandler) resizeIpAndPorts(n int) {
 	if cap(lhh.iap) < n {
 		lhh.iap = make([]IpAndPort, n)
 		lhh.iapp = make([]*IpAndPort, n)
@@ -323,12 +323,10 @@ func (lhh *LightHouseHandler) resetIpAndPorts(n int) []*IpAndPort {
 	}
 	lhh.iap = lhh.iap[:n]
 	lhh.iapp = lhh.iapp[:n]
-
-	return lhh.iapp
 }
 
 func (lhh *LightHouseHandler) setIpAndPortsFromNetIps(ips []udpAddr) []*IpAndPort {
-	lhh.resetIpAndPorts(len(ips))
+	lhh.resizeIpAndPorts(len(ips))
 	for i, e := range ips {
 		lhh.iap[i] = NewIpAndPortFromUDPAddr(e)
 	}

--- a/lighthouse_test.go
+++ b/lighthouse_test.go
@@ -40,9 +40,15 @@ func TestSetipandportsfromudpaddrs(t *testing.T) {
 	blah := NewUDPAddrFromString("1.2.2.3:12345")
 	blah2 := NewUDPAddrFromString("9.9.9.9:47828")
 	group := []udpAddr{*blah, *blah2}
-	hah := make([]IpAndPort, len(group))
-	SetIpAndPortsFromNetIps(group, hah)
-	assert.IsType(t, []IpAndPort{}, hah)
+	var lh *LightHouse
+	lhh := lh.NewRequestHandler()
+	result := lhh.setIpAndPortsFromNetIps(group)
+	assert.IsType(t, []*IpAndPort{}, result)
+	assert.Len(t, result, 2)
+	assert.Equal(t, uint32(0x01020203), result[0].Ip)
+	assert.Equal(t, uint32(12345), result[0].Port)
+	assert.Equal(t, uint32(0x09090909), result[1].Ip)
+	assert.Equal(t, uint32(47828), result[1].Port)
 	//t.Error(reflect.TypeOf(hah))
 
 }

--- a/lighthouse_test.go
+++ b/lighthouse_test.go
@@ -85,6 +85,7 @@ func BenchmarkLighthouseHandleRequest(b *testing.B) {
 	mw := &mockEncWriter{}
 
 	b.Run("notfound", func(b *testing.B) {
+		lhh := lh.NewRequestHandler()
 		req := &NebulaMeta{
 			Type: NebulaMeta_HostQuery,
 			Details: &NebulaMetaDetails{
@@ -95,10 +96,11 @@ func BenchmarkLighthouseHandleRequest(b *testing.B) {
 		p, err := proto.Marshal(req)
 		assert.NoError(b, err)
 		for n := 0; n < b.N; n++ {
-			lh.HandleRequest(rAddr, 2, p, nil, mw)
+			lhh.HandleRequest(rAddr, 2, p, nil, mw)
 		}
 	})
 	b.Run("found", func(b *testing.B) {
+		lhh := lh.NewRequestHandler()
 		req := &NebulaMeta{
 			Type: NebulaMeta_HostQuery,
 			Details: &NebulaMetaDetails{
@@ -110,7 +112,7 @@ func BenchmarkLighthouseHandleRequest(b *testing.B) {
 		assert.NoError(b, err)
 
 		for n := 0; n < b.N; n++ {
-			lh.HandleRequest(rAddr, 2, p, nil, mw)
+			lhh.HandleRequest(rAddr, 2, p, nil, mw)
 		}
 	})
 }

--- a/lighthouse_test.go
+++ b/lighthouse_test.go
@@ -66,6 +66,55 @@ func Test_lhStaticMapping(t *testing.T) {
 	assert.EqualError(t, err, "Lighthouse 10.128.0.3 does not have a static_host_map entry")
 }
 
+func BenchmarkLighthouseHandleRequest(b *testing.B) {
+	lh1 := "10.128.0.2"
+	lh1IP := net.ParseIP(lh1)
+
+	udpServer, _ := NewListener("0.0.0.0", 0, true)
+
+	lh := NewLightHouse(true, 1, []uint32{ip2int(lh1IP)}, 10, 10003, udpServer, false, 1, false)
+
+	hAddr := NewUDPAddrFromString("4.5.6.7:12345")
+	hAddr2 := NewUDPAddrFromString("4.5.6.7:12346")
+	lh.addrMap[3] = []udpAddr{*hAddr, *hAddr2}
+
+	rAddr := NewUDPAddrFromString("1.2.2.3:12345")
+	rAddr2 := NewUDPAddrFromString("1.2.2.3:12346")
+	lh.addrMap[2] = []udpAddr{*rAddr, *rAddr2}
+
+	mw := &mockEncWriter{}
+
+	b.Run("notfound", func(b *testing.B) {
+		req := &NebulaMeta{
+			Type: NebulaMeta_HostQuery,
+			Details: &NebulaMetaDetails{
+				VpnIp:      4,
+				IpAndPorts: nil,
+			},
+		}
+		p, err := proto.Marshal(req)
+		assert.NoError(b, err)
+		for n := 0; n < b.N; n++ {
+			lh.HandleRequest(rAddr, 2, p, nil, mw)
+		}
+	})
+	b.Run("found", func(b *testing.B) {
+		req := &NebulaMeta{
+			Type: NebulaMeta_HostQuery,
+			Details: &NebulaMetaDetails{
+				VpnIp:      3,
+				IpAndPorts: nil,
+			},
+		}
+		p, err := proto.Marshal(req)
+		assert.NoError(b, err)
+
+		for n := 0; n < b.N; n++ {
+			lh.HandleRequest(rAddr, 2, p, nil, mw)
+		}
+	})
+}
+
 //func NewLightHouse(amLighthouse bool, myIp uint32, ips []string, interval int, nebulaPort int, pc *udpConn, punchBack bool) *LightHouse {
 
 /*

--- a/lighthouse_test.go
+++ b/lighthouse_test.go
@@ -36,12 +36,13 @@ func TestNewipandportfromudpaddr(t *testing.T) {
 	assert.Equal(t, uint32(12345), meh.Port)
 }
 
-func TestNewipandportsfromudpaddrs(t *testing.T) {
+func TestSetipandportsfromudpaddrs(t *testing.T) {
 	blah := NewUDPAddrFromString("1.2.2.3:12345")
 	blah2 := NewUDPAddrFromString("9.9.9.9:47828")
 	group := []udpAddr{*blah, *blah2}
-	hah := NewIpAndPortsFromNetIps(group)
-	assert.IsType(t, &[]*IpAndPort{}, hah)
+	hah := make([]IpAndPort, len(group))
+	SetIpAndPortsFromNetIps(group, hah)
+	assert.IsType(t, []IpAndPort{}, hah)
 	//t.Error(reflect.TypeOf(hah))
 
 }

--- a/outside.go
+++ b/outside.go
@@ -17,7 +17,7 @@ const (
 	minFwPacketLen = 4
 )
 
-func (f *Interface) readOutsidePackets(addr *udpAddr, out []byte, packet []byte, header *Header, fwPacket *FirewallPacket, nb []byte) {
+func (f *Interface) readOutsidePackets(addr *udpAddr, out []byte, packet []byte, header *Header, fwPacket *FirewallPacket, lhh *LightHouseHandler, nb []byte) {
 	err := header.Parse(packet)
 	if err != nil {
 		// TODO: best if we return this and let caller log
@@ -66,7 +66,7 @@ func (f *Interface) readOutsidePackets(addr *udpAddr, out []byte, packet []byte,
 			return
 		}
 
-		f.lightHouse.HandleRequest(addr, hostinfo.hostId, d, hostinfo.GetCert(), f)
+		lhh.HandleRequest(addr, hostinfo.hostId, d, hostinfo.GetCert(), f)
 
 		// Fallthrough to the bottom to record incoming traffic
 

--- a/udp_generic.go
+++ b/udp_generic.go
@@ -108,6 +108,8 @@ func (u *udpConn) ListenOut(f *Interface) {
 	udpAddr := &udpAddr{}
 	nb := make([]byte, 12, 12)
 
+	lhh := f.lightHouse.NewRequestHandler()
+
 	for {
 		// Just read one packet at a time
 		n, rua, err := u.ReadFromUDP(buffer)
@@ -117,7 +119,7 @@ func (u *udpConn) ListenOut(f *Interface) {
 		}
 
 		udpAddr.UDPAddr = *rua
-		f.readOutsidePackets(udpAddr, plaintext[:0], buffer[:n], header, fwPacket, nb)
+		f.readOutsidePackets(udpAddr, plaintext[:0], buffer[:n], header, fwPacket, lhh, nb)
 	}
 }
 

--- a/udp_linux.go
+++ b/udp_linux.go
@@ -146,6 +146,8 @@ func (u *udpConn) ListenOut(f *Interface) {
 	udpAddr := &udpAddr{}
 	nb := make([]byte, 12, 12)
 
+	lhh := f.lightHouse.NewRequestHandler()
+
 	//TODO: should we track this?
 	//metric := metrics.GetOrRegisterHistogram("test.batch_read", nil, metrics.NewExpDecaySample(1028, 0.015))
 	msgs, buffers, names := u.PrepareRawMessages(f.udpBatchSize)
@@ -166,7 +168,7 @@ func (u *udpConn) ListenOut(f *Interface) {
 			udpAddr.IP = binary.BigEndian.Uint32(names[i][4:8])
 			udpAddr.Port = binary.BigEndian.Uint16(names[i][2:4])
 
-			f.readOutsidePackets(udpAddr, plaintext[:0], buffers[i][:msgs[i].Len], header, fwPacket, nb)
+			f.readOutsidePackets(udpAddr, plaintext[:0], buffers[i][:msgs[i].Len], header, fwPacket, lhh, nb)
 		}
 	}
 }


### PR DESCRIPTION
We noticed that the number of memory allocations `LightHouse.HandleRequest` creates for each call can seriously impact performance for high traffic lighthouses. This PR introduces a benchmark in the first commit and then optimizes memory usage by creating a `LightHouseHandler` struct. This struct allows us to re-use memory between each lighthouse request (one instance per UDP listener go-routine).

Here is the comparison of before and after (`notfound` is that case that a query is made for a non-existent host. `found` is for the case that the host exists):

```
name                                old time/op    new time/op    delta
LighthouseHandleRequest/notfound-4     944ns ±11%     188ns ±15%   -80.07%
LighthouseHandleRequest/found-4       5.53µs ±40%    1.04µs ± 6%   -81.27%

name                                old alloc/op   new alloc/op   delta
LighthouseHandleRequest/notfound-4      264B ± 0%        0B       -100.00%
LighthouseHandleRequest/found-4       19.7kB ± 0%     0.1kB ± 0%   -99.68%

name                                old allocs/op  new allocs/op  delta
LighthouseHandleRequest/notfound-4      8.00 ± 0%      0.00       -100.00%
LighthouseHandleRequest/found-4         22.0 ± 0%       2.0 ± 0%   -90.91%
```

Thanks @forfuncsake and @psanford for the collaboration.