### PR TITLE
add metrics for the udp sockets using SO_MEMINFO 

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -290,12 +290,10 @@ func (f *Interface) emitStats(i time.Duration) {
 		f.firewall.EmitStats()
 		f.handshakeManager.EmitStats()
 
-		if udpGauges != nil {
-			for i, w := range f.writers {
-				if err := w.getMemInfo(&meminfo); err == nil {
-					for j := 0; j < _SK_MEMINFO_VARS; j++ {
-						udpGauges[i][j].Update(int64(meminfo[j]))
-					}
+		for i, gauges := range udpGauges {
+			if err := f.writers[i].getMemInfo(&meminfo); err == nil {
+				for j := 0; j < _SK_MEMINFO_VARS; j++ {
+					gauges[j].Update(int64(meminfo[j]))
 				}
 			}
 		}

--- a/udp_generic.go
+++ b/udp_generic.go
@@ -96,6 +96,11 @@ func (u *udpConn) reloadConfig(c *Config) {
 	// TODO
 }
 
+func NewUDPStatsEmitter(udpConns []*udpConn) func() {
+	// No UDP stats for non-linux
+	return func() {}
+}
+
 type rawMessage struct {
 	Len uint32
 }


### PR DESCRIPTION
Retrieve the current socket stats using SO_MEMINFO and report them as
metrics gauges. When running with multiqueue, we sum the values
together. If SO_MEMINFO isn't supported, we don't report these metrics.