### PR TITLE
Build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ To build nebula for all platforms:
 To build nebula for a specific platform (ex, Windows):
 `make bin-windows`
 
+To build nebula with a specific version (avoiding auto generation using `git branch --show-version`, if `git` is <2.25.x)
+
+`make all BUILD_NUMBER=1.42`
+
+Note: `GOPATH` and `GOROOT` are not required; the following prefix can be used to resolve any conflicts:
+
+`GOROOT="" GOPATH="" make all`
+
 See the [Makefile](Makefile) for more details on build targets
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -107,18 +107,16 @@ For each host, copy the nebula binary to the host, along with `config.yaml` from
 Download go and clone this repo. Change to the nebula directory.
 
 To build nebula for all platforms:
-`make all`
+* `make all`
 
 To build nebula for a specific platform (ex, Windows):
-`make bin-windows`
+* `make bin-windows`
 
 To build nebula with a specific version (avoiding auto generation using `git branch --show-version`, if `git` is <2.25.x)
-
-`make all BUILD_NUMBER=1.42`
+* `make all BUILD_NUMBER=1.42`
 
 Note: `GOPATH` and `GOROOT` are not required; the following prefix can be used to resolve any conflicts:
-
-`GOROOT="" GOPATH="" make all`
+* `GOROOT="" GOPATH="" make all`
 
 See the [Makefile](Makefile) for more details on build targets
 

--- a/examples/service_scripts/README.md
+++ b/examples/service_scripts/README.md
@@ -1,0 +1,10 @@
+## Systemd:
+1. `# cp nebula.service /lib/systemd/system/`
+1. `# systemctl daemon-reload`
+1. Automatically start at boot (if desired):
+`# systemctl enable nebula.service`
+1. Start immediatly:
+`# systemctl start nebula.service`
+
+## Initd:
+##todo##

--- a/examples/service_scripts/nebula.service
+++ b/examples/service_scripts/nebula.service
@@ -1,8 +1,10 @@
 [Unit]
 Description=nebula
-Wants=basic.target
-After=basic.target network.target
+Wants=network-online.target
+After=nss-lookup.target
 Before=sshd.service
+StartLimitIntervalSec=30
+StartLimitBurst=5
 
 [Service]
 SyslogIdentifier=nebula


### PR DESCRIPTION
The top result for "Debian install Go" on DuckDuckGo instructs users to set a `GOPATH` and `GOROOT` which can cause build time issues. This PR adds a little documentation explaining that, and also provides a solution to a syntax error that will happen if the user is on `git` < v2.25 (such as Debian Buster)