### PR TITLE
Fix UDP listener on IPv4-only Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- UDP listener works on IPv4-only Linux. (#506)
 
 ## [1.5.2] - 2021-12-14
 

--- a/cidr/tree6.go
+++ b/cidr/tree6.go
@@ -23,7 +23,7 @@ func NewTree6() *Tree6 {
 func (tree *Tree6) AddCIDR(cidr *net.IPNet, val interface{}) {
 	var node, next *Node
 
-	cidrIP, ipv4 := isIPV4(cidr.IP)
+	cidrIP, ipv4 := IsIPV4(cidr.IP)
 	if ipv4 {
 		node = tree.root4
 		next = tree.root4
@@ -78,7 +78,7 @@ func (tree *Tree6) AddCIDR(cidr *net.IPNet, val interface{}) {
 func (tree *Tree6) MostSpecificContains(ip net.IP) (value interface{}) {
 	var node *Node
 
-	wholeIP, ipv4 := isIPV4(ip)
+	wholeIP, ipv4 := IsIPV4(ip)
 	if ipv4 {
 		node = tree.root4
 	} else {
@@ -163,7 +163,7 @@ func (tree *Tree6) MostSpecificContainsIpV6(hi, lo uint64) (value interface{}) {
 	return value
 }
 
-func isIPV4(ip net.IP) (net.IP, bool) {
+func IsIPV4(ip net.IP) (net.IP, bool) {
 	if len(ip) == net.IPv4len {
 		return ip, true
 	}

--- a/udp/udp_linux.go
+++ b/udp/udp_linux.go
@@ -212,7 +212,8 @@ func (u *Conn) WriteTo(b []byte, addr *Addr) error {
 	if u.isV4 {
 		addrV4, isAddrV4 := isIPV4(addr.IP)
 		if !isAddrV4 {
-			return fmt.Errorf("listener is IPv4, but writing to IPv6 remote")
+			u.l.Warnf("socket is IPv4-only, not sending to IPv6 address: %s", addr.IP)
+			return nil
 		}
 		var rsa unix.RawSockaddrInet4
 		rsa.Family = unix.AF_INET

--- a/udp/udp_linux.go
+++ b/udp/udp_linux.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/rcrowley/go-metrics"
 	"github.com/sirupsen/logrus"
+	"github.com/slackhq/nebula/cidr"
 	"github.com/slackhq/nebula/config"
 	"github.com/slackhq/nebula/firewall"
 	"github.com/slackhq/nebula/header"
@@ -48,7 +49,7 @@ type _SK_MEMINFO [_SK_MEMINFO_VARS]uint32
 
 func NewListener(l *logrus.Logger, ip string, port int, multi bool, batch int) (*Conn, error) {
 	lip := net.ParseIP(ip)
-	lipV4, isV4 := isIPV4(lip)
+	lipV4, isV4 := cidr.IsIPV4(lip)
 
 	af := unix.AF_INET6
 	if isV4 {
@@ -210,7 +211,7 @@ func (u *Conn) WriteTo(b []byte, addr *Addr) error {
 	var rsaPtr unsafe.Pointer
 	var rsaSize int
 	if u.isV4 {
-		addrV4, isAddrV4 := isIPV4(addr.IP)
+		addrV4, isAddrV4 := cidr.IsIPV4(addr.IP)
 		if !isAddrV4 {
 			u.l.Warnf("socket is IPv4-only, not sending to IPv6 address: %s", addr.IP)
 			return nil

--- a/udp/udp_linux.go
+++ b/udp/udp_linux.go
@@ -159,7 +159,11 @@ func (u *Conn) ListenOut(r EncReader, lhf LightHouseHandlerFunc, cache *firewall
 
 		//metric.Update(int64(n))
 		for i := 0; i < n; i++ {
-			udpAddr.IP = names[i][8:24]
+			if u.isV4 {
+				udpAddr.IP = names[i][4:8]
+			} else {
+				udpAddr.IP = names[i][8:24]
+			}
 			udpAddr.Port = binary.BigEndian.Uint16(names[i][2:4])
 			r(udpAddr, plaintext[:0], buffers[i][:msgs[i].Len], h, fwPacket, lhf, nb, q, cache.Get(u.l))
 		}

--- a/udp/udp_linux.go
+++ b/udp/udp_linux.go
@@ -22,6 +22,7 @@ import (
 
 type Conn struct {
 	sysFd int
+	isV4  bool
 	l     *logrus.Logger
 	batch int
 }
@@ -46,8 +47,15 @@ const (
 type _SK_MEMINFO [_SK_MEMINFO_VARS]uint32
 
 func NewListener(l *logrus.Logger, ip string, port int, multi bool, batch int) (*Conn, error) {
+	lip := net.ParseIP(ip)
+	lipV4, isV4 := isIPV4(lip)
+
+	af := unix.AF_INET6
+	if isV4 {
+		af = unix.AF_INET
+	}
 	syscall.ForkLock.RLock()
-	fd, err := unix.Socket(unix.AF_INET6, unix.SOCK_DGRAM, unix.IPPROTO_UDP)
+	fd, err := unix.Socket(af, unix.SOCK_DGRAM, unix.IPPROTO_UDP)
 	if err == nil {
 		unix.CloseOnExec(fd)
 	}
@@ -58,9 +66,6 @@ func NewListener(l *logrus.Logger, ip string, port int, multi bool, batch int) (
 		return nil, fmt.Errorf("unable to open socket: %s", err)
 	}
 
-	var lip [16]byte
-	copy(lip[:], net.ParseIP(ip))
-
 	if multi {
 		if err = unix.SetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_REUSEPORT, 1); err != nil {
 			return nil, fmt.Errorf("unable to set SO_REUSEPORT: %s", err)
@@ -68,7 +73,17 @@ func NewListener(l *logrus.Logger, ip string, port int, multi bool, batch int) (
 	}
 
 	//TODO: support multiple listening IPs (for limiting ipv6)
-	if err = unix.Bind(fd, &unix.SockaddrInet6{Addr: lip, Port: port}); err != nil {
+	var sa unix.Sockaddr
+	if isV4 {
+		sa4 := &unix.SockaddrInet4{Port: port}
+		copy(sa4.Addr[:], lipV4)
+		sa = sa4
+	} else {
+		sa6 := &unix.SockaddrInet6{Port: port}
+		copy(sa6.Addr[:], lip)
+		sa = sa6
+	}
+	if err = unix.Bind(fd, sa); err != nil {
 		return nil, fmt.Errorf("unable to bind to socket: %s", err)
 	}
 
@@ -77,7 +92,7 @@ func NewListener(l *logrus.Logger, ip string, port int, multi bool, batch int) (
 	//v, err := unix.GetsockoptInt(fd, unix.SOL_SOCKET, unix.SO_INCOMING_CPU)
 	//l.Println(v, err)
 
-	return &Conn{sysFd: fd, l: l, batch: batch}, err
+	return &Conn{sysFd: fd, isV4: isV4, l: l, batch: batch}, err
 }
 
 func (u *Conn) Rebind() error {
@@ -192,13 +207,27 @@ func (u *Conn) ReadMulti(msgs []rawMessage) (int, error) {
 }
 
 func (u *Conn) WriteTo(b []byte, addr *Addr) error {
-
-	var rsa unix.RawSockaddrInet6
-	rsa.Family = unix.AF_INET6
-	p := (*[2]byte)(unsafe.Pointer(&rsa.Port))
-	p[0] = byte(addr.Port >> 8)
-	p[1] = byte(addr.Port)
-	copy(rsa.Addr[:], addr.IP)
+	var rsaPtr unsafe.Pointer
+	var rsaSize int
+	if u.isV4 {
+		addrV4, isAddrV4 := isIPV4(addr.IP)
+		if !isAddrV4 {
+			return fmt.Errorf("listener is IPv4, but writing to IPv6 remote")
+		}
+		var rsa unix.RawSockaddrInet4
+		rsa.Family = unix.AF_INET
+		rsa.Port = (addr.Port >> 8) | ((addr.Port & 0xff) << 8)
+		copy(rsa.Addr[:], addrV4)
+		rsaPtr = unsafe.Pointer(&rsa)
+		rsaSize = unix.SizeofSockaddrInet4
+	} else {
+		var rsa unix.RawSockaddrInet6
+		rsa.Family = unix.AF_INET6
+		rsa.Port = (addr.Port >> 8) | ((addr.Port & 0xff) << 8)
+		copy(rsa.Addr[:], addr.IP)
+		rsaPtr = unsafe.Pointer(&rsa)
+		rsaSize = unix.SizeofSockaddrInet6
+	}
 
 	for {
 		_, _, err := unix.Syscall6(
@@ -207,8 +236,8 @@ func (u *Conn) WriteTo(b []byte, addr *Addr) error {
 			uintptr(unsafe.Pointer(&b[0])),
 			uintptr(len(b)),
 			uintptr(0),
-			uintptr(unsafe.Pointer(&rsa)),
-			uintptr(unix.SizeofSockaddrInet6),
+			uintptr(rsaPtr),
+			uintptr(rsaSize),
 		)
 
 		if err != 0 {


### PR DESCRIPTION
On some systems, IPv6 is disabled (for example, CIS benchmark recommends to disable it when not used), but currently all UDP connections are using AF_INET6 sockets.
When we are binding AF_INET6 socket to an address like ::ffff:1.2.3.4 (IPv4 addresses are parsed by net.ParseIP this way), we can't send or receive IPv6 packets anyway, so this will not break any scenarios.

Fixes #467