### PR TITLE
Fully close tunnels when CloseAllTunnels is called

### DIFF
--- a/control.go
+++ b/control.go
@@ -142,7 +142,7 @@ func (c *Control) CloseTunnel(vpnIP uint32, localOnly bool) bool {
 		)
 	}
 
-	c.f.closeTunnel(hostInfo)
+	c.f.closeTunnel(hostInfo, false)
 	return true
 }
 
@@ -160,6 +160,8 @@ func (c *Control) CloseAllTunnels(excludeLighthouses bool) (closed int) {
 
 		if h.ConnectionState.ready {
 			c.f.send(closeTunnel, 0, h.ConnectionState, h, h.remote, []byte{}, make([]byte, 12, 12), make([]byte, mtu))
+			c.f.closeTunnel(h, true)
+
 			c.l.WithField("vpnIp", IntIp(h.hostId)).WithField("udpAddr", h.remote).
 				Debug("Sending close tunnel message")
 			closed++

--- a/ssh.go
+++ b/ssh.go
@@ -520,7 +520,7 @@ func sshCloseTunnel(ifce *Interface, fs interface{}, a []string, w sshd.StringWr
 		)
 	}
 
-	ifce.closeTunnel(hostInfo)
+	ifce.closeTunnel(hostInfo, false)
 	return w.WriteLine("Closed")
 }
 


### PR DESCRIPTION
@JohnMaguire noticed that when his mobile device sleeps, and all tunnels are closed (a beta feature), the remote end will try to handshake and enter race avoidance because we haven't properly torn down the tunnels.

To be clear, this only affects mobile clients.