### PR TITLE
fix unsafe_route collisions on Darwin

### DIFF
--- a/overlay/tun_darwin.go
+++ b/overlay/tun_darwin.go
@@ -4,6 +4,7 @@
 package overlay
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -272,6 +273,9 @@ func (t *tun) Activate() error {
 	copy(maskAddr.IP[:], mask[:])
 	err = addRoute(routeSock, routeAddr, maskAddr, linkAddr)
 	if err != nil {
+		if errors.Is(err, unix.EEXIST) {
+			err = fmt.Errorf("unable to add tun route, identical route already exists: %s", t.cidr)
+		}
 		return err
 	}
 
@@ -293,7 +297,12 @@ func (t *tun) Activate() error {
 
 		err = addRoute(routeSock, routeAddr, maskAddr, linkAddr)
 		if err != nil {
-			return err
+			if errors.Is(err, unix.EEXIST) {
+				t.l.WithField("route", r.Cidr).
+					Warnf("unable to add unsafe_route, identical route already exists")
+			} else {
+				return err
+			}
 		}
 
 		// TODO how to set metric
@@ -354,11 +363,11 @@ func addRoute(sock int, addr, mask *netroute.Inet4Addr, link *netroute.LinkAddr)
 
 	data, err := r.Marshal()
 	if err != nil {
-		return fmt.Errorf("failed to create route.RouteMessage: %v", err)
+		return fmt.Errorf("failed to create route.RouteMessage: %w", err)
 	}
 	_, err = unix.Write(sock, data[:])
 	if err != nil {
-		return fmt.Errorf("failed to write route.RouteMessage to socket: %v", err)
+		return fmt.Errorf("failed to write route.RouteMessage to socket: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
With Nebula 1.4.0, if you create an unsafe_route that has a collision with an existing route on the system, the unsafe_route will be silently dropped (and the existing system route remains).

With Nebula 1.5.0, this same situation will cause Nebula to fail to start with an error (EEXIST).

This change restores the Nebula 1.4.0 behavior (but with a WARN log as well).