### PR TITLE
Delay opportunistic receive-side hole punching

### DIFF
--- a/hostmap.go
+++ b/hostmap.go
@@ -395,7 +395,8 @@ func (hm *HostMap) Punchy(conn *udpConn) {
 	for {
 		for _, addr := range hm.PunchList() {
 			metricsTxPunchy.Inc(1)
-			conn.WriteTo([]byte{1}, addr)
+			_ = addr
+			//conn.WriteTo([]byte{1}, addr)
 		}
 		time.Sleep(time.Second * 30)
 	}

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -379,11 +379,11 @@ func (lh *LightHouse) HandleRequest(rAddr *udpAddr, vpnIp uint32, p []byte, c *c
 		}
 	case NebulaMeta_HostMovedNotification:
 	case NebulaMeta_HostPunchNotification:
-		/*
-			if !lh.IsLighthouseIP(vpnIp) {
-				return
-			}
-
+		if !lh.IsLighthouseIP(vpnIp) {
+			return
+		}
+		go func() {
+			time.Sleep(time.Second * 2)
 			empty := []byte{0}
 			for _, a := range n.Details.IpAndPorts {
 				vpnPeer := NewUDPAddr(a.Ip, uint16(a.Port))
@@ -395,7 +395,8 @@ func (lh *LightHouse) HandleRequest(rAddr *udpAddr, vpnIp uint32, p []byte, c *c
 				}()
 				l.Debugf("Punching %s on %d for %s", IntIp(a.Ip), a.Port, IntIp(n.Details.VpnIp))
 			}
-		*/
+		}()
+
 		// This sends a nebula test packet to the host trying to contact us. In the case
 		// of a double nat or other difficult scenario, this may help establish
 		// a tunnel.

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -379,27 +379,29 @@ func (lh *LightHouse) HandleRequest(rAddr *udpAddr, vpnIp uint32, p []byte, c *c
 		}
 	case NebulaMeta_HostMovedNotification:
 	case NebulaMeta_HostPunchNotification:
-		if !lh.IsLighthouseIP(vpnIp) {
-			return
-		}
+		/*
+			if !lh.IsLighthouseIP(vpnIp) {
+				return
+			}
 
-		empty := []byte{0}
-		for _, a := range n.Details.IpAndPorts {
-			vpnPeer := NewUDPAddr(a.Ip, uint16(a.Port))
-			go func() {
-				time.Sleep(lh.punchDelay)
-				lh.metricHolepunchTx.Inc(1)
-				lh.punchConn.WriteTo(empty, vpnPeer)
+			empty := []byte{0}
+			for _, a := range n.Details.IpAndPorts {
+				vpnPeer := NewUDPAddr(a.Ip, uint16(a.Port))
+				go func() {
+					time.Sleep(lh.punchDelay)
+					lh.metricHolepunchTx.Inc(1)
+					lh.punchConn.WriteTo(empty, vpnPeer)
 
-			}()
-			l.Debugf("Punching %s on %d for %s", IntIp(a.Ip), a.Port, IntIp(n.Details.VpnIp))
-		}
+				}()
+				l.Debugf("Punching %s on %d for %s", IntIp(a.Ip), a.Port, IntIp(n.Details.VpnIp))
+			}
+		*/
 		// This sends a nebula test packet to the host trying to contact us. In the case
 		// of a double nat or other difficult scenario, this may help establish
 		// a tunnel.
 		if lh.punchBack {
 			go func() {
-				time.Sleep(time.Second * 5)
+				time.Sleep(time.Second * 2)
 				l.Debugf("Sending a nebula test packet to vpn ip %s", IntIp(n.Details.VpnIp))
 				f.SendMessageToVpnIp(test, testRequest, n.Details.VpnIp, []byte(""), make([]byte, 12, 12), make([]byte, mtu))
 			}()

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -383,6 +383,7 @@ func (lh *LightHouse) HandleRequest(rAddr *udpAddr, vpnIp uint32, p []byte, c *c
 		if !lh.IsLighthouseIP(vpnIp) {
 			return
 		}
+		// Start tracking hosts we are punching to and don't duplicate effort here anymore
 		go func() {
 			fi := lh.punchConn.sysFd
 			//time.Sleep(time.Second * 2)

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -393,6 +393,8 @@ func (lh *LightHouse) HandleRequest(rAddr *udpAddr, vpnIp uint32, p []byte, c *c
 				go func() {
 					time.Sleep(lh.punchDelay)
 					lh.metricHolepunchTx.Inc(1)
+					// If we can lock the socket just for hole punches, we can probably just reuse this
+					// instead of gopacket magic and/or reuseport/addr magic
 					syscall.SetsockoptInt(fi, 0x0, syscall.IP_TTL, 3)
 					lh.punchConn.WriteTo(empty, vpnPeer)
 					syscall.SetsockoptInt(fi, 0x0, syscall.IP_TTL, -1)

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -395,7 +395,7 @@ func (lh *LightHouse) HandleRequest(rAddr *udpAddr, vpnIp uint32, p []byte, c *c
 					lh.metricHolepunchTx.Inc(1)
 					// If we can lock the socket just for hole punches, we can probably just reuse this
 					// instead of gopacket magic and/or reuseport/addr magic
-					syscall.SetsockoptInt(fi, 0x0, syscall.IP_TTL, 3)
+					syscall.SetsockoptInt(fi, 0x0, syscall.IP_TTL, 5)
 					lh.punchConn.WriteTo(empty, vpnPeer)
 					syscall.SetsockoptInt(fi, 0x0, syscall.IP_TTL, -1)
 

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -387,7 +387,7 @@ func (lh *LightHouse) HandleRequest(rAddr *udpAddr, vpnIp uint32, p []byte, c *c
 		go func() {
 			fi := lh.punchConn.sysFd
 			//time.Sleep(time.Second * 2)
-			empty := []byte{0}
+			empty := []byte{0, 1, 2}
 			for _, a := range n.Details.IpAndPorts {
 				vpnPeer := NewUDPAddr(a.Ip, uint16(a.Port))
 				go func() {


### PR DESCRIPTION
*WIP* DO NOT MERGE

It turns out that the opportunistic hole punching confused the hell out of linux conntrack. There ended up being additional races in the conntrack table and they were sometimes unresolvable. This is a temporary improvement, and expect some more tweaks in the near term.

...now for the good news: Hole punching works extremely well now! If you have the stomach for it, I'd encourage you to try this branch and see if things are oh-so-much-better.

I'll write up a much more detailed breakdown of the intention of the original feature and the issues it caused to share with the community soon.