### PR TITLE
Routine-local conntrack cache

### DIFF
--- a/firewall.go
+++ b/firewall.go
@@ -971,8 +971,10 @@ func (c *ConntrackCache) Get() map[FirewallPacket]struct{} {
 	if tick := atomic.LoadUint64(&c.cacheTick); tick != c.cacheV {
 		c.cacheV = tick
 		if ll := len(c.Cache); ll > 0 {
-			l.WithField("len", ll).Info("resetting conntrack cache")
-			c.Cache = make(map[FirewallPacket]struct{}, len(c.Cache))
+			if l.GetLevel() == logrus.DebugLevel {
+				l.WithField("len", ll).Debug("resetting conntrack cache")
+			}
+			c.Cache = make(map[FirewallPacket]struct{}, ll)
 		}
 	}
 

--- a/inside.go
+++ b/inside.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (f *Interface) consumeInsidePacket(packet []byte, fwPacket *FirewallPacket, nb, out []byte, q int, localCache map[FirewallPacket]struct{}) {
+func (f *Interface) consumeInsidePacket(packet []byte, fwPacket *FirewallPacket, nb, out []byte, q int, localCache ConntrackCache) {
 	err := newPacket(packet, false, fwPacket)
 	if err != nil {
 		l.WithField("packet", packet).Debugf("Error while validating outbound packet: %s", err)

--- a/interface.go
+++ b/interface.go
@@ -182,9 +182,7 @@ func (f *Interface) listenIn(reader io.ReadWriteCloser, i int) {
 			os.Exit(2)
 		}
 
-		conntrackCache.CheckTick()
-
-		f.consumeInsidePacket(packet[:n], fwPacket, nb, out, i, conntrackCache.Cache)
+		f.consumeInsidePacket(packet[:n], fwPacket, nb, out, i, conntrackCache.Get())
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -120,13 +120,13 @@ func Main(config *Config, configTest bool, buildVersion string, logger *logrus.L
 	// EXPERIMENTAL
 	// Intentionally not documented yet while we do more testing and determine
 	// a good default value.
-	conntrackCache := config.GetDuration("firewall.conntrack.routine_cache", 0)
-	if routines > 1 && !config.IsSet("firewall.conntrack.routine_cache") {
+	conntrackCacheTimeout := config.GetDuration("firewall.conntrack.routine_cache_timeout", 0)
+	if routines > 1 && !config.IsSet("firewall.conntrack.routine_cache_timeout") {
 		// Use a different default if we are running with multiple routines
-		conntrackCache = 1 * time.Second
+		conntrackCacheTimeout = 1 * time.Second
 	}
-	if conntrackCache > 0 {
-		l.WithField("duration", conntrackCache).Info("Using routine-local conntrack cache")
+	if conntrackCacheTimeout > 0 {
+		l.WithField("duration", conntrackCacheTimeout).Info("Using routine-local conntrack cache")
 	}
 
 	var tun Inside
@@ -369,9 +369,10 @@ func Main(config *Config, configTest bool, buildVersion string, logger *logrus.L
 		DropMulticast:           config.GetBool("tun.drop_multicast", false),
 		UDPBatchSize:            config.GetInt("listen.batch", 64),
 		routines:                routines,
-		ConntrackCache:          conntrackCache,
 		MessageMetrics:          messageMetrics,
 		version:                 buildVersion,
+
+		ConntrackCacheTimeout: conntrackCacheTimeout,
 	}
 
 	switch ifConfig.Cipher {

--- a/main.go
+++ b/main.go
@@ -117,6 +117,12 @@ func Main(config *Config, configTest bool, buildVersion string, logger *logrus.L
 		}
 	}
 
+	conntrackCache := config.GetDuration("firewall.conntrack.routine_cache", 0)
+	if routines > 1 && conntrackCache == 0 {
+		// Use a different default if we are running with multiple routines
+		conntrackCache = 1 * time.Second
+	}
+
 	var tun Inside
 	if !configTest {
 		config.CatchHUP()
@@ -357,6 +363,7 @@ func Main(config *Config, configTest bool, buildVersion string, logger *logrus.L
 		DropMulticast:           config.GetBool("tun.drop_multicast", false),
 		UDPBatchSize:            config.GetInt("listen.batch", 64),
 		routines:                routines,
+		ConntrackCache:          conntrackCache,
 		MessageMetrics:          messageMetrics,
 		version:                 buildVersion,
 	}

--- a/main.go
+++ b/main.go
@@ -117,10 +117,16 @@ func Main(config *Config, configTest bool, buildVersion string, logger *logrus.L
 		}
 	}
 
+	// EXPERIMENTAL
+	// Intentionally not documented yet while we do more testing and determine
+	// a good default value.
 	conntrackCache := config.GetDuration("firewall.conntrack.routine_cache", 0)
-	if routines > 1 && conntrackCache == 0 {
+	if routines > 1 && !config.IsSet("firewall.conntrack.routine_cache") {
 		// Use a different default if we are running with multiple routines
 		conntrackCache = 1 * time.Second
+	}
+	if conntrackCache > 0 {
+		l.WithField("duration", conntrackCache).Info("Using routine-local conntrack cache")
 	}
 
 	var tun Inside

--- a/outside.go
+++ b/outside.go
@@ -17,7 +17,7 @@ const (
 	minFwPacketLen = 4
 )
 
-func (f *Interface) readOutsidePackets(addr *udpAddr, out []byte, packet []byte, header *Header, fwPacket *FirewallPacket, lhh *LightHouseHandler, nb []byte, q int) {
+func (f *Interface) readOutsidePackets(addr *udpAddr, out []byte, packet []byte, header *Header, fwPacket *FirewallPacket, lhh *LightHouseHandler, nb []byte, q int, localCache map[FirewallPacket]struct{}) {
 	err := header.Parse(packet)
 	if err != nil {
 		// TODO: best if we return this and let caller log
@@ -45,7 +45,7 @@ func (f *Interface) readOutsidePackets(addr *udpAddr, out []byte, packet []byte,
 			return
 		}
 
-		f.decryptToTun(hostinfo, header.MessageCounter, out, packet, fwPacket, nb, q)
+		f.decryptToTun(hostinfo, header.MessageCounter, out, packet, fwPacket, nb, q, localCache)
 
 		// Fallthrough to the bottom to record incoming traffic
 
@@ -257,7 +257,7 @@ func (f *Interface) decrypt(hostinfo *HostInfo, mc uint64, out []byte, packet []
 	return out, nil
 }
 
-func (f *Interface) decryptToTun(hostinfo *HostInfo, messageCounter uint64, out []byte, packet []byte, fwPacket *FirewallPacket, nb []byte, q int) {
+func (f *Interface) decryptToTun(hostinfo *HostInfo, messageCounter uint64, out []byte, packet []byte, fwPacket *FirewallPacket, nb []byte, q int, localCache map[FirewallPacket]struct{}) {
 	var err error
 
 	out, err = hostinfo.ConnectionState.dKey.DecryptDanger(out, packet[:HeaderLen], packet[HeaderLen:], messageCounter, nb)
@@ -281,7 +281,7 @@ func (f *Interface) decryptToTun(hostinfo *HostInfo, messageCounter uint64, out 
 		return
 	}
 
-	dropReason := f.firewall.Drop(out, *fwPacket, true, hostinfo, trustedCAs)
+	dropReason := f.firewall.Drop(out, *fwPacket, true, hostinfo, trustedCAs, localCache)
 	if dropReason != nil {
 		if l.Level >= logrus.DebugLevel {
 			hostinfo.logger().WithField("fwPacket", fwPacket).

--- a/outside.go
+++ b/outside.go
@@ -17,7 +17,7 @@ const (
 	minFwPacketLen = 4
 )
 
-func (f *Interface) readOutsidePackets(addr *udpAddr, out []byte, packet []byte, header *Header, fwPacket *FirewallPacket, lhh *LightHouseHandler, nb []byte, q int, localCache map[FirewallPacket]struct{}) {
+func (f *Interface) readOutsidePackets(addr *udpAddr, out []byte, packet []byte, header *Header, fwPacket *FirewallPacket, lhh *LightHouseHandler, nb []byte, q int, localCache ConntrackCache) {
 	err := header.Parse(packet)
 	if err != nil {
 		// TODO: best if we return this and let caller log
@@ -257,7 +257,7 @@ func (f *Interface) decrypt(hostinfo *HostInfo, mc uint64, out []byte, packet []
 	return out, nil
 }
 
-func (f *Interface) decryptToTun(hostinfo *HostInfo, messageCounter uint64, out []byte, packet []byte, fwPacket *FirewallPacket, nb []byte, q int, localCache map[FirewallPacket]struct{}) {
+func (f *Interface) decryptToTun(hostinfo *HostInfo, messageCounter uint64, out []byte, packet []byte, fwPacket *FirewallPacket, nb []byte, q int, localCache ConntrackCache) {
 	var err error
 
 	out, err = hostinfo.ConnectionState.dKey.DecryptDanger(out, packet[:HeaderLen], packet[HeaderLen:], messageCounter, nb)

--- a/udp_generic.go
+++ b/udp_generic.go
@@ -119,7 +119,7 @@ func (u *udpConn) ListenOut(f *Interface, q int) {
 		}
 
 		udpAddr.UDPAddr = *rua
-		f.readOutsidePackets(udpAddr, plaintext[:0], buffer[:n], header, fwPacket, lhh, nb, q)
+		f.readOutsidePackets(udpAddr, plaintext[:0], buffer[:n], header, fwPacket, lhh, nb, q, nil)
 	}
 }
 

--- a/udp_generic.go
+++ b/udp_generic.go
@@ -110,7 +110,7 @@ func (u *udpConn) ListenOut(f *Interface, q int) {
 
 	lhh := f.lightHouse.NewRequestHandler()
 
-	conntrackCache := NewConntrackCache(f.conntrackCache)
+	conntrackCache := NewConntrackCacheTicker(f.conntrackCacheTimeout)
 
 	for {
 		// Just read one packet at a time

--- a/udp_generic.go
+++ b/udp_generic.go
@@ -110,6 +110,8 @@ func (u *udpConn) ListenOut(f *Interface, q int) {
 
 	lhh := f.lightHouse.NewRequestHandler()
 
+	conntrackCache := NewConntrackCache(f.conntrackCache)
+
 	for {
 		// Just read one packet at a time
 		n, rua, err := u.ReadFromUDP(buffer)
@@ -119,7 +121,7 @@ func (u *udpConn) ListenOut(f *Interface, q int) {
 		}
 
 		udpAddr.UDPAddr = *rua
-		f.readOutsidePackets(udpAddr, plaintext[:0], buffer[:n], header, fwPacket, lhh, nb, q, nil)
+		f.readOutsidePackets(udpAddr, plaintext[:0], buffer[:n], header, fwPacket, lhh, nb, q, conntrackCache.Get())
 	}
 }
 

--- a/udp_linux.go
+++ b/udp_linux.go
@@ -156,7 +156,7 @@ func (u *udpConn) ListenOut(f *Interface, q int) {
 		read = u.ReadSingle
 	}
 
-	conntrackCache := NewConntrackCache(f.conntrackCache)
+	conntrackCache := NewConntrackCacheTicker(f.conntrackCacheTimeout)
 
 	for {
 		n, err := read(msgs)

--- a/udp_linux.go
+++ b/udp_linux.go
@@ -9,9 +9,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"syscall"
-	"time"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -158,16 +156,7 @@ func (u *udpConn) ListenOut(f *Interface, q int) {
 		read = u.ReadSingle
 	}
 
-	var cacheV uint64
-	cacheTick := new(uint64)
-	localCache := map[FirewallPacket]struct{}{}
-
-	go func() {
-		for {
-			time.Sleep(1 * time.Second)
-			atomic.AddUint64(cacheTick, 1)
-		}
-	}()
+	conntrackCache := NewConntrackCache(f.conntrackCache)
 
 	for {
 		n, err := read(msgs)
@@ -176,17 +165,14 @@ func (u *udpConn) ListenOut(f *Interface, q int) {
 			continue
 		}
 
-		if tick := atomic.LoadUint64(cacheTick); tick != cacheV {
-			cacheV = tick
-			localCache = map[FirewallPacket]struct{}{}
-		}
+		conntrackCache.CheckTick()
 
 		//metric.Update(int64(n))
 		for i := 0; i < n; i++ {
 			udpAddr.IP = binary.BigEndian.Uint32(names[i][4:8])
 			udpAddr.Port = binary.BigEndian.Uint16(names[i][2:4])
 
-			f.readOutsidePackets(udpAddr, plaintext[:0], buffers[i][:msgs[i].Len], header, fwPacket, lhh, nb, q, localCache)
+			f.readOutsidePackets(udpAddr, plaintext[:0], buffers[i][:msgs[i].Len], header, fwPacket, lhh, nb, q, conntrackCache.Cache)
 		}
 	}
 }

--- a/udp_linux.go
+++ b/udp_linux.go
@@ -165,14 +165,12 @@ func (u *udpConn) ListenOut(f *Interface, q int) {
 			continue
 		}
 
-		conntrackCache.CheckTick()
-
 		//metric.Update(int64(n))
 		for i := 0; i < n; i++ {
 			udpAddr.IP = binary.BigEndian.Uint32(names[i][4:8])
 			udpAddr.Port = binary.BigEndian.Uint16(names[i][2:4])
 
-			f.readOutsidePackets(udpAddr, plaintext[:0], buffers[i][:msgs[i].Len], header, fwPacket, lhh, nb, q, conntrackCache.Cache)
+			f.readOutsidePackets(udpAddr, plaintext[:0], buffers[i][:msgs[i].Len], header, fwPacket, lhh, nb, q, conntrackCache.Get())
 		}
 	}
 }


### PR DESCRIPTION
Previously, every packet we see gets a lock on the conntrack table and updates it. When running with multiple routines, this can cause heavy lock contention and limit our ability for the threads to run independently. This change caches reads from the conntrack table for a very short period of time to reduce this lock contention. This cache will currently default to disabled unless you are running with multiple routines, in which case the default cache delay will be 1 second. This means that entries in the conntrack table may be up to 1 second out of date and remain in a routine local cache for up to 1 second longer than the global table.

Instead of calling `time.Now()` for every packet, this cache system relies on a tick thread that updates the current cache "version" each tick. Every packet we check if the cache version is out of date, and reset the cache if so.