### PR TITLE
Get out faster on nil udpAddr

### DIFF
--- a/outside.go
+++ b/outside.go
@@ -335,7 +335,7 @@ func (f *Interface) handleRecvError(addr *udpAddr, h *Header) {
 	if !hostinfo.RecvErrorExceeded() {
 		return
 	}
-	if hostinfo.remote != nil && hostinfo.remote.String() != addr.String() {
+	if hostinfo.remote != nil && hostinfo.remote.Equals(addr) {
 		f.l.Infoln("Someone spoofing recv_errors? ", addr, hostinfo.remote)
 		return
 	}

--- a/remote_list.go
+++ b/remote_list.go
@@ -99,6 +99,10 @@ func (r *RemoteList) ForEach(preferredRanges []*net.IPNet, forEach forEachFunc) 
 // CopyAddrs locks and makes a deep copy of the deduplicated address list
 // The deduplication work may need to occur here, so you must pass preferredRanges
 func (r *RemoteList) CopyAddrs(preferredRanges []*net.IPNet) []*udpAddr {
+	if r == nil {
+		return nil
+	}
+
 	r.Rebuild(preferredRanges)
 
 	r.RLock()

--- a/udp_all.go
+++ b/udp_all.go
@@ -33,14 +33,26 @@ func (ua *udpAddr) Equals(t *udpAddr) bool {
 }
 
 func (ua *udpAddr) String() string {
+	if ua == nil {
+		return "<nil>"
+	}
+
 	return net.JoinHostPort(ua.IP.String(), fmt.Sprintf("%v", ua.Port))
 }
 
 func (ua *udpAddr) MarshalJSON() ([]byte, error) {
+	if ua == nil {
+		return nil, nil
+	}
+
 	return json.Marshal(m{"ip": ua.IP, "port": ua.Port})
 }
 
 func (ua *udpAddr) Copy() *udpAddr {
+	if ua == nil {
+		return nil
+	}
+
 	nu := udpAddr{
 		Port: ua.Port,
 		IP:   make(net.IP, len(ua.IP)),


### PR DESCRIPTION
We had a crash in mobile land related to calling `udpAddr.String()` on a nil address, this addresses other possible crashes.