### PR TITLE
Remove obsolete systemd unit settings (take 2)

### DIFF
--- a/dist/arch/nebula.service
+++ b/dist/arch/nebula.service
@@ -5,8 +5,6 @@ After=basic.target network.target network-online.target
 
 [Service]
 SyslogIdentifier=nebula
-StandardOutput=syslog
-StandardError=syslog
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/bin/nebula -config /etc/nebula/config.yml
 Restart=always

--- a/examples/quickstart-vagrant/ansible/roles/nebula/files/systemd.nebula.service
+++ b/examples/quickstart-vagrant/ansible/roles/nebula/files/systemd.nebula.service
@@ -5,8 +5,6 @@ After=basic.target network.target
 
 [Service]
 SyslogIdentifier=nebula
-StandardOutput=syslog
-StandardError=syslog
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/local/bin/nebula -config /etc/nebula/config.yml
 Restart=always


### PR DESCRIPTION
Similar to PR #412, except this removes the remaining references.

`dist/arch/nebula.service` is used by the [Arch `nebula`](https://github.com/archlinux/svntogit-community/blob/packages/nebula/trunk/PKGBUILD#L40) package.