### PR TITLE
Only set serveDns if the host is also configured to be a lighthouse.

### DIFF
--- a/dns_server.go
+++ b/dns_server.go
@@ -133,7 +133,7 @@ func getDnsServerAddr(c *Config) string {
 func startDns(l *logrus.Logger, c *Config) {
 	dnsAddr = getDnsServerAddr(c)
 	dnsServer = &dns.Server{Addr: dnsAddr, Net: "udp"}
-	l.Infof("Starting DNS responder at %s\n", dnsAddr)
+	l.WithField("dnsListener", dnsAddr).Infof("Starting DNS responder")
 	err := dnsServer.ListenAndServe()
 	defer dnsServer.Shutdown()
 	if err != nil {

--- a/dns_server.go
+++ b/dns_server.go
@@ -133,7 +133,7 @@ func getDnsServerAddr(c *Config) string {
 func startDns(l *logrus.Logger, c *Config) {
 	dnsAddr = getDnsServerAddr(c)
 	dnsServer = &dns.Server{Addr: dnsAddr, Net: "udp"}
-	l.Debugf("Starting DNS responder at %s\n", dnsAddr)
+	l.Infof("Starting DNS responder at %s\n", dnsAddr)
 	err := dnsServer.ListenAndServe()
 	defer dnsServer.Shutdown()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -341,7 +341,15 @@ func Main(config *Config, configTest bool, buildVersion string, logger *logrus.L
 	//handshakeMACKey := config.GetString("handshake_mac.key", "")
 	//handshakeAcceptedMACKeys := config.GetStringSlice("handshake_mac.accepted_keys", []string{})
 
-	serveDns := config.GetBool("lighthouse.am_lighthouse", false) && config.GetBool("lighthouse.serve_dns", false)
+	serveDns := false
+	if config.GetBool("lighthouse.serve_dns", false) {
+		if config.GetBool("lighthouse.am_lighthouse", false) {
+			serveDns = true
+		} else {
+			l.Warn("DNS server refusing to run because this host is not a lighthouse.")
+		}
+	}
+
 	checkInterval := config.GetInt("timers.connection_alive_interval", 5)
 	pendingDeletionInterval := config.GetInt("timers.pending_deletion_interval", 10)
 	ifConfig := &InterfaceConfig{

--- a/main.go
+++ b/main.go
@@ -341,7 +341,7 @@ func Main(config *Config, configTest bool, buildVersion string, logger *logrus.L
 	//handshakeMACKey := config.GetString("handshake_mac.key", "")
 	//handshakeAcceptedMACKeys := config.GetStringSlice("handshake_mac.accepted_keys", []string{})
 
-	serveDns := config.GetBool("lighthouse.serve_dns", false)
+	serveDns := config.GetBool("lighthouse.am_lighthouse", false) && config.GetBool("lighthouse.serve_dns", false)
 	checkInterval := config.GetInt("timers.connection_alive_interval", 5)
 	pendingDeletionInterval := config.GetInt("timers.pending_deletion_interval", 10)
 	ifConfig := &InterfaceConfig{


### PR DESCRIPTION
Nebula attempts an Add() call against the global dnsR variable if serveDns is true.
Unfortunately, the global dnsR is only initialized in main.go if the dns config is set to true AND the system is configured to be a lighthouse.
If the host is not configured to be a lighthouse but is also configured to serve DNS, the Add call will panic against the nil dnsR.