### PR TITLE
Allow setup of a CA pool from bytes that contain expired certs

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -148,7 +148,7 @@ func loadCAFromConfig(l *logrus.Logger, c *config.C) (*cert.NebulaCAPool, error)
 	if errors.Is(err, cert.ErrExpired) {
 		for _, cert := range CAs.CAs {
 			if cert.Expired(time.Now()) {
-				l.WithField("name", cert.Details.Name).Warn("expired certificate present in CA pool")
+				l.WithField("certificate", cert).Warn("expired certificate present in CA pool")
 			}
 		}
 		err = nil

--- a/cert.go
+++ b/cert.go
@@ -144,7 +144,12 @@ func loadCAFromConfig(l *logrus.Logger, c *config.C) (*cert.NebulaCAPool, error)
 		}
 	}
 
-	CAs, err := cert.NewCAPoolFromBytes(rawCA)
+	var ignore []error
+	if c.GetBool("pki.ignore_expired_ca", false) {
+		ignore = append(ignore, cert.ErrExpired)
+	}
+
+	CAs, err := cert.NewCAPoolFromBytes(rawCA, ignore...)
 	if err != nil {
 		return nil, fmt.Errorf("error while adding CA certificate to CA trust store: %s", err)
 	}

--- a/cert.go
+++ b/cert.go
@@ -144,12 +144,11 @@ func loadCAFromConfig(l *logrus.Logger, c *config.C) (*cert.NebulaCAPool, error)
 		}
 	}
 
