### PR TITLE
Fix a failed return in an error case

### DIFF
--- a/lighthouse.go
+++ b/lighthouse.go
@@ -369,7 +369,7 @@ func (lh *LightHouse) SendUpdate(f EncWriter) {
 	out := make([]byte, mtu)
 
 	mm, err := proto.Marshal(m)
-	if err != nil && lh.l.Level >= logrus.DebugLevel {
+	if err != nil {
 		lh.l.WithError(err).Error("Error while marshaling for lighthouse update")
 		return
 	}


### PR DESCRIPTION
This line has drifted to making it possible to send a failed protobuf packet to the lighthouse while hiding an error log behind a debug check