### PR TITLE
Read MaxRemotes and roaming timer values from config file.

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -128,6 +128,15 @@ punchy:
 # and has been deprecated for "preferred_ranges"
 #preferred_ranges: ["172.16.0.0/24"]
 
+dynamic_roaming:
+  #promote_every: 1000
+  #requery_every: 5000
+  # How long we should prevent roaminb back to the previous IP.
+  # This helps prevent flapping due to packets already in flight
+  #roaming_suppress_seconds: 2
+
+#max_remote_peers: 10
+
 # sshd can expose informational and administrative functions via ssh this is a
 #sshd:
   # Toggles the feature

--- a/hostmap.go
+++ b/hostmap.go
@@ -19,13 +19,13 @@ import (
 )
 
 //const ProbeLen = 100
-const PromoteEvery = 1000
-const ReQueryEvery = 5000
-const MaxRemotes = 10
+var PromoteEvery uint32
+var ReQueryEvery uint32
+var MaxRemotes int
 
-// How long we should prevent roaming back to the previous IP.
+// RoamingSuppressSeconds How long we should prevent roaming back to the previous IP.
 // This helps prevent flapping due to packets already in flight
-const RoamingSuppressSeconds = 2
+var RoamingSuppressSeconds time.Duration
 
 type HostMap struct {
 	sync.RWMutex    //Because we concurrently read and write to our maps

--- a/main.go
+++ b/main.go
@@ -89,6 +89,13 @@ func Main(c *config.C, configTest bool, buildVersion string, logger *logrus.Logg
 		}
 	}
 
+	// Set vars from hostmap.go
+	PromoteEvery = uint32(c.GetInt("dynamic_roaming.promote_every", 1000))
+	ReQueryEvery = uint32(c.GetInt("dynamic_roaming.requery_every", 5000))
+	// Must type cast instead of using c.GetDuration because the value is multiplied by time.Second everywhere else.
+	RoamingSuppressSeconds = time.Duration(c.GetInt("dynamic_roaming.roaming_suppress_seconds", 2))
+	MaxRemotes = c.GetInt("max_remote_peers", 10)
+	
 	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 	// All non system modifying configuration consumption should live above this line
 	// tun config, listeners, anything modifying the computer should be below


### PR DESCRIPTION
Read `PromoteEvery`, `ReQueryEvery`, and RoamingSuppressSeconds`
from a new `dynamic_routing` block in the config file instead of
hardcoded constants in the `hostmap.go` file.