### PR TITLE
Refactor handshake_ix

### DIFF
--- a/handshake.go
+++ b/handshake.go
@@ -6,30 +6,23 @@ const (
 )
 
 func HandleIncomingHandshake(f *Interface, addr *udpAddr, packet []byte, h *Header, hostinfo *HostInfo) {
-	newHostinfo, _ := f.handshakeManager.QueryIndex(h.RemoteIndex)
-	//TODO: For stage 1 we won't have hostinfo yet but stage 2 and above would require it, this check may be helpful in those cases
-	//if err != nil {
-	//	l.WithError(err).WithField("udpAddr", addr).Error("Error while finding host info for handshake message")
-	//	return
-	//}
-
 	if !f.lightHouse.remoteAllowList.Allow(udp2ipInt(addr)) {
 		l.WithField("udpAddr", addr).Debug("lighthouse.remote_allow_list denied incoming handshake")
 		return
 	}
 
-	tearDown := false
 	switch h.Subtype {
 	case handshakeIXPSK0:
 		switch h.MessageCounter {
 		case 1:
-			tearDown = ixHandshakeStage1(f, addr, newHostinfo, packet, h)
+			ixHandshakeStage1(f, addr, packet, h)
 		case 2:
-			tearDown = ixHandshakeStage2(f, addr, newHostinfo, packet, h)
+			newHostinfo, _ := f.handshakeManager.QueryIndex(h.RemoteIndex)
+			tearDown := ixHandshakeStage2(f, addr, newHostinfo, packet, h)
+			if tearDown && newHostinfo != nil {
+				f.handshakeManager.DeleteHostInfo(newHostinfo)
+			}
 		}
 	}
 
-	if tearDown && newHostinfo != nil {
-		f.handshakeManager.DeleteHostInfo(newHostinfo)
-	}
 }

--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -154,8 +154,6 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet [
 			hostId:          vpnIP,
 			HandshakePacket: make(map[uint8][]byte, 0),
 		}
-		hostinfo.Lock()
-		defer hostinfo.Unlock()
 
 		l.WithField("vpnIp", IntIp(vpnIP)).WithField("udpAddr", addr).
 			WithField("certName", certName).
