### PR TITLE
Proper multiqueue support for tun devices

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -86,13 +86,11 @@ listen:
   #read_buffer: 10485760
   #write_buffer: 10485760
 
+# EXPERIMENTAL
 # Routines is the number of thread pairs to run that consume from the tun and UDP queues.
 # Currently, this defaults to 1 which means we have 1 tun queue reader and 1
 # UDP queue reader. Setting this above one will set IFF_MULTI_QUEUE on the tun
 # device and SO_REUSEPORT on the UDP socket to allow multiple queues.
-#
-# You can also set this to 0 (or the special string "auto") to pick a good default for
-# the number of CPUs you have. The current logic is Max((NumCPU - 1) / 2, 1).
 #routines: 1
 
 punchy:

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -86,6 +86,15 @@ listen:
   #read_buffer: 10485760
   #write_buffer: 10485760
 
+# Routines is the number of thread pairs to run that consume from the tun and UDP queues.
+# Currently, this defaults to 1 which means we have 1 tun queue reader and 1
+# UDP queue reader. Setting this above one will set IFF_MULTI_QUEUE on the tun
+# device and SO_REUSEPORT on the UDP socket to allow multiple queues.
+#
+# You can also set this to the special string "auto" to pick a good default for
+# the number of CPUs you have. The current logic is (NumCPU - 1) / 2.
+#routines: 1
+
 punchy:
   # Continues to punch inbound/outbound at a regular interval to avoid expiration of firewall nat mappings
   punch: true

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -91,8 +91,8 @@ listen:
 # UDP queue reader. Setting this above one will set IFF_MULTI_QUEUE on the tun
 # device and SO_REUSEPORT on the UDP socket to allow multiple queues.
 #
-# You can also set this to the special string "auto" to pick a good default for
-# the number of CPUs you have. The current logic is (NumCPU - 1) / 2.
+# You can also set this to 0 (or the special string "auto") to pick a good default for
+# the number of CPUs you have. The current logic is Max((NumCPU - 1) / 2, 1).
 #routines: 1
 
 punchy:

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -86,7 +86,9 @@ listen:
   #read_buffer: 10485760
   #write_buffer: 10485760
 
-# EXPERIMENTAL
+# EXPERIMENTAL: This option is currently only supported on linux and may
+# change in future minor releases.
+#
 # Routines is the number of thread pairs to run that consume from the tun and UDP queues.
 # Currently, this defaults to 1 which means we have 1 tun queue reader and 1
 # UDP queue reader. Setting this above one will set IFF_MULTI_QUEUE on the tun

--- a/interface.go
+++ b/interface.go
@@ -114,9 +114,7 @@ func NewInterface(c *InterfaceConfig) (*Interface, error) {
 
 func (f *Interface) run() {
 	// actually turn on tun dev
-	if err := f.inside.Activate(); err != nil {
-		l.Fatal(err)
-	}
+
 
 	addr, err := f.outside.LocalAddr()
 	if err != nil {
@@ -142,6 +140,10 @@ func (f *Interface) run() {
 			}
 		}
 		go f.listenIn(reader, i)
+	}
+
+	if err := f.inside.Activate(); err != nil {
+		l.Fatal(err)
 	}
 }
 

