### PR TITLE
*WIP* Make nebula on windows much faster by buffering on udp

### DIFF
--- a/udp_windows.go
+++ b/udp_windows.go
@@ -11,6 +11,32 @@ import (
 func NewListenConfig(multi bool) net.ListenConfig {
 	return net.ListenConfig{
 		Control: func(network, address string, c syscall.RawConn) error {
+			var controlErr error
+			err := c.Control(func(fd uintptr) {
+				if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.SOL_SOCKET, syscall.SO_SNDBUF, 999999); err != nil {
+					controlErr = fmt.Errorf("SO_SNDBUF failed: %v", err)
+					return
+				}
+			})
+			if err != nil {
+				return err
+			}
+			if controlErr != nil {
+				return controlErr
+			}
+			err = c.Control(func(fd uintptr) {
+				if err := syscall.SetsockoptInt(syscall.Handle(fd), syscall.SOL_SOCKET, syscall.SO_RCVBUF, 999999); err != nil {
+					controlErr = fmt.Errorf("SO_RCVBUF failed: %v", err)
+					return
+				}
+			})
+			if err != nil {
+				return err
+			}
+			if controlErr != nil {
+				return controlErr
+			}
+
 			if multi {
 				// There is no way to support multiple listeners safely on Windows:
 				// https://docs.microsoft.com/en-us/windows/desktop/winsock/using-so-reuseaddr-and-so-exclusiveaddruse


### PR DESCRIPTION
*WIP* - do not merge!

The default windows UDP receive buffer is 8192KB which is .... way too small.

This increases the buffer to an arbitrary value at the moment, but results in a 10x speed increase on my test. I'll clean it up and make it use the listen.read_buffer and write_buffer in the near future.