### PR TITLE
Add a way to trigger punch backs via lighthouse

### DIFF
--- a/control.go
+++ b/control.go
@@ -65,6 +65,12 @@ func (c *Control) ShutdownBlock() {
 // RebindUDPServer asks the UDP listener to rebind it's listener. Mainly used on mobile clients when interfaces change
 func (c *Control) RebindUDPServer() {
 	_ = c.f.outside.Rebind()
+
+	// Trigger a lighthouse update, useful for mobile clients that should have an update interval of 0
+	c.f.lightHouse.SendUpdate(c.f)
+
+	// Let the main interface know that we rebound so that underlying tunnels know to trigger punches from their remotes
+	c.f.rebindCount++
 }
 
 // ListHostmap returns details about the actual or pending (handshaking) hostmap

--- a/hostmap.go
+++ b/hostmap.go
@@ -51,6 +51,11 @@ type HostInfo struct {
 	recvError         int
 	remoteCidr        *CIDRTree
 
+	// lastRebindCount is the other side of Interface.rebindCount, if these values don't match then we need to ask LH
+	// for a punch from the remote end of this tunnel. The goal being to prime their conntrack for our traffic just like
+	// with a handshake
+	lastRebindCount int8
+
 	lastRoam       time.Time
 	lastRoamRemote *udpAddr
 }

--- a/interface.go
+++ b/interface.go
@@ -59,7 +59,10 @@ type Interface struct {
 	dropMulticast      bool
 	udpBatchSize       int
 	routines           int
-	version            string
+
+	// rebindCount is used to decide if an active tunnel should trigger a punch notification through a lighthouse
+	rebindCount int8
+	version     string
 
 	writers []*udpConn
 	readers []io.ReadWriteCloser

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -231,35 +231,7 @@ func (lh *LightHouse) LhUpdateWorker(f EncWriter) {
 	}
 
 	for {
-		ipp := []*IpAndPort{}
-
-		for _, e := range *localIps(lh.localAllowList) {
-			// Only add IPs that aren't my VPN/tun IP
-			if ip2int(e) != lh.myIp {
-				ipp = append(ipp, &IpAndPort{Ip: ip2int(e), Port: uint32(lh.nebulaPort)})
-				//fmt.Println(e)
-			}
-		}
-		m := &NebulaMeta{
-			Type: NebulaMeta_HostUpdateNotification,
-			Details: &NebulaMetaDetails{
-				VpnIp:      lh.myIp,
-				IpAndPorts: ipp,
-			},
-		}
-
-		lh.metricTx(NebulaMeta_HostUpdateNotification, int64(len(lh.lighthouses)))
-		nb := make([]byte, 12, 12)
-		out := make([]byte, mtu)
-		for vpnIp := range lh.lighthouses {
-			mm, err := proto.Marshal(m)
-			if err != nil {
-				l.Debugf("Invalid marshal to update")
-			}
-			//l.Error("LIGHTHOUSE PACKET SEND", mm)
-			f.SendMessageToVpnIp(lightHouse, 0, vpnIp, mm, nb, out)
-
-		}
+		lh.SendUpdate(f)
 		time.Sleep(time.Second * time.Duration(lh.interval))
 	}
 }

--- a/main.go
+++ b/main.go
@@ -256,7 +256,7 @@ func Main(config *Config, configTest bool, buildVersion string, logger *logrus.L
 		lighthouseHosts,
 		//TODO: change to a duration
 		config.GetInt("lighthouse.interval", 10),
-		port,
+		uint32(port),
 		udpConns[0],
 		punchy.Respond,
 		punchy.Delay,


### PR DESCRIPTION
`Rebind` is called by the controlling program when a network interface change is detected (iOS only for now, soon to be others). This code adds a way to signal through the lighthouse that a remote should punch back on a possible new IP for the local, greatly improving the roaming story.

Before this change, roaming on a routable ip generally meant the tunnel would have to die and be stood back up.