### PR TITLE
Add 'tun.su' option to allow changing users after configuring the tunnel

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -160,6 +160,8 @@ tun:
   tx_queue: 500
   # Default MTU for every packet, safe setting is (and the default) 1300 for internet based traffic
   mtu: 1300
+  # Switch to this user after configuring the tun device (useful for running nebula as non-root)
+  #su: nebula
   # Route based MTU overrides, you have known vpn ip paths that can support larger MTUs you can increase/decrease them here
   routes:
     #- mtu: 8800

--- a/main.go
+++ b/main.go
@@ -364,6 +364,7 @@ func Main(c *config.C, configTest bool, buildVersion string, logger *logrus.Logg
 
 		ConntrackCacheTimeout: conntrackCacheTimeout,
 		l:                     l,
+		ChangeToUser:          c.GetString("tun.su", ""),
 	}
 
 	switch ifConfig.Cipher {

--- a/overlay/device.go
+++ b/overlay/device.go
@@ -9,7 +9,7 @@ import (
 
 type Device interface {
 	io.ReadWriteCloser
-	Activate() error
+	Activate(string) error
 	Cidr() *net.IPNet
 	Name() string
 	RouteFor(iputil.VpnIp) iputil.VpnIp

--- a/overlay/tun_android.go
+++ b/overlay/tun_android.go
@@ -44,7 +44,7 @@ func (t *tun) RouteFor(iputil.VpnIp) iputil.VpnIp {
 	return 0
 }
 
-func (t tun) Activate() error {
+func (t tun) Activate(changeToUser string) error {
 	return nil
 }
 

--- a/overlay/tun_darwin.go
+++ b/overlay/tun_darwin.go
@@ -181,7 +181,7 @@ func (t *tun) Close() error {
 	return nil
 }
 
-func (t *tun) Activate() error {
+func (t *tun) Activate(changeToUser string) error {
 	devName := t.deviceBytes()
 
 	var addr, mask [4]byte
@@ -306,6 +306,10 @@ func (t *tun) Activate() error {
 		}
 
 		// TODO how to set metric
+	}
+
+	if err = ChangeToUser(t.l, changeToUser); err != nil {
+		return fmt.Errorf("failed to change users: %s", err)
 	}
 
 	return nil

--- a/overlay/tun_disabled.go
+++ b/overlay/tun_disabled.go
@@ -40,7 +40,7 @@ func newDisabledTun(cidr *net.IPNet, queueLen int, metricsEnabled bool, l *logru
 	return tun
 }
 
-func (*disabledTun) Activate() error {
+func (*disabledTun) Activate(changeToUser string) error {
 	return nil
 }
 

--- a/overlay/tun_freebsd.go
+++ b/overlay/tun_freebsd.go
@@ -64,7 +64,7 @@ func newTun(l *logrus.Logger, deviceName string, cidr *net.IPNet, defaultMTU int
 	}, nil
 }
 
-func (t *tun) Activate() error {
+func (t *tun) Activate(changeToUser string) error {
 	var err error
 	t.ReadWriteCloser, err = os.OpenFile("/dev/"+t.Device, os.O_RDWR, 0)
 	if err != nil {
@@ -97,7 +97,11 @@ func (t *tun) Activate() error {
 		}
 	}
 
-	return nil
+	if err = ChangeToUser(t.l, changeToUser); err != nil {
+		return fmt.Errorf("failed to change users: %s", err)
+	}
+
+    return nil
 }
 
 func (t *tun) RouteFor(ip iputil.VpnIp) iputil.VpnIp {

--- a/overlay/tun_ios.go
+++ b/overlay/tun_ios.go
@@ -38,7 +38,7 @@ func newTunFromFd(_ *logrus.Logger, deviceFd int, cidr *net.IPNet, _ int, routes
 	}, nil
 }
 
-func (t *tun) Activate() error {
+func (t *tun) Activate(changeToUser string) error {
 	return nil
 }
 

--- a/overlay/tun_linux.go
+++ b/overlay/tun_linux.go
@@ -190,7 +190,7 @@ func (t tun) deviceBytes() (o [16]byte) {
 	return
 }
 
-func (t tun) Activate() error {
+func (t tun) Activate(changeToUser string) error {
 	devName := t.deviceBytes()
 
 	var addr, mask [4]byte
@@ -301,6 +301,10 @@ func (t tun) Activate() error {
 	ifrf.Flags = ifrf.Flags | unix.IFF_UP | unix.IFF_RUNNING
 	if err = ioctl(fd, unix.SIOCSIFFLAGS, uintptr(unsafe.Pointer(&ifrf))); err != nil {
 		return fmt.Errorf("failed to run tun device: %s", err)
+	}
+
+	if err = ChangeToUser(t.l, changeToUser); err != nil {
+		return fmt.Errorf("failed to change users: %s", err)
 	}
 
 	return nil

--- a/overlay/tun_tester.go
+++ b/overlay/tun_tester.go
@@ -82,7 +82,7 @@ func (t *TestTun) RouteFor(ip iputil.VpnIp) iputil.VpnIp {
 	return 0
 }
 
-func (t *TestTun) Activate() error {
+func (t *TestTun) Activate(changeToUser string) error {
 	return nil
 }
 

--- a/overlay/tun_unix_change_user.go
+++ b/overlay/tun_unix_change_user.go
@@ -1,0 +1,78 @@
+//go:build !android && !ios && !e2e_testing
+// +build !android,!ios,!e2e_testing
+
+package overlay
+
+import (
+	"syscall"
+	"fmt"
+	"strconv"
+	"os"
+	"os/user"
+
+	"github.com/sirupsen/logrus"
+)
+
+func ChangeToUser(l *logrus.Logger, changeToUser string) error {
+	var account *user.User
+	var err error
+
+	if len(changeToUser) == 0 {
+		return nil
+	}
+
+	if account, err = user.Lookup(changeToUser); err != nil {
+		return fmt.Errorf("could not find user %v: %s", changeToUser, err)
+	}
+
+	uid, err := strconv.ParseInt(account.Uid, 10, 32)
+	if err != nil {
+		return fmt.Errorf("could not parse account UID %v: %s", account.Uid, err)
+	}
+	gid, err := strconv.ParseInt(account.Gid, 10, 32)
+	if err != nil {
+		return fmt.Errorf("could not parse account GID %v: %s", account.Gid, err)
+	}
+
+	groups, err := account.GroupIds()
+	if err != nil {
+		return fmt.Errorf("could not get groups for UID %v: %s", account.Uid, err)
+	}
+
+	gids := make([]int, len(groups))
+	for idx, gidstr := range groups {
+		accountGid, err := strconv.ParseInt(gidstr, 10, 32)
+		if err != nil {
+			return fmt.Errorf("could not parse GID %v: %s", gidstr, err)
+		}
+		gids[idx] = int(accountGid)
+	}
+
+	l.Infof("Dropping privileges to %v (UID %v, GID %v)", account.Username, uid, gid)
+
+	err = syscall.Setgroups(gids)
+	if err != nil {
+		return fmt.Errorf("could not set groups for %v: %s", changeToUser, err)
+	}
+
+	err = syscall.Setgid(int(gid))
+	if err != nil {
+		return fmt.Errorf("could not set GID to %v: %s", gid, err)
+	}
+
+	err = syscall.Setuid(int(uid))
+	if err != nil {
+		return fmt.Errorf("could not set UID to %v: %s", uid, err)
+	}
+
+	actualUid := int64(os.Geteuid())
+	actualGid := int64(os.Getegid())
+
+	if actualUid != uid || actualGid != gid {
+		return fmt.Errorf("expected to be running as %v (%v:%v); actually %v:%v", account.Username, uid, gid, actualUid, actualGid)
+	} else {
+        l.Infof("Now running as %v", account.Username)
+	}
+
+	return nil
+}

--- a/overlay/tun_water_windows.go
+++ b/overlay/tun_water_windows.go
@@ -38,7 +38,7 @@ func newWaterTun(l *logrus.Logger, cidr *net.IPNet, defaultMTU int, routes []Rou
 	}, nil
 }
 
-func (t *waterTun) Activate() error {
+func (t *waterTun) Activate(changeToUser string) error {
 	var err error
 	t.Interface, err = water.New(water.Config{
 		DeviceType: water.TUN,

--- a/overlay/tun_wintun_windows.go
+++ b/overlay/tun_wintun_windows.go
@@ -73,7 +73,7 @@ func newWinTun(l *logrus.Logger, deviceName string, cidr *net.IPNet, defaultMTU 
 	}, nil
 }
 
-func (t *winTun) Activate() error {
+func (t *winTun) Activate(changeToUser string) error {
 	luid := winipcfg.LUID(t.tun.LUID())
 
 	if err := luid.SetIPAddresses([]net.IPNet{*t.cidr}); err != nil {


### PR DESCRIPTION
Other VPNs (e.g. Tinc) let you drop privileges from root after the tunnel is created.

Add a `tun.su` option specifying which user to drop privileges to. That way, Nebula can be started as root and run as a lesser privileged user.

Tested on Linux. Still have to test FreeBSD and Darwin. The `tun.su` option gets ignored on other platforms.