@@ -238,6 +236,7 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet [
 
 			//hostinfo.ClearRemotes()
 			hostinfo.AddRemote(*addr)
+			hostinfo.ForcePromoteBest(f.hostMap.preferredRanges)
 			hostinfo.CreateRemoteCIDR(remoteCert)
 			f.lightHouse.AddRemoteAndReset(ip, addr)
 			if f.serveDns {
@@ -256,9 +255,9 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet [
 				f.hostMap.DeleteHostInfo(ho)
 			}
 
-			f.hostMap.AddVpnIPHostInfo(vpnIP, hostinfo)
-
 			hostinfo.handshakeComplete()
+			f.hostMap.AddVpnIPHostInfo(vpnIP, hostinfo)
+			return false
 		} else {
 			l.WithField("vpnIp", IntIp(hostinfo.hostId)).WithField("udpAddr", addr).
 				WithField("certName", certName).

--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -161,8 +161,7 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet [
 			WithField("fingerprint", fingerprint).
 			WithField("handshake", m{"stage": 1, "style": "ix_psk0"}).Error("Failed to call noise.WriteMessage")
 		return false
-	}
-	if dKey == nil || eKey == nil {
+	} else if dKey == nil || eKey == nil {
 		l.WithField("vpnIp", IntIp(hostinfo.hostId)).WithField("udpAddr", addr).
 			WithField("certName", certName).
 			WithField("fingerprint", fingerprint).

--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -355,21 +355,7 @@ func ixHandshakeStage2(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet [
 	hostinfo.ForcePromoteBest(f.hostMap.preferredRanges)
 	hostinfo.CreateRemoteCIDR(remoteCert)
 
-	_, err = f.handshakeManager.CheckAndComplete(hostinfo, 2, true, f)
-	if err != nil {
-		// Shouldn't happen, since we tell CheckAndComplete to overwrite,
-		// and we shouldn't have a localIndex collision because we reserved
-		// it in pending hostmap.
-		l.WithError(err).WithField("vpnIp", IntIp(vpnIP)).WithField("udpAddr", addr).
-			WithField("certName", certName).
-			WithField("fingerprint", fingerprint).
-			WithField("initiatorIndex", hs.Details.InitiatorIndex).WithField("responderIndex", hs.Details.ResponderIndex).
-			WithField("remoteIndex", h.RemoteIndex).WithField("handshake", m{"stage": 1, "style": "ix_psk0"}).
-			Error("Failed to add HostInfo to HostMap")
-
-		return true
-	}
-
+	f.handshakeManager.Complete(hostinfo, f)
 	hostinfo.handshakeComplete()
 	f.metricHandshakes.Update(duration)
 

--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -146,7 +146,7 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet [
 			return true
 		}
 
-		hostinfo, err = f.handshakeManager.AddIndex(vpnIP, myIndex, hs.Details.InitiatorIndex, ci)
+		hostinfo, err = f.handshakeManager.AddIndex(myIndex, ci)
 		if err != nil {
 			l.WithError(err).WithField("vpnIp", IntIp(vpnIP)).WithField("udpAddr", addr).
 				WithField("certName", certName).
@@ -257,7 +257,7 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet [
 				f.hostMap.DeleteHostInfo(ho)
 			}
 
-			f.hostMap.AddVpnIPHostInfo(hostinfo)
+			f.hostMap.AddVpnIPHostInfo(vpnIP, hostinfo)
 
 			hostinfo.handshakeComplete()
 		} else {
@@ -324,13 +324,6 @@ func ixHandshakeStage2(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet [
 		return true
 	}
 	vpnIP := ip2int(remoteCert.Details.Ips[0].IP)
-	if vpnIP != hostinfo.hostId {
-		l.WithError(err).WithField("vpnIp", IntIp(hostinfo.hostId)).WithField("udpAddr", addr).
-			WithField("cert", remoteCert).WithField("handshake", m{"stage": 2, "style": "ix_psk0"}).
-			WithField("certificateVpnIP", IntIp(vpnIP)).
-			Error("IP in certificate does not match expected vpnIp")
-		return true
-	}
 	certName := remoteCert.Details.Name
 	fingerprint, _ := remoteCert.Sha256Sum()
 
@@ -384,7 +377,7 @@ func ixHandshakeStage2(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet [
 			f.hostMap.DeleteHostInfo(ho)
 		}
 
-		f.hostMap.AddVpnIPHostInfo(hostinfo)
+		f.hostMap.AddVpnIPHostInfo(vpnIP, hostinfo)
 
 		hostinfo.handshakeComplete()
 		f.metricHandshakes.Update(duration)

--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -76,13 +76,6 @@ func ixHandshakeStage0(f *Interface, vpnIp uint32, hostinfo *HostInfo) {
 // Note we always return `false` in ixHandshakeStage1 because there is nothing
 // to tear down.
 func ixHandshakeStage1(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet []byte, h *Header) bool {
-	var ip uint32
-	if h.RemoteIndex != 0 {
-		// We already have this index, add the new remote addr
-		f.hostMap.AddRemote(ip, addr)
-		return false
-	}
-
 	ci := f.newConnectionState(false, noise.HandshakeIX, []byte{}, 0)
 	// Mark packet 1 as seen so it doesn't show up as missed
 	ci.window.Update(1)
@@ -212,7 +205,7 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet [
 			Info("Handshake message sent")
 	}
 
-	ip = ip2int(remoteCert.Details.Ips[0].IP)
+	ip := ip2int(remoteCert.Details.Ips[0].IP)
 	ci.peerCert = remoteCert
 	ci.dKey = NewNebulaCipherState(dKey)
 	ci.eKey = NewNebulaCipherState(eKey)

--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -146,14 +146,13 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet [
 			return true
 		}
 
-		hostinfo, err = f.handshakeManager.AddIndex(myIndex, ci)
-		if err != nil {
-			l.WithError(err).WithField("vpnIp", IntIp(vpnIP)).WithField("udpAddr", addr).
-				WithField("certName", certName).
-				WithField("fingerprint", fingerprint).
-				WithField("handshake", m{"stage": 1, "style": "ix_psk0"}).Error("Error adding index to connection manager")
-
-			return true
+		hostinfo = &HostInfo{
+			ConnectionState: ci,
+			Remotes:         []*HostInfoDest{},
+			localIndexId:    myIndex,
+			remoteIndexId:   hs.Details.InitiatorIndex,
+			hostId:          vpnIP,
+			HandshakePacket: make(map[uint8][]byte, 0),
 		}
 		hostinfo.Lock()
 		defer hostinfo.Unlock()

--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -228,11 +228,6 @@ func (c *HandshakeManager) CheckAndComplete(hostinfo *HostInfo, handshakePacket 
 		if !overwrite {
 			return existingHostInfo, ErrExistingHostInfo
 		}
-
-		// We are going to overwrite this entry, so remove the old references
-		delete(c.mainHostMap.Hosts, existingHostInfo.hostId)
-		delete(c.mainHostMap.Indexes, existingHostInfo.localIndexId)
-		delete(c.mainHostMap.RemoteIndexes, existingHostInfo.remoteIndexId)
 	}
 
 	existingIndex, found := c.mainHostMap.Indexes[hostinfo.localIndexId]
@@ -253,6 +248,13 @@ func (c *HandshakeManager) CheckAndComplete(hostinfo *HostInfo, handshakePacket 
 		hostinfo.logger().
 			WithField("remoteIndex", hostinfo.remoteIndexId).WithField("collision", IntIp(existingRemoteIndex.hostId)).
 			Info("New host shadows existing host remoteIndex")
+	}
+
+	if existingHostInfo != nil {
+		// We are going to overwrite this entry, so remove the old references
+		delete(c.mainHostMap.Hosts, existingHostInfo.hostId)
+		delete(c.mainHostMap.Indexes, existingHostInfo.localIndexId)
+		delete(c.mainHostMap.RemoteIndexes, existingHostInfo.remoteIndexId)
 	}
 
 	c.mainHostMap.addHostInfo(hostinfo, f)

--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -1,6 +1,7 @@
 package nebula
 
 import (
+	"bytes"
 	"crypto/rand"
 	"encoding/binary"
 	"errors"
@@ -217,7 +218,8 @@ func (c *HandshakeManager) CheckAndComplete(hostinfo *HostInfo, overwrite bool, 
 
 	existingHostInfo, found := c.mainHostMap.Hosts[hostinfo.hostId]
 	if found && existingHostInfo != nil {
-		if !overwrite {
+		// Check if dont want to overwrite, or if we already have a completed tunnel for this same packet
+		if !overwrite || bytes.Equal(hostinfo.HandshakePacket[0], existingHostInfo.HandshakePacket[0]) {
 			return existingHostInfo, ErrExistingHostInfo
 		}
 

--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -196,8 +196,8 @@ func (c *HandshakeManager) AddVpnIP(vpnIP uint32) *HostInfo {
 	return hostinfo
 }
 
-func (c *HandshakeManager) AddIndex(hostId, index, remoteIndex uint32, ci *ConnectionState) (*HostInfo, error) {
-	hostinfo, err := c.pendingHostMap.AddIndex(hostId, index, remoteIndex, ci)
+func (c *HandshakeManager) AddIndex(index uint32, ci *ConnectionState) (*HostInfo, error) {
+	hostinfo, err := c.pendingHostMap.AddIndex(index, ci)
 	if err != nil {
 		return nil, fmt.Errorf("Issue adding index: %d", index)
 	}
@@ -208,6 +208,10 @@ func (c *HandshakeManager) AddIndex(hostId, index, remoteIndex uint32, ci *Conne
 
 func (c *HandshakeManager) AddIndexHostInfo(index uint32, h *HostInfo) {
 	c.pendingHostMap.AddIndexHostInfo(index, h)
+}
+
+func (c *HandshakeManager) addRemoteIndexHostInfo(index uint32, h *HostInfo) {
+	c.pendingHostMap.addRemoteIndexHostInfo(index, h)
 }
 
 func (c *HandshakeManager) DeleteHostInfo(hostinfo *HostInfo) {

--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -196,8 +196,8 @@ func (c *HandshakeManager) AddVpnIP(vpnIP uint32) *HostInfo {
 	return hostinfo
 }
 
-func (c *HandshakeManager) AddIndex(index uint32, ci *ConnectionState) (*HostInfo, error) {
-	hostinfo, err := c.pendingHostMap.AddIndex(index, ci)
+func (c *HandshakeManager) AddIndex(hostId, index, remoteIndex uint32, ci *ConnectionState) (*HostInfo, error) {
+	hostinfo, err := c.pendingHostMap.AddIndex(hostId, index, remoteIndex, ci)
 	if err != nil {
 		return nil, fmt.Errorf("Issue adding index: %d", index)
 	}
@@ -208,10 +208,6 @@ func (c *HandshakeManager) AddIndex(index uint32, ci *ConnectionState) (*HostInf
 
 func (c *HandshakeManager) AddIndexHostInfo(index uint32, h *HostInfo) {
 	c.pendingHostMap.AddIndexHostInfo(index, h)
-}
-
-func (c *HandshakeManager) addRemoteIndexHostInfo(index uint32, h *HostInfo) {
-	c.pendingHostMap.addRemoteIndexHostInfo(index, h)
 }
 
 func (c *HandshakeManager) DeleteHostInfo(hostinfo *HostInfo) {

--- a/handshake_manager_test.go
+++ b/handshake_manager_test.go
@@ -28,8 +28,7 @@ func Test_NewHandshakeManagerIndex(t *testing.T) {
 
 	// Add four indexes
 	for _, v := range indexes {
-		// We don't care what the hostId and remoteIndex are, so just use the same value
-		blah.AddIndex(v, v, v, &ConnectionState{})
+		blah.AddIndex(v, &ConnectionState{})
 	}
 	// Confirm they are in the pending index list
 	for _, v := range indexes {
@@ -217,9 +216,9 @@ func Test_NewHandshakeManagerIndexcleanup(t *testing.T) {
 	now := time.Now()
 	blah.NextInboundHandshakeTimerTick(now)
 
-	hostinfo, _ := blah.AddIndex(101010, 12341234, 456, &ConnectionState{})
+	hostinfo, _ := blah.AddIndex(12341234, &ConnectionState{})
 	// Pretned we have an index too
-	blah.pendingHostMap.AddVpnIPHostInfo(hostinfo)
+	blah.pendingHostMap.AddVpnIPHostInfo(101010, hostinfo)
 	assert.Contains(t, blah.pendingHostMap.Hosts, uint32(101010))
 
 	for i := 1; i <= DefaultHandshakeRetries+2; i++ {

--- a/handshake_manager_test.go
+++ b/handshake_manager_test.go
@@ -28,7 +28,8 @@ func Test_NewHandshakeManagerIndex(t *testing.T) {
 
 	// Add four indexes
 	for _, v := range indexes {
-		blah.AddIndex(v, &ConnectionState{})
+		// We don't care what the hostId and remoteIndex are, so just use the same value
+		blah.AddIndex(v, v, v, &ConnectionState{})
 	}
 	// Confirm they are in the pending index list
 	for _, v := range indexes {
@@ -216,9 +217,9 @@ func Test_NewHandshakeManagerIndexcleanup(t *testing.T) {
 	now := time.Now()
 	blah.NextInboundHandshakeTimerTick(now)
 
-	hostinfo, _ := blah.AddIndex(12341234, &ConnectionState{})
+	hostinfo, _ := blah.AddIndex(101010, 12341234, 456, &ConnectionState{})
 	// Pretned we have an index too
-	blah.pendingHostMap.AddVpnIPHostInfo(101010, hostinfo)
+	blah.pendingHostMap.AddVpnIPHostInfo(hostinfo)
 	assert.Contains(t, blah.pendingHostMap.Hosts, uint32(101010))
 
 	for i := 1; i <= DefaultHandshakeRetries+2; i++ {

--- a/hostmap.go
+++ b/hostmap.go
@@ -408,9 +408,9 @@ func (hm *HostMap) CheckAndAddHostInfo(hostinfo *HostInfo, overwrite bool, f *In
 			return existing, false
 		}
 
-		delete(hm.Hosts, hostinfo.hostId)
-		delete(hm.Indexes, hostinfo.localIndexId)
-		delete(hm.RemoteIndexes, hostinfo.remoteIndexId)
+		delete(hm.Hosts, existing.hostId)
+		delete(hm.Indexes, existing.localIndexId)
+		delete(hm.RemoteIndexes, existing.remoteIndexId)
 	}
 
 	hm.addHostInfo(hostinfo, f)

--- a/hostmap.go
+++ b/hostmap.go
@@ -367,11 +367,14 @@ var (
 	ErrLocalIndexCollision = errors.New("local index collision")
 )
 
-// CheckAndAddHostInfo returns the existing hostinfo entry if this
-// hostId already has a complete handshake. If completed is true and
-// existing is non-nil, then we overwrote the old existing tunnel.
-// If completed is false and existing is nil, that means there was a collision
-// on localIndexId so we didn't do the insert
+// CheckAndAddHostInfo checks for any conflicts in the main and pending hostmap
+// before adding it. If err is nil, it was added. Otherwise err will be:
+//
+// ErrExistingHostInfo if we already have an
+// entry in the hostmap for this VpnIP and overwrite was false.
+//
+// ErrLocalIndexCollision if we already have an entry in the main or pending
+// hostmap for the hostinfo.localIndexId.
 func (hm *HostMap) CheckAndAddHostInfo(hostinfo *HostInfo, overwrite bool, f *Interface) (*HostInfo, error) {
 	f.handshakeManager.pendingHostMap.RLock()
 	defer f.handshakeManager.pendingHostMap.RUnlock()

--- a/hostmap.go
+++ b/hostmap.go
@@ -253,7 +253,7 @@ func (hm *HostMap) DeleteIndex(index uint32) {
 			// instance. Clean it up as well if we do.
 			hostinfo2, ok := hm.Hosts[hostId]
 			if ok && hostinfo2 == hostinfo {
-				delete(hm.Hosts, hostinfo.hostId)
+				delete(hm.Hosts, hostId)
 			}
 		}
 	}

--- a/hostmap.go
+++ b/hostmap.go
@@ -377,7 +377,7 @@ func (hm *HostMap) addHostInfo(hostinfo *HostInfo, f *Interface) {
 	hm.Indexes[hostinfo.localIndexId] = hostinfo
 	hm.RemoteIndexes[hostinfo.remoteIndexId] = hostinfo
 
-	if l.Level > logrus.DebugLevel {
+	if l.Level >= logrus.DebugLevel {
 		l.WithField("hostMap", m{"mapName": hm.name, "vpnIp": IntIp(hostinfo.hostId), "mapTotalSize": len(hm.Hosts),
 			"hostinfo": m{"existing": true, "localIndexId": hostinfo.localIndexId, "hostId": IntIp(hostinfo.hostId)}}).
 			Debug("Hostmap vpnIp added")

--- a/hostmap.go
+++ b/hostmap.go
@@ -236,19 +236,19 @@ func (hm *HostMap) DeleteIndex(index uint32) {
 	if ok {
 		delete(hm.Indexes, index)
 		delete(hm.RemoteIndexes, hostinfo.remoteIndexId)
-	}
-	hm.Unlock()
+		hm.Unlock()
 
-	hostinfo.RLock()
-	hostId := hostinfo.hostId
-	hostinfo.RUnlock()
+		hostinfo.RLock()
+		hostId := hostinfo.hostId
+		hostinfo.RUnlock()
 
-	// Check if we have an entry under hostId that matches the same hostinfo
-	// instance. Clean it up as well if we do.
-	hm.Lock()
-	hostinfo2, ok := hm.Hosts[hostId]
-	if ok && hostinfo2 == hostinfo {
-		delete(hm.Hosts, hostinfo.hostId)
+		// Check if we have an entry under hostId that matches the same hostinfo
+		// instance. Clean it up as well if we do.
+		hm.Lock()
+		hostinfo2, ok := hm.Hosts[hostId]
+		if ok && hostinfo2 == hostinfo {
+			delete(hm.Hosts, hostinfo.hostId)
+		}
 	}
 	hm.Unlock()
 

--- a/hostmap.go
+++ b/hostmap.go
@@ -234,19 +234,21 @@ func (hm *HostMap) DeleteIndex(index uint32) {
 	hm.Lock()
 	hostinfo, ok := hm.Indexes[index]
 	if ok {
-		hostinfo.Lock()
-		defer hostinfo.Unlock()
-
 		delete(hm.Indexes, index)
 		delete(hm.RemoteIndexes, hostinfo.remoteIndexId)
+	}
+	hm.Unlock()
 
-		// Check if we have an entry under hostId that matches the same hostinfo
-		// instance. Clean it up as well if we do.
-		var hostinfo2 *HostInfo
-		hostinfo2, ok = hm.Hosts[hostinfo.hostId]
-		if ok && hostinfo2 == hostinfo {
-			delete(hm.Hosts, hostinfo.hostId)
-		}
+	hostinfo.RLock()
+	hostId := hostinfo.hostId
+	hostinfo.RUnlock()
+
+	// Check if we have an entry under hostId that matches the same hostinfo
+	// instance. Clean it up as well if we do.
+	hm.Lock()
+	hostinfo2, ok := hm.Hosts[hostId]
+	if ok && hostinfo2 == hostinfo {
+		delete(hm.Hosts, hostinfo.hostId)
 	}
 	hm.Unlock()
 

--- a/outside.go
+++ b/outside.go
@@ -106,7 +106,6 @@ func (f *Interface) readOutsidePackets(addr *udpAddr, out []byte, packet []byte,
 
 	case recvError:
 		f.messageMetrics.Rx(header.Type, header.Subtype, 1)
-		// TODO: Remove this with recv_error deprecation
 		f.handleRecvError(addr, header)
 		return
 
@@ -312,8 +311,6 @@ func (f *Interface) sendRecvError(endpoint *udpAddr, index uint32) {
 }
 
 func (f *Interface) handleRecvError(addr *udpAddr, h *Header) {
-	// This flag is to stop caring about recv_error from old versions
-	// This should go away when the old version is gone from prod
 	if l.Level >= logrus.DebugLevel {
 		l.WithField("index", h.RemoteIndex).
 			WithField("udpAddr", addr).


### PR DESCRIPTION
There are some subtle race conditions with the previous handshake_ix implementation, mostly around collisions with localIndexId. This change refactors it so that we have  a "commit" phase during the handshake where we grab the lock for the hostmap and ensure that we have a unique local index before storing it. We also now avoid using the pending hostmap at all for receiving stage1 packets, since we have everything we need to just store the completed handshake. 