### PR TITLE
Add a check in the makefile to ensure a minimum version of go is installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,15 @@
+GOMINVERSION = 1.16
 NEBULA_CMD_PATH = "./cmd/nebula"
 BUILD_NUMBER ?= dev+$(shell date -u '+%Y%m%d%H%M%S')
 GO111MODULE = on
 export GO111MODULE
+
+# Ensure the version of go we are using is at least what is defined in GOMINVERSION at the top of this file
+GOVERSION := $(shell go version | awk '{print substr($$3, 3)}')
+GOISMIN := $(shell expr "$(GOVERSION)" ">=" "$(GOMINVERSION)")
+ifneq "$(GOISMIN)" "1"
+$(error "go version $(GOVERSION) is not supported, upgrade to $(GOMINVERSION) or above")
+endif
 
 LDFLAGS = -X main.Build=$(BUILD_NUMBER)
 
@@ -23,6 +31,8 @@ ALL = $(ALL_LINUX) \
 	darwin-arm64 \
 	freebsd-amd64 \
 	windows-amd64
+
+
 
 all: $(ALL:%=build/%/nebula) $(ALL:%=build/%/nebula-cert)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/slackhq/nebula
 
-go 1.12
+go 1.16
 
 require (
 	github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239


### PR DESCRIPTION
This adds a check to the `Makefile` that informs folks that are trying to build nebula if they are using a version of go that is inappropriate.

I'm no `make` expert but this is working on OSX (gnu make 3.81) and Linux (gnu make 4.3)