### PR TITLE
Remove obsolete systemd unit settings.

### DIFF
--- a/examples/service_scripts/nebula.service
+++ b/examples/service_scripts/nebula.service
@@ -6,8 +6,6 @@ Before=sshd.service
 
 [Service]
 SyslogIdentifier=nebula
-StandardOutput=syslog
-StandardError=syslog
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/local/bin/nebula -config /etc/nebula/config.yml
 Restart=always


### PR DESCRIPTION
The `StandardError` and `StandardOutput` directives being set to syslog in systemd are obsolete and are no longer [options](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#StandardOutput=) and this PR removes them to fix the following gripes in the systemd journal.

```
Mar 18 11:56:05 sts7 systemd[1]: /usr/lib/systemd/system/nebula.service:8: Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.
Mar 18 11:56:05 sts7 systemd[1]: /usr/lib/systemd/system/nebula.service:9: Standard output type syslog is obsolete, automatically updating to journal. Please update your unit file, and consider removing the setting altogether.
```