### PR TITLE
fix `wintun` package to have // +build comments

### DIFF
--- a/wintun/device.go
+++ b/wintun/device.go
@@ -1,4 +1,5 @@
 //go:build windows
+// +build windows
 
 /* SPDX-License-Identifier: MIT
  *

--- a/wintun/tun.go
+++ b/wintun/tun.go
@@ -1,4 +1,5 @@
 //go:build windows
+// +build windows
 
 /* SPDX-License-Identifier: MIT
  *


### PR DESCRIPTION
Without these comments, gofmt 1.16.9 will complain. Since we otherwise
still support building with go1.16.9, lets add the comments to make it
easier to compile.

Related: #588