### PR TITLE
Minor windows focused improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOMINVERSION = 1.16
 NEBULA_CMD_PATH = "./cmd/nebula"
 NEBULA_CMD_SUFFIX =
-BUILD_NUMBER ?= $(shell git describe --abbrev=0 --match "v*" | cut -dv -f2)-$(shell git branch --show-current)-$(shell git describe --dirty | cut -d- -f2-)
+BUILD_NUMBER ?= $(shell git describe --abbrev=0 --match "v*" | cut -dv -f2)-$(shell git branch --show-current)-$(shell git describe --long --dirty | cut -d- -f2-)
 
 ifeq ($(OS),Windows_NT)
 	#TODO: we should be able to ditch awk as well

--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,12 @@ else
 	NULL_FILE = /dev/null
 endif
 
-# Only defined the build number if we haven't already, stop
+# Only defined the build number if we haven't already
 ifndef BUILD_NUMBER
-	ifeq ($(shell git describe --exact-match > $(NULL_FILE) 2>&1; echo $$?),0)
-		BUILD_NUMBER ?= $(shell git describe --exact-match --dirty | cut -dv -f2)
+	ifeq ($(shell git describe --exact-match 2>$(NULL_FILE)),)
+		BUILD_NUMBER = $(shell git describe --abbrev=0 --match "v*" | cut -dv -f2)-$(shell git branch --show-current)-$(shell git describe --long --dirty | cut -d- -f2-)
 	else
-		BUILD_NUMBER ?= $(shell git describe --abbrev=0 --match "v*" | cut -dv -f2)-$(shell git branch --show-current)-$(shell git describe --long --dirty | cut -d- -f2-)
+		BUILD_NUMBER = $(shell git describe --exact-match --dirty | cut -dv -f2)
 	endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOMINVERSION = 1.16
 NEBULA_CMD_PATH = "./cmd/nebula"
 NEBULA_CMD_SUFFIX =
-BUILD_NUMBER ?= $(shell git describe --abbrev=0 --match 'v*' | cut -dv -f2)-$(shell git branch --show-current)-$(shell git describe --dirty | cut -d- -f2-)
+BUILD_NUMBER ?= $(shell git describe --abbrev=0 --match "v*" | cut -dv -f2)-$(shell git branch --show-current)-$(shell git describe --dirty | cut -d- -f2-)
 
 ifeq ($(OS),Windows_NT)
 	#TODO: we should be able to ditch awk as well

--- a/Makefile
+++ b/Makefile
@@ -165,5 +165,5 @@ smoke-docker-race: BUILD_ARGS = -race
 smoke-docker-race: smoke-docker
 
 .FORCE:
-.PHONY: e2e e2ev e2evv e2evvv e2evvvv test test-cov-html bench bench-cpu bench-cpu-long bin proto release service smoke-docker smoke-docker-race bin
+.PHONY: e2e e2ev e2evv e2evvv e2evvvv test test-cov-html bench bench-cpu bench-cpu-long bin proto release service smoke-docker smoke-docker-race
 .DEFAULT_GOAL := bin

--- a/cmd/nebula-service/logs_generic.go
+++ b/cmd/nebula-service/logs_generic.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package main
+
+import "github.com/sirupsen/logrus"
+
+func HookLogger(l *logrus.Logger) {
+	// Do nothing, let the logs flow to stdout/stderr
+}

--- a/cmd/nebula-service/logs_windows.go
+++ b/cmd/nebula-service/logs_windows.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"github.com/kardianos/service"
+	"github.com/sirupsen/logrus"
+	"io/ioutil"
+	"os"
+)
+
+// HookLogger routes the logrus logs through the service logger so that they end up in the Windows Event Viewer
+// logrus output will be discarded
+func HookLogger(l *logrus.Logger) {
+	l.AddHook(newLogHook(logger))
+	l.SetOutput(ioutil.Discard)
+}
+
+type logHook struct {
+	sl service.Logger
+}
+
+func newLogHook(sl service.Logger) *logHook {
+	return &logHook{sl: sl}
+}
+
+func (h *logHook) Fire(entry *logrus.Entry) error {
+	line, err := entry.String()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to read entry, %v", err)
+		return err
+	}
+
+	switch entry.Level {
+	case logrus.PanicLevel:
+		return h.sl.Error(line)
+	case logrus.FatalLevel:
+		return h.sl.Error(line)
+	case logrus.ErrorLevel:
+		return h.sl.Error(line)
+	case logrus.WarnLevel:
+		return h.sl.Warning(line)
+	case logrus.InfoLevel:
+		return h.sl.Info(line)
+	case logrus.DebugLevel:
+		return h.sl.Info(line)
+	default:
+		return nil
+	}
+}
+
+func (h *logHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}

--- a/cmd/nebula-service/logs_windows.go
+++ b/cmd/nebula-service/logs_windows.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/kardianos/service"
-	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"os"
+
+	"github.com/kardianos/service"
+	"github.com/sirupsen/logrus"
 )
 
 // HookLogger routes the logrus logs through the service logger so that they end up in the Windows Event Viewer


### PR DESCRIPTION
This change does the following
- Adjusts the build number for non releases to provide more useful information `$lastReleaseTag-$currentBranch-$commitsAheadOfLastRelease-$currentSha`, if the current directory has uncommitted changes `-dirty` is appended. An example here `1.3.0-win-make-51-gd8fe8ad-dirty` (thanks @wadey for putting this together)
- `Makefile` should work on Windows powershell and command prompt assuming you have `gnu make`, `awk`, `cut`, and `git` installed.
- `make bin` will output binaries with the `.exe` suffix
- Service mode logs are routed to the windows event log system instead of nowhere.

For the `make` dependencies I used `choco` to install `awk`, `make`, and `gnuwin32-coreutils.install`. Also added `%PROGRAMFILES(X86)%\GnuWin32\bin` to `%PATH%`