### PR TITLE
Dont apply race avoidance to existing handshakes, use the handshake time to determine who wins

### DIFF
--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -211,7 +211,7 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, packet []byte, h *Header) {
 			f.l.WithField("vpnIp", IntIp(vpnIP)).WithField("udpAddr", addr).
 				WithField("certName", certName).
 				WithField("oldHandshakeTime", existing.lastHandshakeTime).
-				WithField("newHandshakeTime", existing.lastHandshakeTime).
+				WithField("newHandshakeTime", hostinfo.lastHandshakeTime).
 				WithField("fingerprint", fingerprint).
 				WithField("initiatorIndex", hs.Details.InitiatorIndex).WithField("responderIndex", hs.Details.ResponderIndex).
 				WithField("remoteIndex", h.RemoteIndex).WithField("handshake", m{"stage": 1, "style": "ix_psk0"}).

--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -119,11 +119,12 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, packet []byte, h *Header) {
 	}
 
 	hostinfo := &HostInfo{
-		ConnectionState: ci,
-		localIndexId:    myIndex,
-		remoteIndexId:   hs.Details.InitiatorIndex,
-		hostId:          vpnIP,
-		HandshakePacket: make(map[uint8][]byte, 0),
+		ConnectionState:   ci,
+		localIndexId:      myIndex,
+		remoteIndexId:     hs.Details.InitiatorIndex,
+		hostId:            vpnIP,
+		HandshakePacket:   make(map[uint8][]byte, 0),
+		lastHandshakeTime: hs.Details.Time,
 	}
 
 	hostinfo.Lock()
@@ -138,6 +139,8 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, packet []byte, h *Header) {
 
 	hs.Details.ResponderIndex = myIndex
 	hs.Details.Cert = ci.certState.rawCertificateNoKey
+	// Update the time in case their clock is way off from ours
+	hs.Details.Time = uint64(time.Now().Unix())
 
 	hsBytes, err := proto.Marshal(hs)
 	if err != nil {
@@ -204,18 +207,15 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, packet []byte, h *Header) {
 			}
 			return
 		case ErrExistingHostInfo:
-			// This means there was an existing tunnel and we didn't win
-			// handshake avoidance
-
-			//TODO: sprinkle the new protobuf stuff in here, send a reply to get the recv_errors flowing
-			//TODO: if not new send a test packet like old
-
+			// This means there was an existing tunnel and this handshake was older than the one we are currently based on
 			f.l.WithField("vpnIp", IntIp(vpnIP)).WithField("udpAddr", addr).
 				WithField("certName", certName).
+				WithField("oldHandshakeTime", existing.lastHandshakeTime).
+				WithField("newHandshakeTime", existing.lastHandshakeTime).
 				WithField("fingerprint", fingerprint).
 				WithField("initiatorIndex", hs.Details.InitiatorIndex).WithField("responderIndex", hs.Details.ResponderIndex).
 				WithField("remoteIndex", h.RemoteIndex).WithField("handshake", m{"stage": 1, "style": "ix_psk0"}).
-				Info("Prevented a handshake race")
+				Info("Handshake too old")
 
 			// Send a test packet to trigger an authenticated tunnel test, this should suss out any lingering tunnel issues
 			f.SendMessageToVpnIp(test, testRequest, vpnIP, []byte(""), make([]byte, 12, 12), make([]byte, mtu))
@@ -394,7 +394,7 @@ func ixHandshakeStage2(f *Interface, addr *udpAddr, hostinfo *HostInfo, packet [
 		Info("Handshake message received")
 
 	hostinfo.remoteIndexId = hs.Details.ResponderIndex
-	hs.Details.Cert = ci.certState.rawCertificateNoKey
+	hostinfo.lastHandshakeTime = hs.Details.Time
 
 	// Store their cert and our symmetric keys
 	ci.peerCert = remoteCert

--- a/hostmap.go
+++ b/hostmap.go
@@ -59,6 +59,11 @@ type HostInfo struct {
 	// with a handshake
 	lastRebindCount int8
 
+	// lastHandshakeTime records the time the remote side told us about at the stage when the handshake was completed locally
+	// Stage 1 packet will contain it if I am a responder, stage 2 packet if I am an initiator
+	// This is used to avoid an attack where a handshake packet is replayed after some time
+	lastHandshakeTime uint64
+
 	lastRoam       time.Time
 	lastRoamRemote *udpAddr
 }


### PR DESCRIPTION
We used to check the main hostmap at stage 1 for an existing tunnel and apply race avoidance logic to it. This causes a lot of pain for hosts that were unable to transmit a `close_tunnel` packet but declared the tunnel dead locally (through roaming, unclean shutdown, network loss).

What happens now is that we track the `Time` field transmitted in handshake packet on the hostinfo object, this field has always been present and populated. If we get into the situation described above we will make sure the new handshake is _actually_ newer than the one we used before. If it is, we replace the tunnel. If it wasn't, we enter the same old flow of testing the tunnel. I believe the only real world case here are an incredibly high latency link or an attacker cached a handshake packet and retransmitted it at a later time, both which are handled.

Most notably, any client pre v1.4 will transmit the time value it received at stage 1 back on stage 2. If that responders clock is way off from the initiator and they get into the flow described at the top _as an initiator_ they may enter the test tunnel flow, which is identical to how the issue would be handled in v1.3 and before.

TLDR: This makes handshakes *much* faster in some error conditions

