### PR TITLE
Don't check for rebind if we are closing the tunnel

### DIFF
--- a/inside.go
+++ b/inside.go
@@ -201,7 +201,7 @@ func (f *Interface) sendNoMetrics(t NebulaMessageType, st NebulaMessageSubType, 
 
 	// Query our LH if we haven't since the last time we've been rebound, this will cause the remote to punch against
 	// all our IPs and enable a faster roaming.
-	if hostinfo.lastRebindCount != f.rebindCount {
+	if t != closeTunnel && hostinfo.lastRebindCount != f.rebindCount {
 		//NOTE: there is an update hole if a tunnel isn't used and exactly 256 rebinds occur before the tunnel is
 		// finally used again. This tunnel would eventually be torn down and recreated if this action didn't help.
 		f.lightHouse.QueryServer(hostinfo.hostId, f)


### PR DESCRIPTION
This is to primarily avoid a deadlock while shutting down but also there's no point in trying to enable faster roaming if we are closing the tunnel.