### PR TITLE
Increase the timestamp resolution for handshakes

### DIFF
--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -31,7 +31,7 @@ func ixHandshakeStage0(f *Interface, vpnIp uint32, hostinfo *HostInfo) {
 
 	hsProto := &NebulaHandshakeDetails{
 		InitiatorIndex: hostinfo.localIndexId,
-		Time:           uint64(time.Now().Unix()),
+		Time:           uint64(time.Now().UnixNano()),
 		Cert:           ci.certState.rawCertificateNoKey,
 	}
 
@@ -140,7 +140,7 @@ func ixHandshakeStage1(f *Interface, addr *udpAddr, packet []byte, h *Header) {
 	hs.Details.ResponderIndex = myIndex
 	hs.Details.Cert = ci.certState.rawCertificateNoKey
 	// Update the time in case their clock is way off from ours
-	hs.Details.Time = uint64(time.Now().Unix())
+	hs.Details.Time = uint64(time.Now().UnixNano())
 
 	hsBytes, err := proto.Marshal(hs)
 	if err != nil {


### PR DESCRIPTION
#451 introduced a way to more quickly resolve tunnel replacement but the end 2 end tests end up being racy since the current handshake resolution is 1 second and the communication speed there is very fast.

The real world impact of this change is to make tunnel replacement faster on fast networks. Pre v1.4 vs a v1.4 is basically the v1.4 host will always win, even if it shouldn't, but the v1.3 host will always lose in some very specific situations. The fallback mechanism is the same for v1.3 and before, race avoidance.