### PR TITLE
Break apart file loading from Config struct

### DIFF
--- a/cmd/nebula-service/main.go
+++ b/cmd/nebula-service/main.go
@@ -52,9 +52,16 @@ func main() {
 	l.Out = os.Stdout
 
 	c := config.NewC(l)
-	err := c.Load(*configPath)
+
+	// read files from config path and store read files in configFiles string slice
+	configFiles, err := config.ReadConfigFiles(*configPath)
 	if err != nil {
-		fmt.Printf("failed to load config: %s", err)
+		fmt.Printf("failed to read config(s): %s", err)
+		os.Exit(1)
+	}
+
+	if err := c.Load(configFiles...); err != nil {
+		fmt.Printf("failed to load config(s): %s", err)
 		os.Exit(1)
 	}
 

--- a/cmd/nebula-service/service.go
+++ b/cmd/nebula-service/service.go
@@ -29,9 +29,17 @@ func (p *program) Start(s service.Service) error {
 	HookLogger(l)
 
 	c := config.NewC(l)
-	err := c.Load(*p.configPath)
+
+	// read files from config path and store read files in configFiles string slice
+	configFiles, err := config.ReadConfigFiles(*p.configPath)
 	if err != nil {
-		return fmt.Errorf("failed to load config: %s", err)
+		fmt.Printf("failed to read config(s): %s", err)
+		os.Exit(1)
+	}
+
+	if err := c.Load(configFiles...); err != nil {
+		fmt.Printf("failed to load config(s): %s", err)
+		os.Exit(1)
 	}
 
 	p.control, err = nebula.Main(c, *p.configTest, Build, l, nil)

--- a/config/config_files.go
+++ b/config/config_files.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// ReadConfigFiles will find all yaml files within path and read them in lexical order
+func ReadConfigFiles(path string) ([]string, error) {
+	files, err := resolve(path, true)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no config files found at %s", path)
+	}
+
+	sort.Strings(files)
+
+	readFiles := []string{}
+	for _, file := range files {
+		f, err := os.ReadFile(file)
+		if err != nil {
+			return nil, err
+		}
+
+		readFiles = append(readFiles, string(f))
+	}
+
+	return readFiles, nil
+}
+
+// direct signifies if this is the config path directly specified by the user,
+// versus a file/dir found by recursing into that path
+func resolve(path string, direct bool) ([]string, error) {
+	files := []string{}
+
+	i, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if !i.IsDir() {
+		f, shouldAdd := checkFile(path, direct)
+		if !shouldAdd {
+			// If the file is not suitable we return
+			// the original slice
+			return files, err
+		}
+
+		return append(files, f), nil
+	}
+
+	paths, err := readDirNames(path)
+	if err != nil {
+		return nil, fmt.Errorf("problem while reading directory %s: %s", path, err)
+	}
+
+	for _, p := range paths {
+		f, err := resolve(filepath.Join(path, p), false)
+		if err != nil {
+			return nil, err
+		}
+
+		files = append(files, f...)
+	}
+
+	return files, nil
+}
+
+func readDirNames(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	paths, err := f.Readdirnames(-1)
+	f.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Strings(paths)
+	return paths, nil
+}
+
+// checkFile returns the name of the file and wether we should
+// add the file to the list of configs.
+func checkFile(path string, direct bool) (string, bool) {
+	ext := filepath.Ext(path)
+
+	if !direct && ext != ".yaml" && ext != ".yml" {
+		return "", false
+	}
+
+	ap, err := filepath.Abs(path)
+	if err != nil {
+		return "", false
+	}
+
+	return ap, true
+}

--- a/config/config_files_test.go
+++ b/config/config_files_test.go
@@ -1,0 +1,305 @@
+package config
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"testing"
+)
+
+// Given a path check if the file is correctly read.
+func TestReadConfigFilesSimpleFile(t *testing.T) {
+	dir, err := ioutil.TempDir("", "config_files_simple_file_test")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	defer func() {
+		_ = os.RemoveAll(dir)
+	}()
+
+	f, err := ioutil.TempFile(dir, "test_nebula_config_simple_file_*")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	expected := "Expected string to be read"
+
+	if _, err := io.WriteString(f, expected); err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	read, err := ReadConfigFiles(f.Name())
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	if len(read) != 1 {
+		t.Fatalf("len(read)=%v, want %v", len(read), 1)
+		return
+	}
+
+	if read[0] != expected {
+		t.Fatalf("read[0]=%v, want %v", read[0], expected)
+		return
+	}
+}
+
+// Check if .yaml/.yml files in folder get picked up correctly, even when mixed with random files.
+func TestReadConfigFilesMultipleFilesInFolder(t *testing.T) {
+	dir, err := ioutil.TempDir("", "config_files_multiple_files_test")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	defer func() {
+		_ = os.RemoveAll(dir)
+	}()
+
+	f1, err := ioutil.TempFile(dir, "config_files_multiple_files_test_*.yaml")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	defer func() {
+		_ = f1.Close()
+	}()
+
+	f2, err := ioutil.TempFile(dir, "config_files_multiple_files_test_*.notyaml")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	defer func() {
+		_ = f2.Close()
+	}()
+
+	f3, err := ioutil.TempFile(dir, "config_files_multiple_files_test_*.yaml")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	defer func() {
+		_ = f3.Close()
+	}()
+
+	expected := "Expected string to be read"
+	notyaml := "Not YAML"
+
+	if _, err := io.WriteString(f1, expected); err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	if _, err := io.WriteString(f2, notyaml); err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	if _, err := io.WriteString(f3, expected); err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	read, err := ReadConfigFiles(dir)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	if len(read) != 2 {
+		t.Fatalf("len(read)=%v, want %v", len(read), 2)
+		return
+	}
+
+	// Check every file read contains the expected string
+	for i, v := range read {
+		if v != expected {
+			t.Fatalf("read[%v]=%v, want %v", i, v, expected)
+			return
+		}
+	}
+}
+
+// Check if files are read in sorted in a lexicographical fashion
+func TestReadConfigFilesMultipleFilesInFolderCheckLexicographicalSorting(t *testing.T) {
+	// These are starting to get really long, lol
+	dir, err := ioutil.TempDir("", "config_files_multiple_files_check_lexicographical_sorting_test")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	defer func() {
+		_ = os.RemoveAll(dir)
+	}()
+
+	f1, err := ioutil.TempFile(dir, "a*.yaml")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	defer func() {
+		_ = f1.Close()
+	}()
+
+	f2, err := ioutil.TempFile(dir, "b*.yaml")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	defer func() {
+		_ = f2.Close()
+	}()
+
+	f3, err := ioutil.TempFile(dir, "c*.yaml")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	defer func() {
+		_ = f3.Close()
+	}()
+
+	if _, err := io.WriteString(f1, "0"); err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	if _, err := io.WriteString(f2, "1"); err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	if _, err := io.WriteString(f3, "2"); err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	read, err := ReadConfigFiles(dir)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	if len(read) != 3 {
+		t.Fatalf("len(read)=%v, want %v", len(read), 3)
+		return
+	}
+
+	// Check if the slice sorting follows the assumptions we made before
+	for i, v := range read {
+		if v != strconv.Itoa(i) {
+			t.Fatalf("read[%v]=%v, want %v", i, v, strconv.Itoa(i))
+			return
+		}
+	}
+}
+
+func TestReadConfigFilesMultipleFilesInMultipleFoldersSorting(t *testing.T) {
+	rootdir, err := ioutil.TempDir("", "config_files_multiple_files_multiple_folders_sorting_test")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	defer func() {
+		_ = os.RemoveAll(rootdir)
+	}()
+
+	dir1, err := ioutil.TempDir(rootdir, "dir1")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	dir2, err := ioutil.TempDir(rootdir, "dir2")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	f1, err := ioutil.TempFile(dir1, "a*.yaml")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	defer func() {
+		_ = f1.Close()
+	}()
+
+	f2, err := ioutil.TempFile(dir1, "b*.yaml")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	defer func() {
+		_ = f2.Close()
+	}()
+
+	f3, err := ioutil.TempFile(dir2, "a*.yaml")
+	defer func() {
+		_ = f3.Close()
+	}()
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	f4, err := ioutil.TempFile(dir2, "b*.yaml")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	defer func() {
+		_ = f4.Close()
+	}()
+
+	// The first file is f1, since dir1_XXXXXX/aXXXXX.yaml is
+	// lexicographically sorted first
+	if _, err := io.WriteString(f1, "0"); err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	// The second file is f2, since dir1_XXXXXX/bXXXXX.yaml is
+	// lexicographically sorted as second
+	if _, err := io.WriteString(f2, "1"); err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	if _, err := io.WriteString(f3, "2"); err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	if _, err := io.WriteString(f4, "3"); err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	read, err := ReadConfigFiles(rootdir)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	if len(read) != 4 {
+		t.Fatalf("len(read)=%v, want %v", len(read), 3)
+		return
+	}
+
+	// Check if the slice sorting follows the assumptions we made before
+	for i, v := range read {
+		if v != strconv.Itoa(i) {
+			t.Fatalf("read[%v]=%v, want %v", i, v, strconv.Itoa(i))
+			return
+		}
+	}
+}

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -84,7 +84,7 @@ func newSimpleServer(caCrt *cert.NebulaCertificate, caKey []byte, name string, u
 	}
 
 	c := config.NewC(l)
-	c.LoadString(string(cb))
+	c.Load(string(cb))
 
 	control, err := nebula.Main(c, false, "e2e-test", l, nil)
 


### PR DESCRIPTION
I'm embedding nebula in my binary and I'm passing the configuration through LoadString(), so I'm not passing through the usual config file. When using LoadString() there's no way to Reload a certificate, this PR tries to correct that separating the actual Reload() from ReloadConfig(). Function names may not be the clearest, so I'm super open to suggestions.