### PR TITLE
Check CA cert and key match in nebula-cert sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - SSH server handles single `exec` requests correctly. (#483)
 
+- Signing a certificate with `nebula-cert sign` now verifies that the supplied
+  ca-key matches the ca-crt. (#503)
+
 ## [1.4.0] - 2021-05-11
 
 ### Added

--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -375,9 +375,16 @@ func TestNebulaCertificate_Verify_Subnets(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestNebulaVerifyPrivateKey(t *testing.T) {
+func TestNebulaCertificate_VerifyPrivateKey(t *testing.T) {
 	ca, _, caKey, err := newTestCaCert(time.Time{}, time.Time{}, []*net.IPNet{}, []*net.IPNet{}, []string{})
 	assert.Nil(t, err)
+	err = ca.VerifyPrivateKey(caKey)
+	assert.Nil(t, err)
+
+	_, _, caKey2, err := newTestCaCert(time.Time{}, time.Time{}, []*net.IPNet{}, []*net.IPNet{}, []string{})
+	assert.Nil(t, err)
+	err = ca.VerifyPrivateKey(caKey2)
+	assert.NotNil(t, err)
 
 	c, _, priv, err := newTestCert(ca, caKey, time.Time{}, time.Time{}, []*net.IPNet{}, []*net.IPNet{}, []string{})
 	err = c.VerifyPrivateKey(priv)

--- a/cmd/nebula-cert/sign.go
+++ b/cmd/nebula-cert/sign.go
@@ -92,6 +92,10 @@ func signCert(args []string, out io.Writer, errOut io.Writer) error {
 		return fmt.Errorf("error while parsing ca-crt: %s", err)
 	}
 
+	if err := caCert.VerifyPrivateKey(caKey); err != nil {
+		return fmt.Errorf("refusing to sign, root certificate does not match private key")
+	}
+
 	issuer, err := caCert.Sha256Sum()
 	if err != nil {
 		return fmt.Errorf("error while getting -ca-crt fingerprint: %s", err)

--- a/cmd/nebula-cert/sign_test.go
+++ b/cmd/nebula-cert/sign_test.go
@@ -167,6 +167,20 @@ func Test_signCert(t *testing.T) {
 	assert.Empty(t, ob.String())
 	assert.Empty(t, eb.String())
 
+	// mismatched ca key
+	_, caPriv2, _ := ed25519.GenerateKey(rand.Reader)
+	caKeyF2, err := ioutil.TempFile("", "sign-cert-2.key")
+	assert.Nil(t, err)
+	defer os.Remove(caKeyF2.Name())
+	caKeyF2.Write(cert.MarshalEd25519PrivateKey(caPriv2))
+
+	ob.Reset()
+	eb.Reset()
+	args = []string{"-ca-crt", caCrtF.Name(), "-ca-key", caKeyF2.Name(), "-name", "test", "-ip", "1.1.1.1/24", "-out-crt", "nope", "-out-key", "nope", "-duration", "100m", "-subnets", "a"}
+	assert.EqualError(t, signCert(args, ob, eb), "refusing to sign, root certificate does not match private key")
+	assert.Empty(t, ob.String())
+	assert.Empty(t, eb.String())
+
 	// failed key write
 	ob.Reset()
 	eb.Reset()


### PR DESCRIPTION
`func (nc *NebulaCertificate) VerifyPrivateKey(key []byte) error` would
previously return an error even if passed the correct private key for a
CA certificate `nc`.

That function has been updated to support CA certificates, and
nebula-cert now calls it before signing a new certificate. Previously,
it would perform all constraint checks against the CA certificate
provided, take a SHA256 fingerprint of the provided certificate, insert
it into the new node certificate, and then finally sign it with the
mismatching private key provided.