### PR TITLE
Added generic systemd units supporting multiple networks

### DIFF
--- a/dist/systemd/README.md
+++ b/dist/systemd/README.md
@@ -1,0 +1,33 @@
+# Using Nebula with Systemd
+
+This guide describes how to use Systemd to manage one or multiple Nebula services.
+
+## Install the unit files 
+
+Copy the units files in your distribution's service directory.
+
+```sh
+cp dist/systemd/*.service /etc/systemd/system/
+```
+
+## Create a new network
+
+```sh
+mkdir /etc/nebula/mynet
+cd /etc/nebula/mynet
+nebula-cert ca -name "mynet"
+nebula-cert sign -name "lighthouse" -out-key /etc/nebula/mynet/host.key -out-crt /etc/nebula/mynet/host.crt -ip "10.200.0.1/24"
+wget https://raw.githubusercontent.com/slackhq/nebula/master/examples/config.yml
+<edit the config to your needs>
+```
+
+#### REMINDER
+
+You should probably move your ca.key away from the lighthouse or any nebula host.
+
+## Enable the service
+
+```sh
+systemctl enable nebula@mynet
+systemctl start nebula@mynet 
+```

--- a/dist/systemd/nebula.service
+++ b/dist/systemd/nebula.service
@@ -1,0 +1,17 @@
+# This is a mostly empty service, but allows commands like stop, start, reload
+# to propagate to all nebula@ service instances.
+[Unit]
+Description=Nebula VPN
+Documentation=info:nebula
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/true
+ExecReload=/bin/true
+WorkingDirectory=/etc/nebula
+
+[Install]
+WantedBy=multi-user.target

--- a/dist/systemd/nebula@.service
+++ b/dist/systemd/nebula@.service
@@ -1,0 +1,20 @@
+# This unit allows for multiple Nebula to be configured in /etc/nebula/<network_name>
+# It assumes the configuration is located at /etc/nebula/<network_name>/config.yml
+[Unit]
+Description=Nebula net %i
+Documentation=info:nebula
+PartOf=nebula.service
+ReloadPropagatedFrom=nebula.service
+
+[Service]
+Type=simple
+WorkingDirectory=/etc/nebula/%i
+ExecStart=/usr/sbin/nebula -config /etc/nebula/%i/config.yml
+ExecReload=/bin/kill -HUP $MAINPID
+KillMode=process
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=5
+
+[Install]
+WantedBy=nebula.service


### PR DESCRIPTION
I think `network-online.target` is supported on most distributions, not sure about `network.target`.

