### PR TITLE
remove probes of the lighthouse(s)

### DIFF
--- a/connection_manager.go
+++ b/connection_manager.go
@@ -216,6 +216,13 @@ func (n *connectionManager) HandleMonitorTick(now time.Time, p, nb, out []byte) 
 			continue
 		}
 
+		if n.intf.lightHouse.IsLighthouseIP(hostinfo.vpnIp) {
+			// Don't probe lighthouses since recv_error should naturally catch this.
+			n.ClearLocalIndex(localIndex)
+			n.ClearPendingDeletion(localIndex)
+			continue
+		}
+
 		hostinfo.logger(n.l).
 			WithField("tunnelCheck", m{"state": "testing", "method": "active"}).
 			Debug("Tunnel status")


### PR DESCRIPTION
Probing a LH isn't actually very useful, since recv_error should catch issues. this avoids stampeding a LH by dropping good tunnels during a reconnect spike.

I debated putting this in connection_manager.go under the `Out` method, but checking there would mean putting `IsLighthouseIP`, which has a lock, into the hot path. Instead, allow these IPs to go into the wheel, but just delete them instead of probing.

We may want to make this behavior optional via config, but I'm inclined to say this is more correct than we we do now, and the old behavior is of dubious value.