### PR TITLE
give a way to regenerate the pub key when lost

### DIFF
--- a/cmd/nebula-cert/gen_pub.go
+++ b/cmd/nebula-cert/gen_pub.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/slackhq/nebula/cert"
+)
+
+type genPubFlags struct {
+	set        *flag.FlagSet
+	inKeyPath  *string
+	outPubPath *string
+}
+
+func newGenPubFlags() *genPubFlags {
+	pf := genPubFlags{set: flag.NewFlagSet("gen-pub", flag.ContinueOnError)}
+	pf.set.Usage = func() {}
+	pf.inKeyPath = pf.set.String("in-key", "", "Required: path to read the private key from")
+	pf.outPubPath = pf.set.String("out-pub", "", "Optional: path to write the public key to")
+	return &pf
+}
+
+func genPub(args []string, out io.Writer, errOut io.Writer) error {
+	pf := newGenPubFlags()
+	err := pf.set.Parse(args)
+	if err != nil {
+		return err
+	}
+	if err := mustFlagString("in-key", pf.inKeyPath); err != nil {
+		return err
+	}
+
+	rawPriv, err := ioutil.ReadFile(*pf.inKeyPath)
+	if err != nil {
+		return fmt.Errorf("error while reading in-priv: %s", err)
+	}
+	priv, _, err := cert.UnmarshalX25519PrivateKey(rawPriv)
+	if err != nil {
+		return fmt.Errorf("error while parsing in-priv: %s", err)
+	}
+	pub := x25519PubKey(priv)
+
+	if *pf.outPubPath != "" {
+		err = ioutil.WriteFile(*pf.outPubPath, cert.MarshalX25519PublicKey(pub), 0600)
+		if err != nil {
+			return fmt.Errorf("error while writing out-crt: %s", err)
+		}
+
+	} else {
+		fmt.Printf("%s", cert.MarshalX25519PublicKey(pub))
+	}
+	return nil
+}
+
+func genPubSummary() string {
+	return "gen-pub <flags>: prints the public key given the private key"
+}
+
+func genPubHelp(out io.Writer) {
+	pf := newGenPubFlags()
+	out.Write([]byte("Usage of " + os.Args[0] + " " + genPubSummary() + "\n"))
+	pf.set.SetOutput(out)
+	pf.set.PrintDefaults()
+}

--- a/cmd/nebula-cert/gen_pub_test.go
+++ b/cmd/nebula-cert/gen_pub_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/slackhq/nebula/cert"
+	"github.com/stretchr/testify/assert"
+)
+
+//TODO: test file permissions
+
+func Test_genPubSummary(t *testing.T) {
+	assert.Equal(t, "gen-pub <flags>: prints the public key given the private key", genPubSummary())
+}
+
+func Test_genPubHelp(t *testing.T) {
+	ob := &bytes.Buffer{}
+	genPubHelp(ob)
+	assert.Equal(
+		t,
+		"Usage of "+os.Args[0]+" gen-pub <flags>: prints the public key given the private key\n"+
+			"  -in-key string\n"+
+			"    \tRequired: path to read the private key from\n"+
+			"  -out-pub string\n"+
+			"    \tOptional: path to write the public key to\n",
+		ob.String(),
+	)
+}
+
+func Test_genPub(t *testing.T) {
+	ob := &bytes.Buffer{}
+	eb := &bytes.Buffer{}
+	// gb := &bytes.Buffer{}
+
+	// required args
+	assertHelpError(t, genPub([]string{"-out-pub", "some-key"}, ob, eb), "-in-key is required")
+	assert.Equal(t, "", ob.String())
+	assert.Equal(t, "", eb.String())
+
+	// create temp key file
+	keyF, err := ioutil.TempFile("", "test.key")
+	assert.Nil(t, err)
+	defer os.Remove(keyF.Name())
+
+	// create temp pub file
+	pubF, err := ioutil.TempFile("", "test.pub")
+	assert.Nil(t, err)
+	defer os.Remove(pubF.Name())
+
+	ob.Reset()
+	eb.Reset()
+	args := []string{"-out-pub", pubF.Name(), "-out-key", keyF.Name()}
+	assert.Nil(t, keygen(args, ob, eb))
+
+	// read key file
+	rb, _ := ioutil.ReadFile(keyF.Name())
+	lKey, b, err := cert.UnmarshalX25519PrivateKey(rb)
+	assert.Len(t, b, 0)
+	assert.Nil(t, err)
+	assert.Len(t, lKey, 32)
+
+	// read public key
+	pb, _ := ioutil.ReadFile(pubF.Name())
+	rKey, b, err := cert.UnmarshalX25519PublicKey(pb)
+	assert.Len(t, b, 0)
+	assert.Nil(t, err)
+	assert.Len(t, rKey, 32)
+
+	ob.Reset()
+	eb.Reset()
+
+	// create temp pub file for genPub public key
+	genPubF, err := ioutil.TempFile("", "gen.pub")
+	assert.Nil(t, err)
+	defer os.Remove(genPubF.Name())
+
+	genPub([]string{"-in-key", keyF.Name(), "-out-pub", genPubF.Name()}, ob, eb)
+	genPub, _ := ioutil.ReadFile(genPubF.Name())
+
+	assert.Equal(t, pb, genPub)
+}

