### PR TITLE
fix PromoteEvery check

### DIFF
--- a/hostmap.go
+++ b/hostmap.go
@@ -472,7 +472,7 @@ func (i *HostInfo) TryPromoteBest(preferredRanges []*net.IPNet, ifce *Interface)
 		return
 	}
 
-	if atomic.AddUint32(&i.promoteCounter, 1)&PromoteEvery == 0 {
+	if atomic.AddUint32(&i.promoteCounter, 1)%PromoteEvery == 0 {
 		// return early if we are already on a preferred remote
 		rIP := i.remote.IP
 		for _, l := range preferredRanges {


### PR DESCRIPTION
This check was accidentally typo'd in #396 from `%` to `&`. Restore the
correct functionality here (we want to do the check every "PromoteEvery"
count packets).