### PR TITLE
Allow embedding nodes into other services/applications

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"strings"
 	"time"
 
@@ -17,6 +18,10 @@ type CertState struct {
 	rawCertificateNoKey []byte
 	publicKey           []byte
 	privateKey          []byte
+}
+
+func (c *CertState) GetCIDR() *net.IPNet {
+	return c.certificate.Details.Ips[0]
 }
 
 func NewCertState(certificate *cert.NebulaCertificate, privateKey []byte) (*CertState, error) {

--- a/examples/embedded/config.yml
+++ b/examples/embedded/config.yml
@@ -1,0 +1,251 @@
+# This is the nebula example configuration file. You must edit, at a minimum, the static_host_map, lighthouse, and firewall sections
+# Some options in this file are HUPable, including the pki section. (A HUP will reload credentials from disk without affecting existing tunnels)
+
+# PKI defines the location of credentials for this node. Each of these can also be inlined by using the yaml ": |" syntax.
+pki:
+  # The CAs that are accepted by this node. Must contain one or more certificates created by 'nebula-cert ca'
+  ca: ca.crt
+  cert: node3.crt
+  key: node3.key
+  #blocklist is a list of certificate fingerprints that we will refuse to talk to
+  #blocklist:
+  #  - c99d4e650533b92061b09918e838a5a0a6aaee21eed1d12fd937682865936c72
+
+# The static host map defines a set of hosts with fixed IP addresses on the internet (or any network).
+# A host can have multiple fixed IP addresses defined here, and nebula will try each when establishing a tunnel.
+# The syntax is:
+#   "{nebula ip}": ["{routable ip/dns name}:{routable port}"]
+# Example, if your lighthouse has the nebula IP of 10.0.0.1 and has the real ip address of 100.64.22.11 and runs on port 4242:
+static_host_map:
+  "10.0.0.1": ["100.64.22.11:4242"]
+
+
+lighthouse:
+  # am_lighthouse is used to enable lighthouse functionality for a node. This should ONLY be true on nodes
+  # you have configured to be lighthouses in your network
+  am_lighthouse: false
+  # serve_dns optionally starts a dns listener that responds to various queries and can even be
+  # delegated to for resolution
+  #serve_dns: false
+  #dns:
+    # The DNS host defines the IP to bind the dns listener to. This also allows binding to the nebula node IP.
+    #host: 0.0.0.0
+    #port: 53
+  # interval is the number of seconds between updates from this node to a lighthouse.
+  # during updates, a node sends information about its current IP addresses to each node.
+  interval: 60
+  # hosts is a list of lighthouse hosts this node should report to and query from
+  # IMPORTANT: THIS SHOULD BE EMPTY ON LIGHTHOUSE NODES
+  # IMPORTANT2: THIS SHOULD BE LIGHTHOUSES' NEBULA IPs, NOT LIGHTHOUSES' REAL ROUTABLE IPs
+  hosts:
+   - "10.0.0.1"
+
+  # remote_allow_list allows you to control ip ranges that this node will
+  # consider when handshaking to another node. By default, any remote IPs are
+  # allowed. You can provide CIDRs here with `true` to allow and `false` to
+  # deny. The most specific CIDR rule applies to each remote. If all rules are
+  # "allow", the default will be "deny", and vice-versa. If both "allow" and
+  # "deny" rules are present, then you MUST set a rule for "0.0.0.0/0" as the
+  # default.
+  #remote_allow_list:
+    # Example to block IPs from this subnet from being used for remote IPs.
+    #"172.16.0.0/12": false
+
+    # A more complicated example, allow public IPs but only private IPs from a specific subnet
+    #"0.0.0.0/0": true
+    #"10.0.0.0/8": false
+    #"10.42.42.0/24": true
+
+  # local_allow_list allows you to filter which local IP addresses we advertise
+  # to the lighthouses. This uses the same logic as `remote_allow_list`, but
+  # additionally, you can specify an `interfaces` map of regular expressions
+  # to match against interface names. The regexp must match the entire name.
+  # All interface rules must be either true or false (and the default will be
+  # the inverse). CIDR rules are matched after interface name rules.
+  # Default is all local IP addresses.
+  #local_allow_list:
+    # Example to block tun0 and all docker interfaces.
+    #interfaces:
+      #tun0: false
+      #'docker.*': false
+    # Example to only advertise this subnet to the lighthouse.
+    #"10.0.0.0/8": true
+
+# Port Nebula will be listening on. The default here is 4242. For a lighthouse node, the port should be defined,
+# however using port 0 will dynamically assign a port and is recommended for roaming nodes.
+listen:
+  # To listen on both any ipv4 and ipv6 use "[::]"
+  host: 0.0.0.0
+  port: 4242
+  # Sets the max number of packets to pull from the kernel for each syscall (under systems that support recvmmsg)
+  # default is 64, does not support reload
+  #batch: 64
+  # Configure socket buffers for the udp side (outside), leave unset to use the system defaults. Values will be doubled by the kernel
+  # Default is net.core.rmem_default and net.core.wmem_default (/proc/sys/net/core/rmem_default and /proc/sys/net/core/rmem_default)
+  # Maximum is limited by memory in the system, SO_RCVBUFFORCE and SO_SNDBUFFORCE is used to avoid having to raise the system wide
+  # max, net.core.rmem_max and net.core.wmem_max
+  #read_buffer: 10485760
+  #write_buffer: 10485760
+
+# EXPERIMENTAL: This option is currently only supported on linux and may
+# change in future minor releases.
+#
+# Routines is the number of thread pairs to run that consume from the tun and UDP queues.
+# Currently, this defaults to 1 which means we have 1 tun queue reader and 1
+# UDP queue reader. Setting this above one will set IFF_MULTI_QUEUE on the tun
+# device and SO_REUSEPORT on the UDP socket to allow multiple queues.
+#routines: 1
+
+punchy:
+  # Continues to punch inbound/outbound at a regular interval to avoid expiration of firewall nat mappings
+  punch: true
+
+  # respond means that a node you are trying to reach will connect back out to you if your hole punching fails
+  # this is extremely useful if one node is behind a difficult nat, such as a symmetric NAT
+  # Default is false
+  #respond: true
+
+  # delays a punch response for misbehaving NATs, default is 1 second, respond must be true to take effect
+  #delay: 1s
+
+# Cipher allows you to choose between the available ciphers for your network. Options are chachapoly or aes
+# IMPORTANT: this value must be identical on ALL NODES/LIGHTHOUSES. We do not/will not support use of different ciphers simultaneously!
+#cipher: chachapoly
+
+# Local range is used to define a hint about the local network range, which speeds up discovering the fastest
+# path to a network adjacent nebula node.
+#local_range: "172.16.0.0/24"
+
+# sshd can expose informational and administrative functions via ssh this is a
+#sshd:
+  # Toggles the feature
+  #enabled: true
+  # Host and port to listen on, port 22 is not allowed for your safety
+  #listen: 127.0.0.1:2222
+  # A file containing the ssh host private key to use
+  # A decent way to generate one: ssh-keygen -t ed25519 -f ssh_host_ed25519_key -N "" < /dev/null
+  #host_key: ./ssh_host_ed25519_key
+  # A file containing a list of authorized public keys
+  #authorized_users:
+    #- user: steeeeve
+      # keys can be an array of strings or single string
+      #keys:
+        #- "ssh public key string"
+
+# Configure the private interface. Note: addr is baked into the nebula certificate
+tun:
+  # When tun is disabled, a lighthouse can be started without a local tun interface (and therefore without root)
+  disabled: false
+  # Name of the device
+  dev: nebula3
+  # Toggles forwarding of local broadcast packets, the address of which depends on the ip/mask encoded in pki.cert
+  drop_local_broadcast: false
+  # Toggles forwarding of multicast packets
+  drop_multicast: false
+  # Sets the transmit queue length, if you notice lots of transmit drops on the tun it may help to raise this number. Default is 500
+  tx_queue: 500
+  # Default MTU for every packet, safe setting is (and the default) 1300 for internet based traffic
+  mtu: 1300
+  # Route based MTU overrides, you have known vpn ip paths that can support larger MTUs you can increase/decrease them here
+  routes:
+    #- mtu: 8800
+    #  route: 10.0.0.0/16
+  # Unsafe routes allows you to route traffic over nebula to non-nebula nodes
+  # Unsafe routes should be avoided unless you have hosts/services that cannot run nebula
+  # NOTE: The nebula certificate of the "via" node *MUST* have the "route" defined as a subnet in its certificate
+  unsafe_routes:
+    #- route: 172.16.1.0/24
+    #  via: 192.168.100.99
+    #  mtu: 1300 #mtu will default to tun mtu if this option is not sepcified
+
+
+# TODO
+# Configure logging level
+logging:
+  # panic, fatal, error, warning, info, or debug. Default is info
+  level: info
+  # json or text formats currently available. Default is text
+  format: text
+  # Disable timestamp logging. useful when output is redirected to logging system that already adds timestamps. Default is false
+  #disable_timestamp: true
+  # timestamp format is specified in Go time format, see:
+  #     https://golang.org/pkg/time/#pkg-constants
+  # default when `format: json`: "2006-01-02T15:04:05Z07:00" (RFC3339)
+  # default when `format: text`:
+  #     when TTY attached: seconds since beginning of execution
+  #     otherwise: "2006-01-02T15:04:05Z07:00" (RFC3339)
+  # As an example, to log as RFC3339 with millisecond precision, set to:
+  #timestamp_format: "2006-01-02T15:04:05.000Z07:00"
+
+#stats:
+  #type: graphite
+  #prefix: nebula
+  #protocol: tcp
+  #host: 127.0.0.1:9999
+  #interval: 10s
+
+  #type: prometheus
+  #listen: 127.0.0.1:8080
+  #path: /metrics
+  #namespace: prometheusns
+  #subsystem: nebula
+  #interval: 10s
+
+  # enables counter metrics for meta packets
+  #   e.g.: `messages.tx.handshake`
+  # NOTE: `message.{tx,rx}.recv_error` is always emitted
+  #message_metrics: false
+
+  # enables detailed counter metrics for lighthouse packets
+  #   e.g.: `lighthouse.rx.HostQuery`
+  #lighthouse_metrics: false
+
+# Handshake Manager Settings
+#handshakes:
+  # Handshakes are sent to all known addresses at each interval with a linear backoff,
+  # Wait try_interval after the 1st attempt, 2 * try_interval after the 2nd, etc, until the handshake is older than timeout
+  # A 100ms interval with the default 10 retries will give a handshake 5.5 seconds to resolve before timing out
+  #try_interval: 100ms
+  #retries: 20
+  # trigger_buffer is the size of the buffer channel for quickly sending handshakes
+  # after receiving the response for lighthouse queries
+  #trigger_buffer: 64
+
+
+# Nebula security group configuration
+firewall:
+  conntrack:
+    tcp_timeout: 12m
+    udp_timeout: 3m
+    default_timeout: 10m
+    max_connections: 100000
+
+  # The firewall is default deny. There is no way to write a deny rule.
+  # Rules are comprised of a protocol, port, and one or more of host, group, or CIDR
+  # Logical evaluation is roughly: port AND proto AND (ca_sha OR ca_name) AND (host OR group OR groups OR cidr)
+  # - port: Takes `0` or `any` as any, a single number `80`, a range `200-901`, or `fragment` to match second and further fragments of fragmented packets (since there is no port available).
+  #   code: same as port but makes more sense when talking about ICMP, TODO: this is not currently implemented in a way that works, use `any`
+  #   proto: `any`, `tcp`, `udp`, or `icmp`
+  #   host: `any` or a literal hostname, ie `test-host`
+  #   group: `any` or a literal group name, ie `default-group`
+  #   groups: Same as group but accepts a list of values. Multiple values are AND'd together and a certificate would have to contain all groups to pass
+  #   cidr: a CIDR, `0.0.0.0/0` is any.
+  #   ca_name: An issuing CA name
+  #   ca_sha: An issuing CA shasum
+
+  outbound:
+    # Allow all outbound traffic from this node
+    - port: any
+      proto: any
+      host: any
+
+  inbound:
+    # Allow icmp between any nebula hosts
+    - port: any
+      proto: icmp
+      host: any
+
+    # Allow port 8080 any protocol from any host
+    - port: 8080
+      proto: any
+      host: any

--- a/examples/embedded/embedded.go
+++ b/examples/embedded/embedded.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/slackhq/nebula"
+)
+
+func main() {
+	configPath := flag.String("config", "", "Path to either a file or directory to load configuration from")
+	configTest := flag.Bool("test", false, "Test the config and print the end result. Non zero exit indicates a faulty config")
+	printUsage := flag.Bool("help", false, "Print command line usage")
+	thisIP := flag.String("thisIP", "10.0.0.3", "This node's IP in the nebula network")
+	thisPort := flag.Uint64("thisPort", 8080, "Port this node will use for packets")
+	targetIP := flag.String("targetIP", "10.0.0.4", "Target node's IP in the nebula network")
+	targetPort := flag.Uint64("targetPort", 8080, "Port the target node will use for packets")
+
+	flag.Parse()
+
+	if *printUsage {
+		flag.Usage()
+		os.Exit(0)
+	}
+
+	if *configPath == "" {
+		fmt.Println("-config flag must be set")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	l := logrus.New()
+	l.Out = os.Stdout
+
+	config := nebula.NewConfig(l)
+	err := config.Load(*configPath)
+	if err != nil {
+		fmt.Printf("failed to load config: %s", err)
+		os.Exit(1)
+	}
+	cs, err := nebula.NewCertStateFromConfig(config)
+	if err != nil {
+		fmt.Printf("failed to load cert from config: %s", err)
+		os.Exit(1)
+	}
+
+	rxChan := make(chan []byte, 500)
+	txChan := make(chan []byte, 500)
+
+	ft := nebula.NewFakeTun("fakeTun", cs.GetCIDR(), txChan, rxChan)
+
+	go occasionalInjector(txChan, net.ParseIP(*thisIP), net.ParseIP(*targetIP), *thisPort, *targetPort)
+	go receiverHandler(rxChan)
+
+	c, err := nebula.MainWithProvidedTUN(config, *configTest, "a", l, nil, ft)
+
+	switch v := err.(type) {
+	case nebula.ContextualError:
+		v.Log(l)
+		os.Exit(1)
+	case error:
+		l.WithError(err).Error("Failed to start")
+		os.Exit(1)
+	}
+
+	if !*configTest {
+		c.Start()
+		c.ShutdownBlock()
+	}
+
+	os.Exit(0)
+}
+
+func occasionalInjector(sendPackets chan<- []byte, usIP, themIP net.IP, usPort, themPort uint64) {
+	payload := []byte{0x0, 0x1, 0x2, 0x3, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10}
+	for {
+		time.Sleep(time.Second)
+		fmt.Printf("Injecting packet from %v:%v to %v:%v\n", usIP.To4(), usPort, themIP.To4(), themPort)
+		b := UDPPacket(usIP, themIP, uint16(themPort), uint16(usPort), payload)
+		DecodePacket(b)
+		sendPackets <- b
+
+		for i := 0; i < len(payload); i++ {
+			if payload[i] == 0xff {
+				payload[i] = 0
+			} else {
+				payload[i] += 1
+			}
+		}
+	}
+}
+
+func receiverHandler(receivePackets <-chan []byte) {
+	for {
+		b := <-receivePackets
+		DecodePacket(b)
+	}
+}

--- a/examples/embedded/packets.go
+++ b/examples/embedded/packets.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+)
+
+func UDPPacket(from net.IP, toIp net.IP, toPort uint16, fromPort uint16, data []byte) []byte {
+	ip := layers.IPv4{
+		Version:  4,
+		TTL:      64,
+		Protocol: layers.IPProtocolUDP,
+		SrcIP:    from,
+		DstIP:    toIp,
+	}
+
+	udp := layers.UDP{
+		SrcPort: layers.UDPPort(fromPort),
+		DstPort: layers.UDPPort(toPort),
+	}
+	err := udp.SetNetworkLayerForChecksum(&ip)
+	if err != nil {
+		panic(err)
+	}
+
+	buffer := gopacket.NewSerializeBuffer()
+	opt := gopacket.SerializeOptions{
+		ComputeChecksums: true,
+		FixLengths:       true,
+	}
+	err = gopacket.SerializeLayers(buffer, opt, &ip, &udp, gopacket.Payload(data))
+	if err != nil {
+		panic(err)
+	}
+
+	return buffer.Bytes()
+}
+
+func DecodePacket(myPacketData []byte) {
+	packet := gopacket.NewPacket(myPacketData, layers.LayerTypeIPv4, gopacket.Lazy)
+	v4 := packet.Layer(layers.LayerTypeIPv4).(*layers.IPv4)
+	if v4 == nil {
+		fmt.Println("No ipv4 data found")
+		return
+	}
+	fmt.Printf("From src %v to dst %v\n", v4.SrcIP, v4.DstIP)
+	tV := packet.Layer(layers.LayerTypeUDP)
+	if tV == nil {
+		fmt.Println("No udp layer found")
+		return
+	}
+	udp := tV.(*layers.UDP)
+	if udp == nil {
+		fmt.Println("No udp data found")
+		return
+	}
+
+	fmt.Printf("From src port %d to dst port %d\n", uint16(udp.SrcPort), uint16(udp.DstPort))
+
+	data := packet.ApplicationLayer()
+	if data == nil {
+		fmt.Println("No application data found")
+		return
+	}
+	fmt.Println("App Payload: ", data.Payload())
+}

