### PR TITLE
Fix flaky test

### DIFF
--- a/cmd/nebula-cert/verify_test.go
+++ b/cmd/nebula-cert/verify_test.go
@@ -72,7 +72,7 @@ func Test_verify(t *testing.T) {
 		Details: cert.NebulaCertificateDetails{
 			Name:      "test-ca",
 			NotBefore: time.Now().Add(time.Hour * -1),
-			NotAfter:  time.Now().Add(time.Hour),
+			NotAfter:  time.Now().Add(time.Hour * 2),
 			PublicKey: caPub,
 			IsCA:      true,
 		},


### PR DESCRIPTION
The most recent test run failed on master: https://github.com/slackhq/nebula/runs/4108898294?check_suite_focus=true

This is because both the CA & node cert are set to a NotAfter of one hour from now. As long as the test executes within the same second, this succeeds. However, if the second boundary elapses between the two cert structs' initialization, the signed cert will have an invalid NotAfter.