### PR TITLE
Fix single command ssh exec, add a `raw` flag to `print-cert`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- SSH `print-cert` has a new `-raw` flag to get the PEM representation of a certificate. (#483)
+
 ### Fixed
 
 - Valid recv_error packets were incorrectly marked as "spoofing" and ignored. (#482)
+
+- SSH server handles single `exec` requests correctly. (#483)
 
 ## [1.4.0] - 2021-05-11
 

--- a/ssh.go
+++ b/ssh.go
@@ -26,6 +26,7 @@ type sshListHostMapFlags struct {
 type sshPrintCertFlags struct {
 	Json   bool
 	Pretty bool
+	Raw    bool
 }
 
 type sshPrintTunnelFlags struct {
@@ -266,6 +267,7 @@ func attachCommands(l *logrus.Logger, ssh *sshd.SSHServer, hostMap *HostMap, pen
 			s := sshPrintCertFlags{}
 			fl.BoolVar(&s.Json, "json", false, "outputs as json")
 			fl.BoolVar(&s.Pretty, "pretty", false, "pretty prints json, assumes -json")
+			fl.BoolVar(&s.Raw, "raw", false, "raw prints the PEM encoded certificate, not compatible with -json or -pretty")
 			return fl, &s
 		},
 		Callback: func(fs interface{}, a []string, w sshd.StringWriter) error {
@@ -706,6 +708,16 @@ func sshPrintCert(ifce *Interface, fs interface{}, a []string, w sshd.StringWrit
 				//TODO: handle it
 				return nil
 			}
+		}
+
+		return w.WriteBytes(b)
+	}
+
+	if args.Raw {
+		b, err := cert.MarshalToPEM()
+		if err != nil {
+			//TODO: handle it
+			return nil
 		}
 
 		return w.WriteBytes(b)

--- a/sshd/session.go
+++ b/sshd/session.go
@@ -81,11 +81,18 @@ func (s *session) handleRequests(in <-chan *ssh.Request, channel ssh.Channel) {
 		case "exec":
 			var payload = struct{ Value string }{}
 			cErr := ssh.Unmarshal(req.Payload, &payload)
-			if cErr == nil {
-				s.dispatchCommand(payload.Value, &stringWriter{channel})
-			} else {
-				//TODO: log it
+			if cErr != nil {
+				req.Reply(false, nil)
+				return
 			}
+
+			req.Reply(true, nil)
+			s.dispatchCommand(payload.Value, &stringWriter{channel})
+
+			//TODO: Fix error handling and report the proper status back
+			status := struct{ Status uint32 }{uint32(0)}
+			//TODO: I think this is how we shut down a shell as well?
+			channel.SendRequest("exit-status", false, ssh.Marshal(status))
 			channel.Close()
 			return
 


### PR DESCRIPTION
Before, if you tried to use an ssh client to execute a single command (not on the command line) it would hang as the session would not close properly, this fixes that and adds a way to get a tunnels cert as a PEM.