### PR TITLE
Increase MaxRemotes and warn if reaching that limit

### DIFF
--- a/hostmap.go
+++ b/hostmap.go
@@ -15,7 +15,7 @@ import (
 
 //const ProbeLen = 100
 const PromoteEvery = 1000
-const MaxRemotes = 10
+const MaxRemotes = 25
 
 // How long we should prevent roaming back to the previous IP.
 // This helps prevent flapping due to packets already in flight
@@ -627,6 +627,7 @@ func (i *HostInfo) AddRemote(r udpAddr) *udpAddr {
 	}
 	// Trim this down if necessary
 	if len(i.Remotes) > MaxRemotes {
+		l.WithField("delRemote", i.Remotes[0].addr).Warn("Reached MaxRemotes; skipping first entry")
 		i.Remotes = i.Remotes[len(i.Remotes)-MaxRemotes:]
 	}
 	i.Remotes = append(i.Remotes, NewHostInfoDest(remote))


### PR DESCRIPTION
While running nebula on a docker host (which dozens of host ips as you might guess) we ran into the issue that the MaxRemotes of 10 weren't enough.
As we wanted to be at least warned in that case (as it would have reduced our debugging time enormously) I added a log as well so people may find it in their logs if a host reports more than MaxRemotes hosts to the lighthouse.

Alternative approach:
Add a Filter in addRemotes to only include an entry in Remotes if it may be addressed via preferred_range or isPrivate (optionally only in case we are reaching the limit)