### PR TITLE
Simple e2e lies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,9 @@ jobs:
     - name: Test
       run: make test
 
+    - name: End 2 end
+      run: make e2e
+
   test:
     name: Build and test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -72,3 +75,6 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+    - name: End 2 end
+      run: go test -tags=e2e_testing -count=1 ./e2e

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,19 @@ ALL = $(ALL_LINUX) \
 	windows-amd64
 
 e2e:
-	go test -v -tags=e2e_testing ./e2e
+	$(TEST_ENV) go test -tags=e2e_testing -count=1 $(TEST_FLAGS) ./e2e
+
+e2ev: TEST_FLAGS = -v
+e2ev: e2e
+
+e2evv: TEST_ENV += TEST_LOGS=1
+e2evv: e2ev
+
+e2evvv: TEST_ENV += TEST_LOGS=2
+e2evvv: e2ev
+
+e2evvvv: TEST_ENV += TEST_LOGS=3
+e2evvvv: e2ev
 
 all: $(ALL:%=build/%/nebula) $(ALL:%=build/%/nebula-cert)
 
@@ -138,5 +150,5 @@ smoke-docker-race: BUILD_ARGS = -race
 smoke-docker-race: smoke-docker
 
 .FORCE:
-.PHONY: e2e test test-cov-html bench bench-cpu bench-cpu-long bin proto release service smoke-docker smoke-docker-race
+.PHONY: e2e e2ev e2evv e2evvv e2evvvv test test-cov-html bench bench-cpu bench-cpu-long bin proto release service smoke-docker smoke-docker-race
 .DEFAULT_GOAL := bin

