### PR TITLE
Warn if no lighthouses were configured on a non lighthouse node

### DIFF
--- a/main.go
+++ b/main.go
@@ -249,6 +249,10 @@ func Main(c *config.C, configTest bool, buildVersion string, logger *logrus.Logg
 		lighthouseHosts[i] = iputil.Ip2VpnIp(ip)
 	}
 
+	if !amLighthouse && len(lighthouseHosts) == 0 {
+		l.Warn("No lighthouses.hosts configured, this host will only be able to initiate tunnels with static_host_map entries")
+	}
+
 	lightHouse := NewLightHouse(
 		l,
 		amLighthouse,


### PR DESCRIPTION
Would help in situations like #585 