--- a/cmd/nebula-cert/main.go
+++ b/cmd/nebula-cert/main.go
@@ -71,6 +71,8 @@ func main() {
 		err = printCert(args[1:], os.Stdout, os.Stderr)
 	case "verify":
 		err = verify(args[1:], os.Stdout, os.Stderr)
+	case "gen-pub":
+		err = genPub(args[1:], os.Stdout, os.Stderr)
 	default:
 		err = fmt.Errorf("unknown mode: %s", args[0])
 	}
@@ -104,7 +106,10 @@ func handleError(mode string, e error, out io.Writer) int {
 			printHelp(out)
 		case "verify":
 			verifyHelp(out)
+		case "gen-pub":
+			genPubHelp(out)
 		}
+
 	}
 
 	return code
@@ -127,6 +132,8 @@ func help(err string, out io.Writer) {
 	fmt.Fprintln(out, "    "+signSummary())
 	fmt.Fprintln(out, "    "+printSummary())
 	fmt.Fprintln(out, "    "+verifySummary())
+	fmt.Fprintln(out, "    "+genPubSummary())
+
 }
 
 func mustFlagString(name string, val *string) error {

--- a/cmd/nebula-cert/main_test.go
+++ b/cmd/nebula-cert/main_test.go
@@ -22,7 +22,8 @@ func Test_help(t *testing.T) {
 		"    " + keygenSummary() + "\n" +
 		"    " + signSummary() + "\n" +
 		"    " + printSummary() + "\n" +
-		"    " + verifySummary() + "\n"
+		"    " + verifySummary() + "\n" +
+		"    " + genPubSummary() + "\n"
 
 	ob := &bytes.Buffer{}
 

--- a/cmd/nebula-cert/sign.go
+++ b/cmd/nebula-cert/sign.go
@@ -230,6 +230,13 @@ func x25519Keypair() ([]byte, []byte) {
 	return pubkey[:], privkey[:]
 }
 
+func x25519PubKey(privkey []byte) []byte {
+	var pubkey, priv32 [32]byte
+	copy(priv32[:], privkey)
+	curve25519.ScalarBaseMult(&pubkey, &priv32)
+	return pubkey[:]
+}
+
 func signSummary() string {
 	return "sign <flags>: create and sign a certificate"
 }


### PR DESCRIPTION
Re-create the public key from the private X25519 key.

```
alanlam@sw:~/repos/alanhlam/nebula$ make
go build -trimpath -ldflags "-X main.Build=1.4.0-gen-pub-key-from-priv-3-gbc5dc50" -o ./nebula "./cmd/nebula"
go build -trimpath -ldflags "-X main.Build=1.4.0-gen-pub-key-from-priv-3-gbc5dc50" -o ./nebula-cert ./cmd/nebula-cert
alanlam@sw:~/repos/alanhlam/nebula$ ./nebula-cert keygen -out-key test1.key -out-pub test1.pub

alanlam@sw:~/repos/alanhlam/nebula$ cat test1.pub 
-----BEGIN NEBULA X25519 PUBLIC KEY-----
8UIZSvHAWHfbFYHC701xiLRnKNeSdqBunuREGsFmhiE=
-----END NEBULA X25519 PUBLIC KEY-----

alanlam@sw:~/repos/alanhlam/nebula$ ./nebula-cert gen-pub -in-key test1.key 
-----BEGIN NEBULA X25519 PUBLIC KEY-----
8UIZSvHAWHfbFYHC701xiLRnKNeSdqBunuREGsFmhiE=
-----END NEBULA X25519 PUBLIC KEY-----
```