### PR TITLE
Add README and restart burst limit to service file

### DIFF
--- a/examples/service_scripts/README.md
+++ b/examples/service_scripts/README.md
@@ -1,0 +1,10 @@
+## Systemd:
+1. `# cp nebula.service /lib/systemd/system/`
+1. `# systemctl daemon-reload`
+1. Automatically start at boot (if desired):
+`# systemctl enable nebula.service`
+1. Start immediatly:
+`# systemctl start nebula.service`
+
+## Initd:
+##todo##

--- a/examples/service_scripts/nebula.service
+++ b/examples/service_scripts/nebula.service
@@ -1,8 +1,10 @@
 [Unit]
 Description=nebula
-Wants=basic.target
-After=basic.target network.target
+Wants=network-online.target
+After=nss-lookup.target
 Before=sshd.service
+StartLimitIntervalSec=30
+StartLimitBurst=5
 
 [Service]
 SyslogIdentifier=nebula


### PR DESCRIPTION
Add a 30 second delay before restarting the service after a failure and
prevents additional restarts after 5 attempts.

Add some basic usage/installation instructions for the Systemd service
file to the README.md within the example service file directory.

Change `After=` to nss-lookup for when hostnames are in the nebula config file.