### PR TITLE
Remove log when no handshake message is sent

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,4 +77,4 @@ jobs:
       run: go test -v ./...
 
     - name: End 2 end
-      run: go test -tags=e2e_testing -count=1 ./e2e
+      run: make e2evv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       run: make test
 
     - name: End 2 end
-      run: make e2e
+      run: make e2evv
 
   test:
     name: Build and test on ${{ matrix.os }}

--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -160,10 +160,13 @@ func (c *HandshakeManager) handleOutbound(vpnIP uint32, f EncWriter, lighthouseT
 		}
 	})
 
-	hostinfo.logger(c.l).WithField("udpAddrs", sentTo).
-		WithField("initiatorIndex", hostinfo.localIndexId).
-		WithField("handshake", m{"stage": 1, "style": "ix_psk0"}).
-		Info("Handshake message sent")
+	// Don't be too noisy or confusing if we fail to send a handshake - if we don't get through we'll eventually log a timeout
+	if len(sentTo) > 0 {
+		hostinfo.logger(c.l).WithField("udpAddrs", sentTo).
+			WithField("initiatorIndex", hostinfo.localIndexId).
+			WithField("handshake", m{"stage": 1, "style": "ix_psk0"}).
+			Info("Handshake message sent")
+	}
 
 	// Increment the counter to increase our delay, linear backoff
 	hostinfo.HandshakeCounter++


### PR DESCRIPTION
There are two cases where you might see a log message "Handshake message
sent" when in actually this did not occur:

1. An error occurred sending the handshake message
2. There were no addresses for consideration when attempting to
   handshake

The first case already logs an error. This PR removes the log message in
the second case. It will eventually result in a timeout log.