-	var ignore []error
-	if c.GetBool("pki.ignore_expired_ca", false) {
-		ignore = append(ignore, cert.ErrExpired)
+	CAs, err := cert.NewCAPoolFromBytes(rawCA)
+	if errors.Is(err, cert.ErrExpired) {
+		l.WithError(err).Warn("expired certificates present in CA pool")
+		err = nil
 	}
-
-	CAs, err := cert.NewCAPoolFromBytes(rawCA, ignore...)
 	if err != nil {
 		return nil, fmt.Errorf("error while adding CA certificate to CA trust store: %s", err)
 	}

--- a/cert.go
+++ b/cert.go
@@ -148,7 +148,13 @@ func loadCAFromConfig(l *logrus.Logger, c *config.C) (*cert.NebulaCAPool, error)
 	if errors.Is(err, cert.ErrExpired) {
 		for _, cert := range CAs.CAs {
 			if cert.Expired(time.Now()) {
-				l.WithField("certificate", cert).Warn("expired certificate present in CA pool")
+				fingerprint, _ := cert.Sha256Sum()
+				l.WithField("name", cert.Details.Name).
+					WithField("not_before", cert.Details.NotBefore).
+					WithField("not_after", cert.Details.NotAfter).
+					WithField("fingerprint", fingerprint).
+					WithField("signature", fmt.Sprintf("%x", cert.Signature)).
+					Warn("expired certificate present in CA pool")
 			}
 		}
 		err = nil

--- a/cert.go
+++ b/cert.go
@@ -146,7 +146,11 @@ func loadCAFromConfig(l *logrus.Logger, c *config.C) (*cert.NebulaCAPool, error)
 
 	CAs, err := cert.NewCAPoolFromBytes(rawCA)
 	if errors.Is(err, cert.ErrExpired) {
-		l.WithError(err).Warn("expired certificates present in CA pool")
+		for _, cert := range CAs.CAs {
+			if cert.Expired(time.Now()) {
+				l.WithField("name", cert.Details.Name).Warn("expired certificate present in CA pool")
+			}
+		}
 		err = nil
 	}
 	if err != nil {

--- a/cert.go
+++ b/cert.go
@@ -125,18 +125,12 @@ func loadCAFromConfig(l *logrus.Logger, c *config.C) (*cert.NebulaCAPool, error)
 
 	caPathOrPEM := c.GetString("pki.ca", "")
 	if caPathOrPEM == "" {
-		// Support backwards compat with the old x509
-		//TODO: remove after this is rolled out everywhere - NB 2018/02/23
-		caPathOrPEM = c.GetString("x509.ca", "")
-	}
-
-	if caPathOrPEM == "" {
 		return nil, errors.New("no pki.ca path or PEM data provided")
 	}
 
 	if strings.Contains(caPathOrPEM, "-----BEGIN") {
 		rawCA = []byte(caPathOrPEM)
-		caPathOrPEM = "<inline>"
+
 	} else {
 		rawCA, err = ioutil.ReadFile(caPathOrPEM)
 		if err != nil {
@@ -144,26 +138,21 @@ func loadCAFromConfig(l *logrus.Logger, c *config.C) (*cert.NebulaCAPool, error)
 		}
 	}
 
-	var expired int
 	CAs, err := cert.NewCAPoolFromBytes(rawCA)
 	if errors.Is(err, cert.ErrExpired) {
+		var expired int
 		for _, cert := range CAs.CAs {
 			if cert.Expired(time.Now()) {
 				expired++
-				fingerprint, _ := cert.Sha256Sum()
-				l.WithField("name", cert.Details.Name).
-					WithField("not_before", cert.Details.NotBefore).
-					WithField("not_after", cert.Details.NotAfter).
-					WithField("fingerprint", fingerprint).
-					WithField("signature", fmt.Sprintf("%x", cert.Signature)).
-					Warn("expired certificate present in CA pool")
+				l.WithField("cert", cert).Warn("expired certificate present in CA pool")
 			}
 		}
-		if expired < len(CAs.CAs) {
-			err = nil
+
+		if expired >= len(CAs.CAs) {
+			return nil, errors.New("no valid CA certificates present")
 		}
-	}
-	if err != nil {
+
+	} else if err != nil {
 		return nil, fmt.Errorf("error while adding CA certificate to CA trust store: %s", err)
 	}
 
@@ -172,7 +161,8 @@ func loadCAFromConfig(l *logrus.Logger, c *config.C) (*cert.NebulaCAPool, error)
 		CAs.BlocklistFingerprint(fp)
 	}
 
-	// Support deprecated config for at leaast one minor release to allow for migrations
+	// Support deprecated config for at least one minor release to allow for migrations
+	//TODO: remove in 2022 or later
 	for _, fp := range c.GetStringSlice("pki.blacklist", []string{}) {
 		l.WithField("fingerprint", fp).Infof("Blocklisting cert")
 		l.Warn("pki.blacklist is deprecated and will not be supported in a future release. Please migrate your config to use pki.blocklist")

--- a/cert/ca.go
+++ b/cert/ca.go
@@ -29,11 +29,11 @@ func NewCAPool() *NebulaCAPool {
 func NewCAPoolFromBytes(caPEMs []byte) (*NebulaCAPool, error) {
 	pool := NewCAPool()
 	var err error
-	var expired []string
+	var expired int
 	for {
 		caPEMs, err = pool.AddCACertificate(caPEMs)
 		if errors.Is(err, ErrExpired) {
-			expired = append(expired, err.Error())
+			expired++
 			err = nil
 		}
 		if err != nil {
@@ -44,12 +44,12 @@ func NewCAPoolFromBytes(caPEMs []byte) (*NebulaCAPool, error) {
 		}
 	}
 
-	if len(pool.CAs)-len(expired) == 0 {
+	if len(pool.CAs)-expired == 0 {
 		return nil, ErrEmptyCAPool
 	}
 
-	if len(expired) > 0 {
-		return pool, fmt.Errorf("%s: %w", strings.Join(expired, ","), ErrExpired)
+	if expired > 0 {
+		return pool, ErrExpired
 	}
 
 	return pool, nil

--- a/cert/ca.go
+++ b/cert/ca.go
@@ -29,11 +29,11 @@ func NewCAPool() *NebulaCAPool {
 func NewCAPoolFromBytes(caPEMs []byte) (*NebulaCAPool, error) {
 	pool := NewCAPool()
 	var err error
-	var expired int
+	var expired bool
 	for {
 		caPEMs, err = pool.AddCACertificate(caPEMs)
 		if errors.Is(err, ErrExpired) {
-			expired++
+			expired = true
 			err = nil
 		}
 		if err != nil {
@@ -44,11 +44,7 @@ func NewCAPoolFromBytes(caPEMs []byte) (*NebulaCAPool, error) {
 		}
 	}
 
-	if len(pool.CAs)-expired == 0 {
-		return nil, ErrEmptyCAPool
-	}
-
-	if expired > 0 {
+	if expired {
 		return pool, ErrExpired
 	}
 

--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -469,7 +469,7 @@ WH1M9n4O7cFtGlM6sJJOS+rCVVEJ3ABS7+MPdQs=
 
 	// expired cert, with valid certs
 	pppp, err := NewCAPoolFromBytes(append([]byte(expired), noNewLines...))
-	assert.Equal(t, fmt.Errorf("expired: %s: %w", ErrExpired, ErrExpired), err)
+	assert.Equal(t, ErrExpired, err)
 	assert.Equal(t, pppp.CAs[string("c9bfaf7ce8e84b2eeda2e27b469f4b9617bde192efd214b68891ecda6ed49522")].Details.Name, rootCA.Details.Name)
 	assert.Equal(t, pppp.CAs[string("5c9c3f23e7ee7fe97637cbd3a0a5b854154d1d9aaaf7b566a51f4a88f76b64cd")].Details.Name, rootCA01.Details.Name)
 	assert.Equal(t, pppp.CAs[string("152070be6bb19bc9e3bde4c2f0e7d8f4ff5448b4c9856b8eccb314fade0229b0")].Details.Name, "expired")

--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -431,6 +431,15 @@ BVG+oJpAoqokUBbI4U0N8CSfpUABEkB/Pm5A2xyH/nc8mg/wvGUWG3pZ7nHzaDMf
 
 `
 
+	expired := `
+# expired certificate
+-----BEGIN NEBULA CERTIFICATE-----
+CjkKB2V4cGlyZWQouPmWjQYwufmWjQY6ILCRaoCkJlqHgv5jfDN4lzLHBvDzaQm4
+vZxfu144hmgjQAESQG4qlnZi8DncvD/LDZnLgJHOaX1DWCHHEh59epVsC+BNgTie
+WH1M9n4O7cFtGlM6sJJOS+rCVVEJ3ABS7+MPdQs=
+-----END NEBULA CERTIFICATE-----
+`
+
 	rootCA := NebulaCertificate{
 		Details: NebulaCertificateDetails{
 			Name: "nebula root ca",
@@ -452,6 +461,17 @@ BVG+oJpAoqokUBbI4U0N8CSfpUABEkB/Pm5A2xyH/nc8mg/wvGUWG3pZ7nHzaDMf
 	assert.Nil(t, err)
 	assert.Equal(t, pp.CAs[string("c9bfaf7ce8e84b2eeda2e27b469f4b9617bde192efd214b68891ecda6ed49522")].Details.Name, rootCA.Details.Name)
 	assert.Equal(t, pp.CAs[string("5c9c3f23e7ee7fe97637cbd3a0a5b854154d1d9aaaf7b566a51f4a88f76b64cd")].Details.Name, rootCA01.Details.Name)
+
+	// expired cert, no ignored errors
+	ppp, err := NewCAPoolFromBytes(append([]byte(expired), noNewLines...))
+	assert.Nil(t, ppp)
+	assert.Equal(t, err, fmt.Errorf("expired: %w", ErrExpired))
+
+	// expired cert, ignore expired errors
+	pppp, err := NewCAPoolFromBytes(append([]byte(expired), noNewLines...), ErrExpired)
+	assert.Nil(t, err)
+	assert.Equal(t, pppp.CAs[string("c9bfaf7ce8e84b2eeda2e27b469f4b9617bde192efd214b68891ecda6ed49522")].Details.Name, rootCA.Details.Name)
+	assert.Equal(t, pppp.CAs[string("5c9c3f23e7ee7fe97637cbd3a0a5b854154d1d9aaaf7b566a51f4a88f76b64cd")].Details.Name, rootCA01.Details.Name)
 }
 
 func appendByteSlices(b ...[]byte) []byte {

--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -462,16 +462,18 @@ WH1M9n4O7cFtGlM6sJJOS+rCVVEJ3ABS7+MPdQs=
 	assert.Equal(t, pp.CAs[string("c9bfaf7ce8e84b2eeda2e27b469f4b9617bde192efd214b68891ecda6ed49522")].Details.Name, rootCA.Details.Name)
 	assert.Equal(t, pp.CAs[string("5c9c3f23e7ee7fe97637cbd3a0a5b854154d1d9aaaf7b566a51f4a88f76b64cd")].Details.Name, rootCA01.Details.Name)
 
-	// expired cert, no ignored errors
-	ppp, err := NewCAPoolFromBytes(append([]byte(expired), noNewLines...))
+	// expired cert, no valid certs
+	ppp, err := NewCAPoolFromBytes([]byte(expired))
 	assert.Nil(t, ppp)
-	assert.Equal(t, err, fmt.Errorf("expired: %w", ErrExpired))
+	assert.Equal(t, ErrEmptyCAPool, err)
 
-	// expired cert, ignore expired errors
-	pppp, err := NewCAPoolFromBytes(append([]byte(expired), noNewLines...), ErrExpired)
-	assert.Nil(t, err)
+	// expired cert, with valid certs
+	pppp, err := NewCAPoolFromBytes(append([]byte(expired), noNewLines...))
+	assert.Equal(t, fmt.Errorf("expired: %s: %w", ErrExpired, ErrExpired), err)
 	assert.Equal(t, pppp.CAs[string("c9bfaf7ce8e84b2eeda2e27b469f4b9617bde192efd214b68891ecda6ed49522")].Details.Name, rootCA.Details.Name)
 	assert.Equal(t, pppp.CAs[string("5c9c3f23e7ee7fe97637cbd3a0a5b854154d1d9aaaf7b566a51f4a88f76b64cd")].Details.Name, rootCA01.Details.Name)
+	assert.Equal(t, pppp.CAs[string("152070be6bb19bc9e3bde4c2f0e7d8f4ff5448b4c9856b8eccb314fade0229b0")].Details.Name, "expired")
+	assert.Equal(t, len(pppp.CAs), 3)
 }
 
 func appendByteSlices(b ...[]byte) []byte {

--- a/cert/cert_test.go
+++ b/cert/cert_test.go
@@ -464,8 +464,8 @@ WH1M9n4O7cFtGlM6sJJOS+rCVVEJ3ABS7+MPdQs=
 
 	// expired cert, no valid certs
 	ppp, err := NewCAPoolFromBytes([]byte(expired))
-	assert.Nil(t, ppp)
-	assert.Equal(t, ErrEmptyCAPool, err)
+	assert.Equal(t, ErrExpired, err)
+	assert.Equal(t, ppp.CAs[string("152070be6bb19bc9e3bde4c2f0e7d8f4ff5448b4c9856b8eccb314fade0229b0")].Details.Name, "expired")
 
 	// expired cert, with valid certs
 	pppp, err := NewCAPoolFromBytes(append([]byte(expired), noNewLines...))

--- a/cert/errors.go
+++ b/cert/errors.go
@@ -1,0 +1,9 @@
+package cert
+
+import "errors"
+
+var (
+	ErrExpired       = errors.New("certificate is expired")
+	ErrNotCA         = errors.New("certificate is not a CA")
+	ErrNotSelfSigned = errors.New("certificate is not self-signed")
+)

--- a/cert/errors.go
+++ b/cert/errors.go
@@ -3,7 +3,6 @@ package cert
 import "errors"
 
 var (
-	ErrEmptyCAPool   = errors.New("ca pool had no valid certificates")
 	ErrExpired       = errors.New("certificate is expired")
 	ErrNotCA         = errors.New("certificate is not a CA")
 	ErrNotSelfSigned = errors.New("certificate is not self-signed")

--- a/cert/errors.go
+++ b/cert/errors.go
@@ -3,6 +3,7 @@ package cert
 import "errors"
 
 var (
+	ErrEmptyCAPool   = errors.New("ca pool had no valid certificates")
 	ErrExpired       = errors.New("certificate is expired")
 	ErrNotCA         = errors.New("certificate is not a CA")
 	ErrNotSelfSigned = errors.New("certificate is not self-signed")

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -12,6 +12,9 @@ pki:
   #  - c99d4e650533b92061b09918e838a5a0a6aaee21eed1d12fd937682865936c72
   # disconnect_invalid is a toggle to force a client to be disconnected if the certificate is expired or invalid.
   #disconnect_invalid: false
+  # ignore_expired_ca is a toggle that will allow nebula to start when there are expired certificates in the ca file.
+  # Expired certs are not loaded, and so will not be trusted.
+  #ignore_expired_ca: false
 
 # The static host map defines a set of hosts with fixed IP addresses on the internet (or any network).
 # A host can have multiple fixed IP addresses defined here, and nebula will try each when establishing a tunnel.

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -12,9 +12,6 @@ pki:
   #  - c99d4e650533b92061b09918e838a5a0a6aaee21eed1d12fd937682865936c72
   # disconnect_invalid is a toggle to force a client to be disconnected if the certificate is expired or invalid.
   #disconnect_invalid: false
-  # ignore_expired_ca is a toggle that will allow nebula to start when there are expired certificates in the ca file.
-  # Expired certs are not loaded, and so will not be trusted.
-  #ignore_expired_ca: false
 
 # The static host map defines a set of hosts with fixed IP addresses on the internet (or any network).
 # A host can have multiple fixed IP addresses defined here, and nebula will try each when establishing a tunnel.


### PR DESCRIPTION
Certs can expire while they are in a running config, but nebula will fail to start or to reload config if certs in the PEM are expired at load time.

This PR makes the behaviour more consistent by loading the expired certs into the CA pool (ensuring that host connections with certs issued by the expired CA will log that the CA is expired, rather than missing). We log an error and continue when expired certs exist alongside valid certs, but will hard error and fail to start if there are any other error types or there are only expired certs in the pool.