### PR TITLE
Add DNS server support for PTR queries

### DIFF
--- a/dns_server.go
+++ b/dns_server.go
@@ -2,8 +2,10 @@ package nebula
 
 import (
 	"fmt"
+	"math/bits"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/miekg/dns"
@@ -57,6 +59,23 @@ func (d *dnsRecords) QueryCert(data string) string {
 	return c
 }
 
+func (d *dnsRecords) QueryPTR(data string) string {
+	ip := net.ParseIP(strings.TrimSuffix(data, ".in-addr.arpa.")).To4()
+	if ip == nil {
+		return ""
+	}
+	iip := bits.ReverseBytes32(ip2int(ip))
+	hostinfo, err := d.hostMap.QueryVpnIP(iip)
+	if err != nil {
+		return ""
+	}
+	q := hostinfo.GetCert()
+	if q == nil {
+		return ""
+	}
+	return q.Details.Name + "."
+}
+
 func (d *dnsRecords) Add(host, data string) {
 	d.Lock()
 	d.dnsMap[host] = data
@@ -87,6 +106,22 @@ func parseQuery(m *dns.Msg, w dns.ResponseWriter) {
 			ip := dnsR.QueryCert(q.Name)
 			if ip != "" {
 				rr, err := dns.NewRR(fmt.Sprintf("%s TXT %s", q.Name, ip))
+				if err == nil {
+					m.Answer = append(m.Answer, rr)
+				}
+			}
+		case dns.TypePTR:
+			a, _, _ := net.SplitHostPort(w.RemoteAddr().String())
+			b := net.ParseIP(a)
+			// We don't answer these queries from non nebula nodes or localhost
+			//l.Debugf("Does %s contain %s", b, dnsR.hostMap.vpnCIDR)
+			if !dnsR.hostMap.vpnCIDR.Contains(b) && a != "127.0.0.1" {
+				return
+			}
+			l.Debugf("Query for PTR %s", q.Name)
+			name := dnsR.QueryPTR(q.Name)
+			if name != "" {
+				rr, err := dns.NewRR(fmt.Sprintf("%s PTR %s", q.Name, name))
 				if err == nil {
 					m.Answer = append(m.Answer, rr)
 				}


### PR DESCRIPTION
The TXT implementation is lovely, so this adds PTR query support based on it. This is useful for IP-to-name in a more machine/standards-friendly way.