### PR TITLE
Fix build on riscv64

### DIFF
--- a/udp_linux_64.go
+++ b/udp_linux_64.go
@@ -1,5 +1,5 @@
 // +build linux
-// +build amd64 arm64 ppc64 ppc64le mips64 mips64le s390x
+// +build amd64 arm64 ppc64 ppc64le mips64 mips64le s390x riscv64
 // +build !android
 // +build !e2e_testing
 


### PR DESCRIPTION
Add `riscv64` build tag for `udp_linux_64.go` to fix build on riscv64