### PR TITLE
Fix most known data races

### DIFF
--- a/connection_manager_test.go
+++ b/connection_manager_test.go
@@ -49,9 +49,8 @@ func Test_NewConnectionManagerTest(t *testing.T) {
 	// Add an ip we have established a connection w/ to hostmap
 	hostinfo := nc.hostMap.AddVpnIP(vpnIP)
 	hostinfo.ConnectionState = &ConnectionState{
-		certState:      cs,
-		H:              &noise.HandshakeState{},
-		messageCounter: new(uint64),
+		certState: cs,
+		H:         &noise.HandshakeState{},
 	}
 
 	// We saw traffic out to vpnIP
@@ -115,9 +114,8 @@ func Test_NewConnectionManagerTest2(t *testing.T) {
 	// Add an ip we have established a connection w/ to hostmap
 	hostinfo := nc.hostMap.AddVpnIP(vpnIP)
 	hostinfo.ConnectionState = &ConnectionState{
-		certState:      cs,
-		H:              &noise.HandshakeState{},
-		messageCounter: new(uint64),
+		certState: cs,
+		H:         &noise.HandshakeState{},
 	}
 
 	// We saw traffic out to vpnIP

--- a/control.go
+++ b/control.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 
 	"github.com/sirupsen/logrus"
@@ -156,7 +157,7 @@ func copyHostInfo(h *HostInfo) ControlHostInfo {
 		RemoteIndex:    h.remoteIndexId,
 		RemoteAddrs:    make([]udpAddr, len(addrs), len(addrs)),
 		CachedPackets:  len(h.packetStore),
-		MessageCounter: *h.ConnectionState.messageCounter,
+		MessageCounter: atomic.LoadUint64(&h.ConnectionState.atomicMessageCounter),
 	}
 
 	if c := h.GetCert(); c != nil {

--- a/control_test.go
+++ b/control_test.go
@@ -43,15 +43,13 @@ func TestControl_GetHostInfoByVpnIP(t *testing.T) {
 		},
 		Signature: []byte{1, 2, 1, 2, 1, 3},
 	}
-	counter := uint64(0)
 
 	remotes := []*HostInfoDest{NewHostInfoDest(remote1), NewHostInfoDest(remote2)}
 	hm.Add(ip2int(ipNet.IP), &HostInfo{
 		remote:  remote1,
 		Remotes: remotes,
 		ConnectionState: &ConnectionState{
-			peerCert:       crt,
-			messageCounter: &counter,
+			peerCert: crt,
 		},
 		remoteIndexId: 200,
 		localIndexId:  201,
@@ -62,8 +60,7 @@ func TestControl_GetHostInfoByVpnIP(t *testing.T) {
 		remote:  remote1,
 		Remotes: remotes,
 		ConnectionState: &ConnectionState{
-			peerCert:       nil,
-			messageCounter: &counter,
+			peerCert: nil,
 		},
 		remoteIndexId: 200,
 		localIndexId:  201,

--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -103,6 +103,8 @@ func (c *HandshakeManager) handleOutbound(vpnIP uint32, f EncWriter, lighthouseT
 	if err != nil {
 		return
 	}
+	hostinfo.Lock()
+	defer hostinfo.Unlock()
 
 	// If we haven't finished the handshake and we haven't hit max retries, query
 	// lighthouse and then send the handshake packet again.

--- a/inside.go
+++ b/inside.go
@@ -106,16 +106,18 @@ func (f *Interface) getOrHandshake(vpnIp uint32) *HostInfo {
 		hostinfo.Lock()
 		defer hostinfo.Unlock()
 
-		ixHandshakeStage0(f, vpnIp, hostinfo)
-		// FIXME: Maybe make XX selectable, but probably not since psk makes it nearly pointless for us.
-		//xx_handshakeStage0(f, ip, hostinfo)
+		if !hostinfo.HandshakeReady {
+			ixHandshakeStage0(f, vpnIp, hostinfo)
+			// FIXME: Maybe make XX selectable, but probably not since psk makes it nearly pointless for us.
+			//xx_handshakeStage0(f, ip, hostinfo)
 
-		// If this is a static host, we don't need to wait for the HostQueryReply
-		// We can trigger the handshake right now
-		if _, ok := f.lightHouse.staticList[vpnIp]; ok {
-			select {
-			case f.handshakeManager.trigger <- vpnIp:
-			default:
+			// If this is a static host, we don't need to wait for the HostQueryReply
+			// We can trigger the handshake right now
+			if _, ok := f.lightHouse.staticList[vpnIp]; ok {
+				select {
+				case f.handshakeManager.trigger <- vpnIp:
+				default:
+				}
 			}
 		}
 	}

--- a/interface.go
+++ b/interface.go
@@ -134,11 +134,6 @@ func (f *Interface) run() {
 
 	metrics.GetOrRegisterGauge("routines", nil).Update(int64(f.routines))
 
-	// Launch n queues to read packets from udp
-	for i := 0; i < f.routines; i++ {
-		go f.listenOut(i)
-	}
-
 	// Prepare n tun queues
 	var reader io.ReadWriteCloser = f.inside
 	for i := 0; i < f.routines; i++ {
@@ -153,6 +148,11 @@ func (f *Interface) run() {
 
 	if err := f.inside.Activate(); err != nil {
 		l.Fatal(err)
+	}
+
+	// Launch n queues to read packets from udp
+	for i := 0; i < f.routines; i++ {
+		go f.listenOut(i)
 	}
 
 	// Launch n queues to read packets from tun dev

--- a/ssh.go
+++ b/ssh.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"runtime/pprof"
 	"strings"
+	"sync/atomic"
 	"syscall"
 
 	"github.com/sirupsen/logrus"
@@ -353,7 +354,7 @@ func sshListHostMap(hostMap *HostMap, a interface{}, w sshd.StringWriter) error 
 			}
 
 			if v.ConnectionState != nil {
-				h["messageCounter"] = v.ConnectionState.messageCounter
+				h["messageCounter"] = atomic.LoadUint64(&v.ConnectionState.atomicMessageCounter)
 			}
 
 			d[x] = h


### PR DESCRIPTION
This change fixes all of the known data races that `make smoke-docker-race` finds, except for one.

Most of these races are around the handshake phase for a hostinfo, so we add a RWLock to the hostinfo and Lock during each of the handshake stages.

Some of the other races are around consistently using `atomic` around the `messageCounter` field. To make this harder to mess up, I have renamed the field to `atomicMessageCounter` (I also removed the unnecessary extra pointer deference as we can just point directly to the struct field).

The last remaining data race is around reading `ConnectionInfo.ready`, which is a boolean that is only written to once when the handshake has finished. Due to it being in the hot path for packets and the rare case that this could actually be an issue, holding off on fixing that one for now.

here is the results of `make smoke-docker-race`:

before:

```
lighthouse1: Found 2 data race(s)
host2:       Found 36 data race(s)
host3:       Found 17 data race(s)
host4:       Found 31 data race(s)
```

after:

```
host2: Found 1 data race(s)
host4: Found 1 data race(s)
```

Fixes: #147
Fixes: #226
Fixes: #283
Fixes: #316