### PR TITLE
Filter DNS queries by zone

### DIFF
--- a/dns_server.go
+++ b/dns_server.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-	"sync"
 	"strings"
+	"sync"
 
 	"github.com/miekg/dns"
 	"github.com/sirupsen/logrus"
@@ -176,7 +176,7 @@ func getDnsServerAddr(c *Config) string {
 func getDnsZones(c *Config) Zones {
 	zones := c.GetStringSlice("lighthouse.dns.zones", []string{})
 	for i := range zones {
-		zones[i] = strings.ToLower(dns.Fqdn(zones[i]))  // equivalent to dns.CanonicalName in latest version of dns
+		zones[i] = strings.ToLower(dns.Fqdn(zones[i])) // equivalent to dns.CanonicalName in latest version of dns
 	}
 	return zones
 }

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -35,6 +35,8 @@ lighthouse:
     # Use zones to filter DNS responses
     #zones:
     #  - nebula.example.com
+    # If respond_to_filtered is false, drop queries that do not match any of the zones.
+    #respond_to_filtered: false
   # interval is the number of seconds between updates from this node to a lighthouse.
   # during updates, a node sends information about its current IP addresses to each node.
   interval: 60

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -32,7 +32,9 @@ lighthouse:
     # Use domain to filter DNS A responses to those ending with domain.
     #host: 0.0.0.0
     #port: 53
-    #domain:
+    # Use zones to filter DNS responses
+    #zones:
+    #  - nebula.example.com
   # interval is the number of seconds between updates from this node to a lighthouse.
   # during updates, a node sends information about its current IP addresses to each node.
   interval: 60

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -29,8 +29,10 @@ lighthouse:
   #serve_dns: false
   #dns:
     # The DNS host defines the IP to bind the dns listener to. This also allows binding to the nebula node IP.
+    # Use domain to filter DNS A responses to those ending with domain.
     #host: 0.0.0.0
     #port: 53
+    #domain:
   # interval is the number of seconds between updates from this node to a lighthouse.
   # during updates, a node sends information about its current IP addresses to each node.
   interval: 60

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -34,8 +34,8 @@ lighthouse:
     # Use zones to filter DNS replies
     #zones:
     #  - nebula.example.com
-    # If respond_to_filtered is false, drop queries that do not match any of the zones. Otherwise, send an empty reply.
-    #respond_to_filtered: true
+    # If drop_filtered is true, drop queries that do not match any of the zones. Otherwise, send an empty reply.
+    #drop_filtered: false
   # interval is the number of seconds between updates from this node to a lighthouse.
   # during updates, a node sends information about its current IP addresses to each node.
   interval: 60

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -29,14 +29,13 @@ lighthouse:
   #serve_dns: false
   #dns:
     # The DNS host defines the IP to bind the dns listener to. This also allows binding to the nebula node IP.
-    # Use domain to filter DNS A responses to those ending with domain.
     #host: 0.0.0.0
     #port: 53
-    # Use zones to filter DNS responses
+    # Use zones to filter DNS replies
     #zones:
     #  - nebula.example.com
-    # If respond_to_filtered is false, drop queries that do not match any of the zones.
-    #respond_to_filtered: false
+    # If respond_to_filtered is false, drop queries that do not match any of the zones. Otherwise, send an empty reply.
+    #respond_to_filtered: true
   # interval is the number of seconds between updates from this node to a lighthouse.
   # during updates, a node sends information about its current IP addresses to each node.
   interval: 60


### PR DESCRIPTION
Adds config options `lighthouse.dns.zones`, a list of DNS zones the server has an answer for, and `lighthouse.dns.drop_filtered`, which specifies whether to reply to queries outside of those zones.