--- a/control.go
+++ b/control.go
@@ -164,12 +164,11 @@ func (c *Control) CloseAllTunnels(excludeLighthouses bool) (closed int) {
 }
 
 func copyHostInfo(h *HostInfo) ControlHostInfo {
-	addrs := h.RemoteUDPAddrs()
 	chi := ControlHostInfo{
 		VpnIP:          int2ip(h.hostId),
 		LocalIndex:     h.localIndexId,
 		RemoteIndex:    h.remoteIndexId,
-		RemoteAddrs:    make([]*udpAddr, len(addrs), len(addrs)),
+		RemoteAddrs:    h.CopyRemotes(),
 		CachedPackets:  len(h.packetStore),
 		MessageCounter: atomic.LoadUint64(&h.ConnectionState.atomicMessageCounter),
 	}
@@ -180,10 +179,6 @@ func copyHostInfo(h *HostInfo) ControlHostInfo {
 
 	if h.remote != nil {
 		chi.CurrentRemote = h.remote.Copy()
-	}
-
-	for i, addr := range addrs {
-		chi.RemoteAddrs[i] = addr.Copy()
 	}
 
 	return chi

--- a/control_test.go
+++ b/control_test.go
@@ -45,7 +45,7 @@ func TestControl_GetHostInfoByVpnIP(t *testing.T) {
 		Signature: []byte{1, 2, 1, 2, 1, 3},
 	}
 
-	remotes := []*HostInfoDest{NewHostInfoDest(remote1), NewHostInfoDest(remote2)}
+	remotes := []*udpAddr{remote1, remote2}
 	hm.Add(ip2int(ipNet.IP), &HostInfo{
 		remote:  remote1,
 		Remotes: remotes,

--- a/control_tester.go
+++ b/control_tester.go
@@ -57,6 +57,14 @@ func (c *Control) GetFromUDP(block bool) *UdpPacket {
 	return c.f.outside.Get(block)
 }
 
+func (c *Control) GetUDPTxChan() <-chan *UdpPacket {
+	return c.f.outside.txPackets
+}
+
+func (c *Control) GetTunTxChan() <-chan []byte {
+	return c.f.inside.(*Tun).txPackets
+}
+
 // InjectUDPPacket will inject a packet into the udp side of nebula
 func (c *Control) InjectUDPPacket(p *UdpPacket) {
 	c.f.outside.Send(p)
@@ -89,4 +97,8 @@ func (c *Control) InjectTunUDPPacket(toIp net.IP, toPort uint16, fromPort uint16
 	}
 
 	c.f.inside.(*Tun).Send(buffer.Bytes())
+}
+
+func (c *Control) GetUDPAddr() string {
+	return c.f.outside.addr.String()
 }

--- a/e2e/handshakes_test.go
+++ b/e2e/handshakes_test.go
@@ -6,29 +6,24 @@ import (
 	"net"
 	"testing"
 	"time"
+
+	"github.com/slackhq/nebula/e2e/router"
 )
 
 func TestGoodHandshake(t *testing.T) {
 	ca, _, caKey, _ := newTestCaCert(time.Now(), time.Now().Add(10*time.Minute), []*net.IPNet{}, []*net.IPNet{}, []string{})
-	defMask := net.IPMask{0, 0, 0, 0}
-
-	myUdpAddr := &net.UDPAddr{IP: net.IP{10, 0, 0, 1}, Port: 4242}
-	myVpnIpNet := &net.IPNet{IP: net.IP{10, 128, 0, 1}, Mask: defMask}
-	myControl := newSimpleServer(ca, caKey, "me", myUdpAddr, myVpnIpNet)
-
-	theirUdpAddr := &net.UDPAddr{IP: net.IP{10, 0, 0, 2}, Port: 4242}
-	theirVpnIpNet := &net.IPNet{IP: net.IP{10, 128, 0, 2}, Mask: defMask}
-	theirControl := newSimpleServer(ca, caKey, "them", theirUdpAddr, theirVpnIpNet)
+	myControl, myVpnIp, myUdpAddr := newSimpleServer(ca, caKey, "me", net.IP{10, 0, 0, 1})
+	theirControl, theirVpnIp, theirUdpAddr := newSimpleServer(ca, caKey, "them", net.IP{10, 0, 0, 2})
 
 	// Put their info in our lighthouse
-	myControl.InjectLightHouseAddr(theirVpnIpNet.IP, theirUdpAddr)
+	myControl.InjectLightHouseAddr(theirVpnIp, theirUdpAddr)
 
 	// Start the servers
 	myControl.Start()
 	theirControl.Start()
 
 	// Send a udp packet through to begin standing up the tunnel, this should come out the other side
-	myControl.InjectTunUDPPacket(theirVpnIpNet.IP, 80, 80, []byte("Hi from me"))
+	myControl.InjectTunUDPPacket(theirVpnIp, 80, 80, []byte("Hi from me"))
 
 	// Have them consume my stage 0 packet. They have a tunnel now
 	theirControl.InjectUDPPacket(myControl.GetFromUDP(true))
@@ -40,21 +35,172 @@ func TestGoodHandshake(t *testing.T) {
 	myControl.WaitForType(1, 0, theirControl)
 
 	// Make sure our host infos are correct
-	assertHostInfoPair(t, myUdpAddr, theirUdpAddr, myVpnIpNet.IP, theirVpnIpNet.IP, myControl, theirControl)
+	assertHostInfoPair(t, myUdpAddr, theirUdpAddr, myVpnIp, theirVpnIp, myControl, theirControl)
 
 	// Get that cached packet and make sure it looks right
 	myCachedPacket := theirControl.GetFromTun(true)
-	assertUdpPacket(t, []byte("Hi from me"), myCachedPacket, myVpnIpNet.IP, theirVpnIpNet.IP, 80, 80)
+	assertUdpPacket(t, []byte("Hi from me"), myCachedPacket, myVpnIp, theirVpnIp, 80, 80)
 
-	// Send a packet from them to me
-	theirControl.InjectTunUDPPacket(myVpnIpNet.IP, 80, 80, []byte("Hi from them"))
-	myControl.InjectUDPPacket(theirControl.GetFromUDP(true))
-	theirPacket := myControl.GetFromTun(true)
-	assertUdpPacket(t, []byte("Hi from them"), theirPacket, theirVpnIpNet.IP, myVpnIpNet.IP, 80, 80)
+	// Do a bidirectional tunnel test
+	assertTunnel(t, myVpnIp, theirVpnIp, myControl, theirControl, router.NewR(myControl, theirControl))
 
-	// And once more from me to them
-	myControl.InjectTunUDPPacket(theirVpnIpNet.IP, 80, 80, []byte("Hello again from me"))
-	theirControl.InjectUDPPacket(myControl.GetFromUDP(true))
-	myPacket := theirControl.GetFromTun(true)
-	assertUdpPacket(t, []byte("Hello again from me"), myPacket, myVpnIpNet.IP, theirVpnIpNet.IP, 80, 80)
+	myControl.Stop()
+	theirControl.Stop()
+	//TODO: assert hostmaps
 }
+
+func TestWrongResponderHandshake(t *testing.T) {
+	ca, _, caKey, _ := newTestCaCert(time.Now(), time.Now().Add(10*time.Minute), []*net.IPNet{}, []*net.IPNet{}, []string{})
+
+	myControl, myVpnIp, myUdpAddr := newSimpleServer(ca, caKey, "me", net.IP{10, 0, 0, 1})
+	theirControl, theirVpnIp, theirUdpAddr := newSimpleServer(ca, caKey, "them", net.IP{10, 0, 0, 2})
+	evilControl, evilVpnIp, evilUdpAddr := newSimpleServer(ca, caKey, "evil", net.IP{10, 0, 0, 99})
+
+	// Put the evil udp addr in for their vpn Ip, this is a case of being lied to by the lighthouse
+	myControl.InjectLightHouseAddr(theirVpnIp, evilUdpAddr)
+
+	// But also add their real udp addr, which should be tried after evil
+	myControl.InjectLightHouseAddr(theirVpnIp, theirUdpAddr)
+
+	// Build a router so we don't have to reason who gets which packet
+	r := router.NewR(myControl, theirControl, evilControl)
+
+	// Start the servers
+	myControl.Start()
+	theirControl.Start()
+	evilControl.Start()
+
+	t.Log("Stand up the tunnel with evil (because the lighthouse cache is lying to us about who it is)")
+	myControl.InjectTunUDPPacket(theirVpnIp, 80, 80, []byte("Hi from me"))
+	r.OnceFrom(myControl)
+	r.OnceFrom(evilControl)
+
+	t.Log("I should have a tunnel with evil now and there should not be a cached packet waiting for us")
+	assertTunnel(t, myVpnIp, evilVpnIp, myControl, evilControl, r)
+	assertHostInfoPair(t, myUdpAddr, evilUdpAddr, myVpnIp, evilVpnIp, myControl, evilControl)
+
+	//TODO: Assert pending hostmap - I should have a correct hostinfo for them now
+
+	t.Log("Lets let the messages fly, this time we should have a tunnel with them")
+	r.OnceFrom(myControl)
+	r.OnceFrom(theirControl)
+
+	t.Log("I should now have a tunnel with them now and my original packet should get there")
+	r.RouteUntilAfterMsgType(myControl, 1, 0)
+	myCachedPacket := theirControl.GetFromTun(true)
+	assertUdpPacket(t, []byte("Hi from me"), myCachedPacket, myVpnIp, theirVpnIp, 80, 80)
+
+	t.Log("I should now have a proper tunnel with them")
+	assertHostInfoPair(t, myUdpAddr, theirUdpAddr, myVpnIp, theirVpnIp, myControl, theirControl)
+	assertTunnel(t, myVpnIp, theirVpnIp, myControl, theirControl, r)
+
+	t.Log("Lets make sure evil is still good")
+	assertTunnel(t, myVpnIp, evilVpnIp, myControl, evilControl, r)
+
+	//TODO: assert hostmaps for everyone
+	t.Log("Success!")
+	//TODO: myControl is attempting to shut down 2 tunnels but is blocked on the udp txChan after the first close message
+	// what we really need here is a way to exit all the go routines loops (there are many)
+	//myControl.Stop()
+	//theirControl.Stop()
+}
+
+////TODO: We need to test lies both as the race winner and race loser
+//func TestManyWrongResponderHandshake(t *testing.T) {
+//	ca, _, caKey, _ := newTestCaCert(time.Now(), time.Now().Add(10*time.Minute), []*net.IPNet{}, []*net.IPNet{}, []string{})
+//
+//	myControl, myVpnIp, myUdpAddr := newSimpleServer(ca, caKey, "me", net.IP{10, 0, 0, 99})
+//	theirControl, theirVpnIp, theirUdpAddr := newSimpleServer(ca, caKey, "them", net.IP{10, 0, 0, 2})
+//	evilControl, evilVpnIp, evilUdpAddr := newSimpleServer(ca, caKey, "evil", net.IP{10, 0, 0, 1})
+//
+//	t.Log("Build a router so we don't have to reason who gets which packet")
+//	r := newRouter(myControl, theirControl, evilControl)
+//
+//	t.Log("Lets add more than 10 evil addresses, this exceeds the hostinfo remotes limit")
+//	for i := 0; i < 10; i++ {
+//		addr := net.UDPAddr{IP: evilUdpAddr.IP, Port: evilUdpAddr.Port + i}
+//		myControl.InjectLightHouseAddr(theirVpnIp, &addr)
+//		// We also need to tell our router about it
+//		r.AddRoute(addr.IP, uint16(addr.Port), evilControl)
+//	}
+//
+//	// Start the servers
+//	myControl.Start()
+//	theirControl.Start()
+//	evilControl.Start()
+//
+//	t.Log("Stand up the tunnel with evil (because the lighthouse cache is lying to us about who it is)")
+//	myControl.InjectTunUDPPacket(theirVpnIp, 80, 80, []byte("Hi from me"))
+//
+//	t.Log("We need to spin until we get to the right remote for them")
+//	getOut := false
+//	injected := false
+//	for {
+//		t.Log("Routing for me and evil while we work through the bad ips")
+//		r.RouteExitFunc(myControl, func(packet *nebula.UdpPacket, receiver *nebula.Control) exitType {
+//			// We should stop routing right after we see a packet coming from us to them
+//			if *receiver == *theirControl {
+//				getOut = true
+//				return drainAndExit
+//			}
+//
+//			// We need to poke our real ip in at some point, this is a well protected check looking for that moment
+//			if *receiver == *evilControl {
+//				hi := myControl.GetHostInfoByVpnIP(ip2int(theirVpnIp), true)
+//				if !injected && len(hi.RemoteAddrs) == 1 {
+//					t.Log("I am on my last ip for them, time to inject the real one into my lighthouse")
+//					myControl.InjectLightHouseAddr(theirVpnIp, theirUdpAddr)
+//					injected = true
+//				}
+//				return drainAndExit
+//			}
+//
+//			return keepRouting
+//		})
+//
+//		if getOut {
+//			break
+//		}
+//
+//		r.RouteForUntilAfterToAddr(evilControl, myUdpAddr, drainAndExit)
+//	}
+//
+//	t.Log("I should have a tunnel with evil and them, evil should not have a cached packet")
+//	assertTunnel(t, myVpnIp, evilVpnIp, myControl, evilControl, r)
+//	evilHostInfo := myControl.GetHostInfoByVpnIP(ip2int(evilVpnIp), false)
+//	realEvilUdpAddr := &net.UDPAddr{IP: evilHostInfo.CurrentRemote.IP, Port: int(evilHostInfo.CurrentRemote.Port)}
+//
+//	t.Log("Assert mine and evil's host pairs", evilUdpAddr, realEvilUdpAddr)
+//	assertHostInfoPair(t, myUdpAddr, realEvilUdpAddr, myVpnIp, evilVpnIp, myControl, evilControl)
+//
+//	//t.Log("Draining everyones packets")
+//	//r.Drain(theirControl)
+//	//r.DrainAll(myControl, theirControl, evilControl)
+//	//
+//	//go func() {
+//	//	for {
+//	//		time.Sleep(10 * time.Millisecond)
+//	//		t.Log(len(theirControl.GetUDPTxChan()))
+//	//		t.Log(len(theirControl.GetTunTxChan()))
+//	//		t.Log(len(myControl.GetUDPTxChan()))
+//	//		t.Log(len(evilControl.GetUDPTxChan()))
+//	//		t.Log("=====")
+//	//	}
+//	//}()
+//
+//	t.Log("I should have a tunnel with them now and my original packet should get there")
+//	r.RouteUntilAfterMsgType(myControl, 1, 0)
+//	myCachedPacket := theirControl.GetFromTun(true)
+//
+//	t.Log("Got the cached packet, lets test the tunnel")
+//	assertUdpPacket(t, []byte("Hi from me"), myCachedPacket, myVpnIp, theirVpnIp, 80, 80)
+//
+//	t.Log("Testing tunnels with them")
+//	assertHostInfoPair(t, myUdpAddr, theirUdpAddr, myVpnIp, theirVpnIp, myControl, theirControl)
+//	assertTunnel(t, myVpnIp, theirVpnIp, myControl, theirControl, r)
+//
+//	t.Log("Testing tunnels with evil")
+//	assertTunnel(t, myVpnIp, evilVpnIp, myControl, evilControl, r)
+//
+//	//TODO: assert hostmaps for everyone
+//}

--- a/e2e/router/router.go
+++ b/e2e/router/router.go
@@ -1,0 +1,221 @@
+// +build e2e_testing
+
+package router
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"sync"
+
+	"github.com/slackhq/nebula"
+)
+
+type R struct {
+	// Simple map of the ip:port registered on a control to the control
+	// Basically a router, right?
+	controls map[string]*nebula.Control
+
+	// A map for inbound packets for a control that doesn't know about this address
+	inNat map[string]*nebula.Control
+
+	// A last used map, if an inbound packet hit the inNat map then
+	// all return packets should use the same last used inbound address for the outbound sender
+	// map[from address + ":" + to address] => ip:port to rewrite in the udp packet to receiver
+	outNat map[string]net.UDPAddr
+
+	// All interactions are locked to help serialize behavior
+	sync.Mutex
+}
+
+type exitType int
+
+const (
+	// Keeps routing, the function will get called again on the next packet
+	keepRouting exitType = 0
+	// Does not route this packet and exits immediately
+	exitNow exitType = 1
+	// Routes this packet and exits immediately afterwards
+	routeAndExit exitType = 2
+)
+
+type ExitFunc func(packet *nebula.UdpPacket, receiver *nebula.Control) exitType
+
+func NewR(controls ...*nebula.Control) *R {
+	r := &R{
+		controls: make(map[string]*nebula.Control),
+		inNat:    make(map[string]*nebula.Control),
+		outNat:   make(map[string]net.UDPAddr),
+	}
+
+	for _, c := range controls {
+		addr := c.GetUDPAddr()
+		if _, ok := r.controls[addr]; ok {
+			panic("Duplicate listen address: " + addr)
+		}
+		r.controls[addr] = c
+	}
+
+	return r
+}
+
+// AddRoute will place the nebula controller at the ip and port specified.
+// It does not look at the addr attached to the instance.
+// If a route is used, this will behave like a NAT for the return path.
+// Rewriting the source ip:port to what was last sent to from the origin
+func (r *R) AddRoute(ip net.IP, port uint16, c *nebula.Control) {
+	r.Lock()
+	defer r.Unlock()
+
+	inAddr := net.JoinHostPort(ip.String(), fmt.Sprintf("%v", port))
+	if _, ok := r.inNat[inAddr]; ok {
+		panic("Duplicate listen address inNat: " + inAddr)
+	}
+	r.inNat[inAddr] = c
+}
+
+// OnceFrom will route a single packet from sender then return
+// If the router doesn't have the nebula controller for that address, we panic
+func (r *R) OnceFrom(sender *nebula.Control) {
+	r.RouteExitFunc(sender, func(*nebula.UdpPacket, *nebula.Control) exitType {
+		return routeAndExit
+	})
+}
+
+// RouteUntilTxTun will route for sender and return when a packet is seen on receivers tun
+// If the router doesn't have the nebula controller for that address, we panic
+func (r *R) RouteUntilTxTun(sender *nebula.Control, receiver *nebula.Control) []byte {
+	tunTx := receiver.GetTunTxChan()
+	udpTx := sender.GetUDPTxChan()
+
+	for {
+		select {
+		// Maybe we already have something on the tun for us
+		case b := <-tunTx:
+			return b
+
+		// Nope, lets push the sender along
+		case p := <-udpTx:
+			outAddr := sender.GetUDPAddr()
+			r.Lock()
+			inAddr := net.JoinHostPort(p.ToIp.String(), fmt.Sprintf("%v", p.ToPort))
+			c := r.getControl(outAddr, inAddr, p)
+			if c == nil {
+				r.Unlock()
+				panic("No control for udp tx")
+			}
+
+			c.InjectUDPPacket(p)
+			r.Unlock()
+		}
+	}
+}
+
+// RouteExitFunc will call the whatDo func with each udp packet from sender.
+// whatDo can return:
+//   - exitNow: the packet will not be routed and this call will return immediately
+//   - routeAndExit: this call will return immediately after routing the last packet from sender
+//   - keepRouting: the packet will be routed and whatDo will be called again on the next packet from sender
+//TODO: is this RouteWhile?
+func (r *R) RouteExitFunc(sender *nebula.Control, whatDo ExitFunc) {
+	h := &nebula.Header{}
+	for {
+		p := sender.GetFromUDP(true)
+		r.Lock()
+		if err := h.Parse(p.Data); err != nil {
+			panic(err)
+		}
+
+		outAddr := sender.GetUDPAddr()
+		inAddr := net.JoinHostPort(p.ToIp.String(), fmt.Sprintf("%v", p.ToPort))
+		receiver := r.getControl(outAddr, inAddr, p)
+		if receiver == nil {
+			r.Unlock()
+			panic("Can't route for host: " + inAddr)
+		}
+
+		e := whatDo(p, receiver)
+		switch e {
+		case exitNow:
+			r.Unlock()
+			return
+
+		case routeAndExit:
+			receiver.InjectUDPPacket(p)
+			r.Unlock()
+			return
+
+		case keepRouting:
+			receiver.InjectUDPPacket(p)
+
+		default:
+			panic(fmt.Sprintf("Unknown exitFunc return: %v", e))
+		}
+
+		r.Unlock()
+	}
+}
+
+// RouteUntilAfterMsgType will route for sender until a message type is seen and sent from sender
+// If the router doesn't have the nebula controller for that address, we panic
+func (r *R) RouteUntilAfterMsgType(sender *nebula.Control, msgType nebula.NebulaMessageType, subType nebula.NebulaMessageSubType) {
+	h := &nebula.Header{}
+	r.RouteExitFunc(sender, func(p *nebula.UdpPacket, r *nebula.Control) exitType {
+		if err := h.Parse(p.Data); err != nil {
+			panic(err)
+		}
+		if h.Type == msgType && h.Subtype == subType {
+			return routeAndExit
+		}
+
+		return keepRouting
+	})
+}
+
+// RouteForUntilAfterToAddr will route for sender and return only after it sees and sends a packet destined for toAddr
+// finish can be any of the exitType values except `keepRouting`, the default value is `routeAndExit`
+// If the router doesn't have the nebula controller for that address, we panic
+func (r *R) RouteForUntilAfterToAddr(sender *nebula.Control, toAddr *net.UDPAddr, finish exitType) {
+	if finish == keepRouting {
+		finish = routeAndExit
+	}
+
+	r.RouteExitFunc(sender, func(p *nebula.UdpPacket, r *nebula.Control) exitType {
+		if p.ToIp.Equal(toAddr.IP) && p.ToPort == uint16(toAddr.Port) {
+			return finish
+		}
+
+		return keepRouting
+	})
+}
+
+// getControl performs or seeds NAT translation and returns the control for toAddr, p from fields may change
+// This is an internal router function, the caller must hold the lock
+func (r *R) getControl(fromAddr, toAddr string, p *nebula.UdpPacket) *nebula.Control {
+	if newAddr, ok := r.outNat[fromAddr+":"+toAddr]; ok {
+		p.FromIp = newAddr.IP
+		p.FromPort = uint16(newAddr.Port)
+	}
+
+	c, ok := r.inNat[toAddr]
+	if ok {
+		sHost, sPort, err := net.SplitHostPort(toAddr)
+		if err != nil {
+			panic(err)
+		}
+
+		port, err := strconv.Atoi(sPort)
+		if err != nil {
+			panic(err)
+		}
+
+		r.outNat[c.GetUDPAddr()+":"+fromAddr] = net.UDPAddr{
+			IP:   net.ParseIP(sHost),
+			Port: port,
+		}
+		return c
+	}
+
+	//TODO: call receive hooks!
+	return r.controls[toAddr]
+}

--- a/inside.go
+++ b/inside.go
@@ -215,9 +215,11 @@ func (f *Interface) SendMessageToAll(t NebulaMessageType, st NebulaMessageSubTyp
 }
 
 func (f *Interface) sendMessageToAll(t NebulaMessageType, st NebulaMessageSubType, hostInfo *HostInfo, p, nb, b []byte) {
-	for _, r := range hostInfo.RemoteUDPAddrs() {
+	hostInfo.RLock()
+	for _, r := range hostInfo.Remotes {
 		f.send(t, st, hostInfo.ConnectionState, hostInfo, r, p, nb, b)
 	}
+	hostInfo.RUnlock()
 }
 
 func (f *Interface) send(t NebulaMessageType, st NebulaMessageSubType, ci *ConnectionState, hostinfo *HostInfo, remote *udpAddr, p, nb, out []byte) {

--- a/ssh.go
+++ b/ssh.go
@@ -352,7 +352,7 @@ func sshListHostMap(hostMap *HostMap, a interface{}, w sshd.StringWriter) error 
 				"vpnIp":         int2ip(v.hostId),
 				"localIndex":    v.localIndexId,
 				"remoteIndex":   v.remoteIndexId,
-				"remoteAddrs":   v.RemoteUDPAddrs(),
+				"remoteAddrs":   v.CopyRemotes(),
 				"cachedPackets": len(v.packetStore),
 				"cert":          v.GetCert(),
 			}
@@ -372,7 +372,7 @@ func sshListHostMap(hostMap *HostMap, a interface{}, w sshd.StringWriter) error 
 		}
 	} else {
 		for i, v := range hostMap.Hosts {
-			err := w.WriteLine(fmt.Sprintf("%s: %s", int2ip(i), v.RemoteUDPAddrs()))
+			err := w.WriteLine(fmt.Sprintf("%s: %s", int2ip(i), v.CopyRemotes()))
 			if err != nil {
 				return err
 			}

--- a/tun_tester.go
+++ b/tun_tester.go
@@ -28,8 +28,8 @@ func newTun(l *logrus.Logger, deviceName string, cidr *net.IPNet, defaultMTU int
 		MTU:          defaultMTU,
 		UnsafeRoutes: unsafeRoutes,
 		l:            l,
-		rxPackets:    make(chan []byte, 100),
-		txPackets:    make(chan []byte, 100),
+		rxPackets:    make(chan []byte, 1),
+		txPackets:    make(chan []byte, 1),
 	}, nil
 }
 
@@ -41,6 +41,9 @@ func newTunFromFd(_ *logrus.Logger, _ int, _ *net.IPNet, _ int, _ []route, _ []r
 // These are unencrypted ip layer frames destined for another nebula node.
 // packets should exit the udp side, capture them with udpConn.Get
 func (c *Tun) Send(packet []byte) {
+	if c.l.Level >= logrus.DebugLevel {
+		c.l.Debug("Tun injecting packet")
+	}
 	c.rxPackets <- packet
 }
 

--- a/tun_windows.go
+++ b/tun_windows.go
@@ -1,3 +1,5 @@
+// +build !e2e_testing
+
 package nebula
 
 import (

--- a/udp_tester.go
+++ b/udp_tester.go
@@ -38,6 +38,7 @@ func NewListener(l *logrus.Logger, ip string, port int, _ bool) (*udpConn, error
 // this is an encrypted packet or a handshake message in most cases
 // packets were transmitted from another nebula node, you can send them with Tun.Send
 func (u *udpConn) Send(packet *UdpPacket) {
+	u.l.Infof("UDP injecting packet %+v", packet)
 	u.rxPackets <- packet
 }
 
@@ -71,8 +72,8 @@ func (u *udpConn) WriteTo(b []byte, addr *udpAddr) error {
 	}
 
 	copy(p.Data, b)
-	copy(p.ToIp, addr.IP)
-	copy(p.FromIp, u.addr.IP)
+	copy(p.ToIp, addr.IP.To16())
+	copy(p.FromIp, u.addr.IP.To16())
 
 	u.txPackets <- p
 	return nil

--- a/udp_windows.go
+++ b/udp_windows.go
@@ -1,3 +1,5 @@
+// +build !e2e_testing
+
 package nebula
 
 // Windows support is primarily implemented in udp_generic, besides NewListenConfig


### PR DESCRIPTION
This test case covers the changes necessary to move beyond a simple case of "I have a bad ip in my hostinfo"

New make targets
- `make e2e` - smallest possible output
- `make e2ev` - include `t.Log` output
- `make e2evv` - include `t.Log` and `logger` `INFO` level output
- `make e2evvv` - include `t.Log` and `logger` `DEBUG` level output
- `make e2evvvv` - include `t.Log` and `logger` `VERBOSE` level output