### PR TITLE
add building of debian files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           mv build/*.deb release
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: debian-latest
           path: release
@@ -248,7 +248,17 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./debian-latest/nebula-linux-amd64.deb
           asset_name: nebula-linux-amd64.deb
-          asset_content_type: application/gzip
+          asset_content_type: application/octet-stream
+
+      - name: Upload debian-arm-7
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./debian-latest/nebula-linux-arm-7.deb
+          asset_name: nebula-linux-arm-7.deb
+          asset_content_type: application/octet-stream
 
       - name: Upload debian-arm64
         uses: actions/upload-release-asset@v1.0.1
@@ -258,7 +268,7 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./debian-latest/nebula-linux-arm64.deb
           asset_name: nebula-linux-arm64.deb
-          asset_content_type: application/gzip
+          asset_content_type: application/octet-stream
 
       - name: Upload linux-amd64
         uses: actions/upload-release-asset@v1.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,30 @@ jobs:
           name: linux-latest
           path: release
 
+  build-debian:
+    name: Build Debian Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.18
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build
+        run: |
+          make BUILD_NUMBER="${GITHUB_REF#refs/tags/v}" release-deb
+          mkdir release
+          mv build/*.deb release
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: debian-latest
+          path: release
+
   build-windows:
     name: Build Windows
     runs-on: windows-latest
@@ -114,7 +138,7 @@ jobs:
 
   release:
     name: Create and Upload Release
-    needs: [build-linux, build-darwin, build-windows]
+    needs: [build-debian, build-linux, build-darwin, build-windows]
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
@@ -130,7 +154,7 @@ jobs:
 
       - name: Create sha256sum
         run: |
-          for dir in linux-latest darwin-latest windows-latest
+          for dir in debian-latest linux-latest darwin-latest windows-latest
           do
             (
               cd $dir
@@ -148,6 +172,10 @@ jobs:
                 sha256sum <nebula | sed 's=-$=nebula-darwin.zip/nebula='
                 sha256sum <nebula-cert | sed 's=-$=nebula-darwin.zip/nebula-cert='
               else
+                for v in *.deb
+                do
+                  sha256sum $v
+                done
                 for v in *.tar.gz
                 do
                   sha256sum $v
@@ -211,6 +239,26 @@ jobs:
           asset_path: ./windows-latest/nebula-windows-arm64.zip
           asset_name: nebula-windows-arm64.zip
           asset_content_type: application/zip
+
+      - name: Upload debian-amd64
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./debian-latest/nebula-linux-amd64.deb
+          asset_name: nebula-linux-amd64.deb
+          asset_content_type: application/gzip
+
+      - name: Upload debian-arm64
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./debian-latest/nebula-linux-arm64.deb
+          asset_name: nebula-linux-arm64.deb
+          asset_content_type: application/gzip
 
       - name: Upload linux-amd64
         uses: actions/upload-release-asset@v1.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Build target to build Debian packages. (#514)
+
 ## [1.5.2] - 2021-12-14
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ endif
 LDFLAGS = -X main.Build=$(BUILD_NUMBER)
 
 ALL_DEBIAN = linux-amd64 \
+	linux-arm-7 \
 	linux-arm64
 ALL_LINUX = linux-amd64 \
 	linux-386 \
@@ -125,6 +126,10 @@ build/%/nebula-cert.exe: build/%/nebula-cert
 build/nebula-%.deb: build/%/nebula build/%/nebula-cert
 	cp -av dist/debian/ build/$*
 	sed -i "s/ARCHITECTURE/$(word 2, $(subst -, ,$*))/" build/$*/debian/DEBIAN/control
+	# fix package name
+	if [ "$*" = "linux-arm-7" ]; then \
+	    sed -i "s/arm$$/armhf/" build/$*/debian/DEBIAN/control; \
+	fi
 	sed -i "s/VERSION/$(BUILD_NUMBER)/" build/$*/debian/DEBIAN/control
 	mkdir -p build/$*/debian/usr/bin
 	cp -av build/$*/nebula build/$*/nebula-cert build/$*/debian/usr/bin

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,8 @@ build/nebula-%.deb: build/%/nebula build/%/nebula-cert
 	cp -av build/$*/nebula build/$*/nebula-cert build/$*/debian/usr/bin
 	mkdir -p build/$*/debian/lib/systemd/system
 	cp -v dist/arch/nebula.service build/$*/debian/lib/systemd/system
+	mkdir -p build/$*/debian/etc/nebula
+	cp -v examples/config.yml build/$*/debian/etc/nebula
 	dpkg-deb --build --root-owner-group build/$*/debian build/nebula-$*.deb
 
 build/nebula-%.tar.gz: build/%/nebula build/%/nebula-cert

--- a/dist/debian/DEBIAN/conffiles
+++ b/dist/debian/DEBIAN/conffiles
@@ -1,0 +1,1 @@
+/etc/nebula/config.yml

--- a/dist/debian/DEBIAN/control
+++ b/dist/debian/DEBIAN/control
@@ -1,0 +1,6 @@
+Package: nebula
+Version: VERSION
+Architecture: ARCHITECTURE
+Maintainer: Freifunk München <hilfe@ffmuc.net>
+Description: Nebula network connectivity daemon for encrypted communications
+ More details in https://github.com/slackhq/nebula


### PR DESCRIPTION
This extends the Makefile to be able to build a debian package with
`make release-deb` and extends github workflow to automatically build and publish this automatically when a new version is pushed.

This fixes one part of #101 which asks for deb and rpm packages.

 I tested it by tagging on my fork to check if its working: https://github.com/krombel/nebula/releases/tag/v1.4.0-1