### PR TITLE
Including FreeBSD 12 rc.d service script

### DIFF
--- a/examples/service_scripts/nebula
+++ b/examples/service_scripts/nebula
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+. /etc/rc.subr
+
+name="nebula"
+rcvar="nebula_enable"
+
+load_rc_config $name
+
+: ${nebula_log_file:="/var/log/nebula.log"}
+: ${config:="/usr/local/etc/nebula/config.yml"}
+: ${pidfile:="/var/run/nebula.pid"}
+
+command="/usr/sbin/daemon"
+command_args="-c -f -o ${nebula_log_file} -P ${pidfile} -r /usr/local/sbin/nebula -config ${config}"
+
+run_rc_command "$1"


### PR DESCRIPTION
This PR implements a simple but clean FreeBSD 12 rc.d service script. It provides basic functionality for starting/stopping the service, including loading a custom nebula rc config (if any - defaults provided), log redirection, and passing the config parameter to the nebula process. There can probably be more things improved since this is my first FreeBSD rc.d script, but hopefully the more experienced FreeBSD Nebula users can further improve it.