### PR TITLE
Do not allow someone to run a nebula lighthouse with an ephemeral port

### DIFF
--- a/main.go
+++ b/main.go
@@ -246,7 +246,7 @@ func Main(config *Config, configTest bool, buildVersion string, logger *logrus.L
 
 	// fatal if am_lighthouse is enabled but we are using an ephemeral port
 	if amLighthouse && (config.GetInt("listen.port", 0) == 0) {
-		return nil, NewContextualError("lighthouse.am_lighthouse enabled on node but no port number is set in config", nil, err)
+		return nil, errors.New("lighthouse.am_lighthouse enabled on node but no port number is set in config")
 	}
 
 	// warn if am_lighthouse is enabled but upstream lighthouses exists

--- a/main.go
+++ b/main.go
@@ -245,7 +245,7 @@ func Main(config *Config, configTest bool, buildVersion string, logger *logrus.L
 	amLighthouse := config.GetBool("lighthouse.am_lighthouse", false)
 
 	// fatal if am_lighthouse is enabled but we are using an ephemeral port
-	if amLighthouse && port == 0 {
+	if amLighthouse && (config.GetInt("listen.port", 0) == 0) {
 		return nil, NewContextualError("lighthouse.am_lighthouse enabled on node but no port number is set in config", nil, err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package nebula
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"

--- a/main.go
+++ b/main.go
@@ -246,7 +246,7 @@ func Main(config *Config, configTest bool, buildVersion string, logger *logrus.L
 
 	// fatal if am_lighthouse is enabled but we are using an ephemeral port
 	if amLighthouse && (config.GetInt("listen.port", 0) == 0) {
-		return nil, errors.New("lighthouse.am_lighthouse enabled on node but no port number is set in config")
+		return nil, NewContextualError("lighthouse.am_lighthouse enabled on node but no port number is set in config", nil, err)
 	}
 
 	// warn if am_lighthouse is enabled but upstream lighthouses exists

--- a/main.go
+++ b/main.go
@@ -246,7 +246,7 @@ func Main(config *Config, configTest bool, buildVersion string, logger *logrus.L
 
 	// fatal if am_lighthouse is enabled but we are using an ephemeral port
 	if amLighthouse && (config.GetInt("listen.port", 0) == 0) {
-		return nil, NewContextualError("lighthouse.am_lighthouse enabled on node but no port number is set in config", nil, err)
+		return nil, NewContextualError("lighthouse.am_lighthouse enabled on node but no port number is set in config", nil, nil)
 	}
 
 	// warn if am_lighthouse is enabled but upstream lighthouses exists

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package nebula
 
 import (
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"net"
 	"strconv"

--- a/main.go
+++ b/main.go
@@ -244,6 +244,11 @@ func Main(config *Config, configTest bool, buildVersion string, logger *logrus.L
 
 	amLighthouse := config.GetBool("lighthouse.am_lighthouse", false)
 
+	// fatal if am_lighthouse is enabled but we are using an ephemeral port
+	if amLighthouse && port == 0 {
+		return nil, NewContextualError("lighthouse.am_lighthouse enabled on node but no port number is set in config", nil, err)
+	}
+
 	// warn if am_lighthouse is enabled but upstream lighthouses exists
 	rawLighthouseHosts := config.GetStringSlice("lighthouse.hosts", []string{})
 	if amLighthouse && len(rawLighthouseHosts) != 0 {


### PR DESCRIPTION
Running a lighthouse with an ephemeral port doesn't make sense, so we should not allow nebula to be started this way.