### PR TITLE
More validation in pending hostmap deletes

### DIFF
--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -181,11 +181,7 @@ func (c *HandshakeManager) NextInboundHandshakeTimerTick(now time.Time) {
 		}
 		index := ep.(uint32)
 
-		hostinfo, err := c.pendingHostMap.QueryIndex(index)
-		if err != nil {
-			continue
-		}
-		c.pendingHostMap.DeleteHostInfo(hostinfo)
+		c.pendingHostMap.DeleteIndex(index)
 	}
 }
 

--- a/outside.go
+++ b/outside.go
@@ -320,6 +320,9 @@ func (f *Interface) handleRecvError(addr *udpAddr, h *Header) {
 			Debug("Recv error received")
 	}
 
+	// First, clean up in the pending hostmap
+	f.handshakeManager.pendingHostMap.DeleteReverseIndex(h.RemoteIndex)
+
 	hostinfo, err := f.hostMap.QueryReverseIndex(h.RemoteIndex)
 	if err != nil {
 		l.Debugln(err, ": ", h.RemoteIndex)


### PR DESCRIPTION
We are currently seeing some cases where we are not deleting entries
correctly from the pending hostmap. I believe this is a case of
an inbound timer tick firing and deleting the Hosts map entry for
a newer handshake attempt than intended, thus leaving the Indexes
entry orphaned. This change adds some extra checking when deleteing from
the Indexes and Hosts maps to ensure we clean everything up correctly. With testing, we no longer are seeing a leak with pending hostmap indexes.