--- a/interface.go
+++ b/interface.go
@@ -102,8 +102,8 @@ func NewInterface(c *InterfaceConfig) (*Interface, error) {
 		udpQueues:          c.udpQueues,
 		tunQueues:          c.tunQueues,
 		version:            c.version,
-		writers: make([]*udpConn, c.udpQueues),
-		readers: make([]io.ReadWriteCloser, c.tunQueues),
+		writers:            make([]*udpConn, c.udpQueues),
+		readers:            make([]io.ReadWriteCloser, c.tunQueues),
 
 		metricHandshakes: metrics.GetOrRegisterHistogram("handshakes", nil, metrics.NewExpDecaySample(1028, 0.015)),
 		messageMetrics:   c.MessageMetrics,
@@ -116,7 +116,6 @@ func NewInterface(c *InterfaceConfig) (*Interface, error) {
 
 func (f *Interface) run() {
 	// actually turn on tun dev
-
 
 	addr, err := f.outside.LocalAddr()
 	if err != nil {

--- a/interface.go
+++ b/interface.go
@@ -123,6 +123,8 @@ func (f *Interface) run() {
 		WithField("build", f.version).WithField("udpAddr", addr).
 		Info("Nebula interface is active")
 
+	metrics.GetOrRegisterGauge("routines", nil).Update(int64(f.routines))
+
 	// Launch n queues to read packets from udp
 	for i := 0; i < f.routines; i++ {
 		go f.listenOut(i)

--- a/interface.go
+++ b/interface.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/rcrowley/go-metrics"
@@ -142,6 +143,8 @@ func (f *Interface) run() {
 }
 
 func (f *Interface) listenOut(i int) {
+	runtime.LockOSThread()
+
 	//TODO: handle error
 	addr, err := f.outside.LocalAddr()
 	if err != nil {
@@ -163,6 +166,8 @@ func (f *Interface) listenOut(i int) {
 }
 
 func (f *Interface) listenIn(reader io.ReadWriteCloser, i int) {
+	runtime.LockOSThread()
+
 	packet := make([]byte, mtu)
 	out := make([]byte, mtu)
 	fwPacket := &FirewallPacket{}

--- a/interface.go
+++ b/interface.go
@@ -101,7 +101,7 @@ func NewInterface(c *InterfaceConfig) (*Interface, error) {
 		udpQueues:          c.udpQueues,
 		tunQueues:          c.tunQueues,
 		version:            c.version,
-		writers: []*udpConn{},
+		writers: make([]*udpConn, c.udpQueues),
 
 		metricHandshakes: metrics.GetOrRegisterHistogram("handshakes", nil, metrics.NewExpDecaySample(1028, 0.015)),
 		messageMetrics:   c.MessageMetrics,

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -97,16 +96,7 @@ func Main(config *Config, configTest bool, buildVersion string, logger *logrus.L
 	var routines int
 
 	// If `routines` is set, use that and ignore the specific values
-	if routinesString := config.GetString("routines", ""); routinesString != "" {
-		if routinesString == "auto" {
-			routines = 0
-		} else {
-			routines = config.GetInt("routines", 1)
-		}
-
-		if routines == 0 {
-			routines = (runtime.NumCPU() - 1) / 2
-		}
+	if routines = config.GetInt("routines", 0); routines != 0 {
 		if routines < 1 {
 			routines = 1
 		}
@@ -114,6 +104,7 @@ func Main(config *Config, configTest bool, buildVersion string, logger *logrus.L
 			l.WithField("routines", routines).Info("using multiple routines")
 		}
 	} else {
+		// deprecated and undocumented
 		tunQueues := config.GetInt("tun.routines", 1)
 		udpQueues := config.GetInt("listen.routines", 1)
 		if tunQueues > udpQueues {

--- a/main.go
+++ b/main.go
@@ -93,6 +93,8 @@ func Main(config *Config, configTest bool, buildVersion string, logger *logrus.L
 	// tun config, listeners, anything modifying the computer should be below
 	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+	tunQueues := config.GetInt("tun.routines", 1)
+
 	var tun Inside
 	if !configTest {
 		config.CatchHUP()
@@ -117,6 +119,7 @@ func Main(config *Config, configTest bool, buildVersion string, logger *logrus.L
 				routes,
 				unsafeRoutes,
 				config.GetInt("tun.tx_queue", 500),
+				tunQueues > 1,
 			)
 		}
 
@@ -330,7 +333,7 @@ func Main(config *Config, configTest bool, buildVersion string, logger *logrus.L
 		DropMulticast:           config.GetBool("tun.drop_multicast", false),
 		UDPBatchSize:            config.GetInt("listen.batch", 64),
 		udpQueues:               udpQueues,
-		tunQueues:               config.GetInt("tun.routines", 1),
+		tunQueues:               tunQueues,
 		MessageMetrics:          messageMetrics,
 		version:                 buildVersion,
 	}

--- a/main.go
+++ b/main.go
@@ -101,7 +101,7 @@ func Main(config *Config, configTest bool, buildVersion string, logger *logrus.L
 			routines = 1
 		}
 		if routines > 1 {
-			l.WithField("routines", routines).Info("using multiple routines")
+			l.WithField("routines", routines).Info("Using multiple routines")
 		}
 	} else {
 		// deprecated and undocumented
@@ -113,7 +113,7 @@ func Main(config *Config, configTest bool, buildVersion string, logger *logrus.L
 			routines = udpQueues
 		}
 		if routines != 1 {
-			l.WithField("routines", routines).Warn("setting tun.routines and listen.routines is deprecated. use `routines` instead.")
+			l.WithField("routines", routines).Warn("Setting tun.routines and listen.routines is deprecated. Use `routines` instead")
 		}
 	}
 

--- a/tun_android.go
+++ b/tun_android.go
@@ -37,7 +37,7 @@ func newTunFromFd(deviceFd int, cidr *net.IPNet, defaultMTU int, routes []route,
 	return
 }
 
-func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, unsafeRoutes []route, txQueueLen int) (ifce *Tun, err error) {
+func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, unsafeRoutes []route, txQueueLen int, multiqueue bool) (ifce *Tun, err error) {
 	return nil, fmt.Errorf("newTun not supported in Android")
 }
 

--- a/tun_android.go
+++ b/tun_android.go
@@ -74,3 +74,7 @@ func (c *Tun) CidrNet() *net.IPNet {
 func (c *Tun) DeviceName() string {
 	return c.Device
 }
+
+func (t *Tun) NewMultiQueueReader() (io.ReadWriteCloser, error) {
+	return nil, fmt.Errorf("TODO: multiqueue not implemented for android")
+}

--- a/tun_darwin.go
+++ b/tun_darwin.go
@@ -21,7 +21,7 @@ type Tun struct {
 	*water.Interface
 }
 
-func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, unsafeRoutes []route, txQueueLen int) (ifce *Tun, err error) {
+func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, unsafeRoutes []route, txQueueLen int, multiqueue bool) (ifce *Tun, err error) {
 	if len(routes) > 0 {
 		return nil, fmt.Errorf("route MTU not supported in Darwin")
 	}

--- a/tun_darwin.go
+++ b/tun_darwin.go
@@ -4,6 +4,7 @@ package nebula
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"os/exec"
 	"strconv"
@@ -79,4 +80,8 @@ func (c *Tun) DeviceName() string {
 func (c *Tun) WriteRaw(b []byte) error {
 	_, err := c.Write(b)
 	return err
+}
+
+func (t *Tun) NewMultiQueueReader() (io.ReadWriteCloser, error) {
+	return nil, fmt.Errorf("TODO: multiqueue not implemented for darwin")
 }

--- a/tun_disabled.go
+++ b/tun_disabled.go
@@ -50,6 +50,10 @@ func (t *disabledTun) WriteRaw(b []byte) error {
 	return err
 }
 
+func (t *disabledTun) NewMultiQueueReader() (io.ReadWriteCloser, error) {
+	return t, nil
+}
+
 func (t *disabledTun) Close() error {
 	if t.block != nil {
 		close(t.block)

--- a/tun_freebsd.go
+++ b/tun_freebsd.go
@@ -87,3 +87,7 @@ func (c *Tun) WriteRaw(b []byte) error {
 	_, err := c.Write(b)
 	return err
 }
+
+func (t *Tun) NewMultiQueueReader() (io.ReadWriteCloser, error) {
+	return nil, fmt.Errorf("TODO: multiqueue not implemented for freebsd")
+}

--- a/tun_freebsd.go
+++ b/tun_freebsd.go
@@ -26,7 +26,7 @@ func newTunFromFd(deviceFd int, cidr *net.IPNet, defaultMTU int, routes []route,
 	return nil, fmt.Errorf("newTunFromFd not supported in FreeBSD")
 }
 
-func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, unsafeRoutes []route, txQueueLen int) (ifce *Tun, err error) {
+func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, unsafeRoutes []route, txQueueLen int, multiqueue bool) (ifce *Tun, err error) {
 	if len(routes) > 0 {
 		return nil, fmt.Errorf("Route MTU not supported in FreeBSD")
 	}

--- a/tun_ios.go
+++ b/tun_ios.go
@@ -18,7 +18,7 @@ type Tun struct {
 	Cidr   *net.IPNet
 }
 
-func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, unsafeRoutes []route, txQueueLen int) (ifce *Tun, err error) {
+func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, unsafeRoutes []route, txQueueLen int, multiqueue bool) (ifce *Tun, err error) {
 	return nil, fmt.Errorf("newTun not supported in iOS")
 }
 

--- a/tun_ios.go
+++ b/tun_ios.go
@@ -111,3 +111,7 @@ func (c *Tun) CidrNet() *net.IPNet {
 func (c *Tun) DeviceName() string {
 	return c.Device
 }
+
+func (t *Tun) NewMultiQueueReader() (io.ReadWriteCloser, error) {
+	return nil, fmt.Errorf("TODO: multiqueue not implemented for ios")
+}

--- a/tun_linux.go
+++ b/tun_linux.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net"
 	"os"
-	"strings"
 	"unsafe"
 
 	"github.com/vishvananda/netlink"
@@ -104,13 +103,13 @@ func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, 
 	var req ifReq
 	req.Flags = uint16(cIFF_TUN | cIFF_NO_PI)
 	if multiqueue {
+		l.Error("SETTING MULTI")
 		req.Flags |= cIFF_MULTI_QUEUE
 	}
 	copy(req.Name[:], deviceName)
 	if err = ioctl(uintptr(fd), uintptr(unix.TUNSETIFF), uintptr(unsafe.Pointer(&req))); err != nil {
 		return nil, err
 	}
-	name := strings.Trim(string(req.Name[:]), "\x00")
 
 	file := os.NewFile(uintptr(fd), "/dev/net/tun")
 
@@ -124,7 +123,7 @@ func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, 
 	ifce = &Tun{
 		ReadWriteCloser: file,
 		fd:              int(file.Fd()),
-		Device:          name,
+		Device:          deviceName,
 		Cidr:            cidr,
 		MaxMTU:          maxMTU,
 		DefaultMTU:      defaultMTU,

--- a/tun_linux.go
+++ b/tun_linux.go
@@ -174,6 +174,11 @@ func (c *Tun) WriteRaw(b []byte) error {
 	}
 }
 
+func (c *Tun) Write(b []byte) (int, error) {
+	c.WriteRaw(b)
+	return len(b), nil
+}
+
 func (c Tun) deviceBytes() (o [16]byte) {
 	for i, c := range c.Device {
 		o[i] = byte(c)

--- a/tun_windows.go
+++ b/tun_windows.go
@@ -2,6 +2,7 @@ package nebula
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"os/exec"
 	"strconv"
@@ -99,4 +100,8 @@ func (c *Tun) DeviceName() string {
 func (c *Tun) WriteRaw(b []byte) error {
 	_, err := c.Write(b)
 	return err
+}
+
+func (t *Tun) NewMultiQueueReader() (io.ReadWriteCloser, error) {
+	return nil, fmt.Errorf("TODO: multiqueue not implemented for windows")
 }

--- a/tun_windows.go
+++ b/tun_windows.go
@@ -23,7 +23,7 @@ func newTunFromFd(deviceFd int, cidr *net.IPNet, defaultMTU int, routes []route,
 	return nil, fmt.Errorf("newTunFromFd not supported in Windows")
 }
 
-func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, unsafeRoutes []route, txQueueLen int) (ifce *Tun, err error) {
+func newTun(deviceName string, cidr *net.IPNet, defaultMTU int, routes []route, unsafeRoutes []route, txQueueLen int, multiqueue bool) (ifce *Tun, err error) {
 	if len(routes) > 0 {
 		return nil, fmt.Errorf("route MTU not supported in Windows")
 	}

--- a/udp_generic.go
+++ b/udp_generic.go
@@ -100,7 +100,7 @@ type rawMessage struct {
 	Len uint32
 }
 
-func (u *udpConn) ListenOut(f *Interface) {
+func (u *udpConn) ListenOut(f *Interface, q int) {
 	plaintext := make([]byte, mtu)
 	buffer := make([]byte, mtu)
 	header := &Header{}
@@ -119,7 +119,7 @@ func (u *udpConn) ListenOut(f *Interface) {
 		}
 
 		udpAddr.UDPAddr = *rua
-		f.readOutsidePackets(udpAddr, plaintext[:0], buffer[:n], header, fwPacket, lhh, nb)
+		f.readOutsidePackets(udpAddr, plaintext[:0], buffer[:n], header, fwPacket, lhh, nb, q)
 	}
 }
 

--- a/udp_linux.go
+++ b/udp_linux.go
@@ -139,7 +139,7 @@ func (u *udpConn) LocalAddr() (*udpAddr, error) {
 	return addr, nil
 }
 
-func (u *udpConn) ListenOut(f *Interface) {
+func (u *udpConn) ListenOut(f *Interface, q int) {
 	plaintext := make([]byte, mtu)
 	header := &Header{}
 	fwPacket := &FirewallPacket{}
@@ -168,7 +168,7 @@ func (u *udpConn) ListenOut(f *Interface) {
 			udpAddr.IP = binary.BigEndian.Uint32(names[i][4:8])
 			udpAddr.Port = binary.BigEndian.Uint16(names[i][2:4])
 
-			f.readOutsidePackets(udpAddr, plaintext[:0], buffers[i][:msgs[i].Len], header, fwPacket, lhh, nb)
+			f.readOutsidePackets(udpAddr, plaintext[:0], buffers[i][:msgs[i].Len], header, fwPacket, lhh, nb, q)
 		}
 	}
 }


### PR DESCRIPTION
This change is for Linux only.

Previously, when running with multiple `tun.routines`, we would only have one file descriptor. This change instead sets IFF_MULTI_QUEUE and opens a file descriptor for each routine. This allows us to process with multiple threads while preventing out of order packet reception issues.

To attempt to distribute the flows across the queues, we try to write to the tun/UDP queue that corresponds with the one we read from. So if we read a packet from tun queue "2", we will write the outgoing encrypted packet to UDP queue "2". Because of the nature of how multi queue works with flows, a given host tunnel will be sticky to a given routine (so if you try to performance benchmark by only using one tunnel between two hosts, you are only going to be using a max of one thread for each direction).

Because this system works much better when we can correlate flows between the tun and udp routines, we are deprecating the undocumented "tun.routines" and "listen.routines" parameters and introducing a new "routines" parameter that sets the value for both. If you use the old undocumented parameters, the max of the values will be used and a warning logged.

Co-author: @nbrownus 