### PR TITLE
don't allow a useless handshake with yourself

### DIFF
--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -107,6 +107,14 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, packet []byte, h *Header) {
 	certName := remoteCert.Details.Name
 	fingerprint, _ := remoteCert.Sha256Sum()
 
+	if vpnIP == f.GetVpnIP() {
+		l.WithField("vpnIp", IntIp(vpnIP)).WithField("udpAddr", addr).
+			WithField("certName", certName).
+			WithField("fingerprint", fingerprint).
+			WithField("handshake", m{"stage": 1, "style": "ix_psk0"}).Error("Refusing to handshake with myself")
+		return
+	}
+
 	myIndex, err := generateIndex()
 	if err != nil {
 		l.WithError(err).WithField("vpnIp", IntIp(vpnIP)).WithField("udpAddr", addr).

--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -107,7 +107,7 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, packet []byte, h *Header) {
 	certName := remoteCert.Details.Name
 	fingerprint, _ := remoteCert.Sha256Sum()
 
-	if vpnIP == f.GetVpnIP() {
+	if vpnIP == ip2int(f.certState.certificate.Details.Ips[0].IP) {
 		l.WithField("vpnIp", IntIp(vpnIP)).WithField("udpAddr", addr).
 			WithField("certName", certName).
 			WithField("fingerprint", fingerprint).

--- a/interface.go
+++ b/interface.go
@@ -289,7 +289,3 @@ func (f *Interface) emitStats(i time.Duration) {
 		udpStats()
 	}
 }
-
-func (f *Interface) GetVpnIP() uint32 {
-	return ip2int(f.inside.CidrNet().IP)
-}

--- a/interface.go
+++ b/interface.go
@@ -289,3 +289,7 @@ func (f *Interface) emitStats(i time.Duration) {
 		udpStats()
 	}
 }
+
+func (f *Interface) GetVpnIP() uint32 {
+	return ip2int(f.inside.CidrNet().IP)
+}


### PR DESCRIPTION
This prevents a silly condition noticed in #313 where a host can handshake with itself. 

Notes:
* This is NOT a fix for that issue, and is unlikely to be the cause of the issue, but something we should also stop from happening, because this is a useless entry in the hostMap.
* This will not cleanly merge with #401 and that PR should take precedence. I will update this one once it is merged.

To reproduce this issue you can simply create a `static_host_map` entry pointing a nebula ip besides your own at your local nebula port and initiating traffic to it.

Example:

Host1:
  Real IP: 10.1.1.1
  Nebula listener port: 1234
  Nebula IP: 192.168.1.1
 
```
static_host_map:
  "192.168.1.222": ["10.1.1.1:1234"]
```

```shell
ping 192.168.1.222
(fails)
```

A hostmap entry for yourself will appear and the nebula logs will show a successful handshake.