--- a/main.go
+++ b/main.go
@@ -14,6 +14,10 @@ import (
 type m map[string]interface{}
 
 func Main(config *Config, configTest bool, buildVersion string, logger *logrus.Logger, tunFd *int) (*Control, error) {
+	return MainWithProvidedTUN(config, configTest, buildVersion, logger, tunFd, nil)
+}
+
+func MainWithProvidedTUN(config *Config, configTest bool, buildVersion string, logger *logrus.Logger, tunFd *int, setTun Inside) (*Control, error) {
 	l := logger
 	l.Formatter = &logrus.TextFormatter{
 		FullTimestamp: true,
@@ -125,7 +129,7 @@ func Main(config *Config, configTest bool, buildVersion string, logger *logrus.L
 	}
 
 	var tun Inside
-	if !configTest {
+	if setTun == nil && !configTest {
 		config.CatchHUP()
 
 		switch {
@@ -157,6 +161,8 @@ func Main(config *Config, configTest bool, buildVersion string, logger *logrus.L
 		if err != nil {
 			return nil, NewContextualError("Failed to get a tun/tap device", nil, err)
 		}
+	} else {
+		tun = setTun
 	}
 
 	// set up our UDP listener

--- a/tun_fake.go
+++ b/tun_fake.go
@@ -1,0 +1,62 @@
+package nebula
+
+import (
+	"fmt"
+	"io"
+	"net"
+)
+
+//A fake Tun interface, for when a Tun isn't possible or desireable for this node (e.g. lacking Admin priviledges, embedding into programs, etc.)
+type FakeTun struct {
+	sendingPackets  chan []byte //Data from this node, to be sent into the nebula network
+	receivedPackets chan []byte //Data for this node, received from the nebula network
+	cidr            *net.IPNet  //see Inside.CidrNet(). More-or-less nebula IP address/range of the node
+	deviceName      string
+}
+
+//Caller can provide unbuffered or buffered channels, thus deciding if FakeTun runs synchronous or asynchronous (respectively)
+func NewFakeTun(deviceName string, cidr *net.IPNet, sendingPackets chan []byte, receivedPackets chan []byte) *FakeTun {
+	return &FakeTun{
+		cidr:            cidr,
+		sendingPackets:  sendingPackets,
+		receivedPackets: receivedPackets,
+		deviceName:      deviceName,
+	}
+}
+
+func (c *FakeTun) Activate() (err error) {
+	return
+}
+
+func (c *FakeTun) CidrNet() *net.IPNet {
+	return c.cidr
+}
+
+func (c *FakeTun) DeviceName() string {
+	return c.deviceName
+}
+
+func (c *FakeTun) Write(b []byte) (n int, err error) {
+	return len(b), c.WriteRaw(b)
+}
+
+func (c *FakeTun) Close() error {
+	return nil
+}
+
+func (c *FakeTun) NewMultiQueueReader() (io.ReadWriteCloser, error) {
+	return nil, fmt.Errorf("NewMultiQueueReader not supported by FakeTun\n")
+}
+
+func (c *FakeTun) WriteRaw(b []byte) error {
+	buff := make([]byte, len(b))
+	copy(buff, b)
+	c.receivedPackets <- buff //Data received by this node
+	return nil
+}
+
+func (c *FakeTun) Read(b []byte) (int, error) {
+	buff := <-c.sendingPackets //Data to be sent by this node
+	n := copy(b, buff)
+	return n, nil
+}


### PR DESCRIPTION
In certain cases, it may not desirable or even possible to install a tun device to connect to a Nebula network. A neat alternative would be to allow embedding of the Nebula service into applications or other services, which would then have individual access to resources on a Nebula network. This changeset includes:
-A fake Tun to handle packets in/out.
-Minor modifications to allow providing a Tun when starting Nebula.
-An example application that sends and receives packets directly through Nebula, without a real Tun device.