### PR TITLE
Add dns wildcarding

### DIFF
--- a/dns_server.go
+++ b/dns_server.go
@@ -130,8 +130,8 @@ func handleDnsRequest(l *logrus.Logger, w dns.ResponseWriter, r *dns.Msg) {
 
 func dnsMain(l *logrus.Logger, hostMap *HostMap, c *config.C) func() {
 	dnsR = newDnsRecords(hostMap)
-	dnsR.dnsWildcardEnabled = c.GetBool("dns.wildcard", false)
-	dnsR.dnsWildcardLimit = c.GetInt("dns.wildcard_limit", 5)
+	dnsR.dnsWildcardEnabled = c.GetBool("lighthouse.dns.wildcard", false)
+	dnsR.dnsWildcardLimit = c.GetInt("lighthouse.dns.wildcard_limit", 5)
 
 	// attach request handler func
 	dns.HandleFunc(".", func(w dns.ResponseWriter, r *dns.Msg) {

--- a/dns_server_test.go
+++ b/dns_server_test.go
@@ -25,7 +25,10 @@ func TestDnsWildcardLookup(t *testing.T) {
 	ds.Add("test.com.com", "1.2.3.4")
 	ds.dnsWildcardEnabled = true
 
-	result := ds.Query("foo.test.com.com")
+	result := ds.Query("test.com.com")
+	assert.Equal(t, "1.2.3.4", result)
+
+	result = ds.Query("foo.test.com.com")
 	assert.Equal(t, "1.2.3.4", result)
 }
 
@@ -48,7 +51,10 @@ func TestDnsWildcardLookupLimit(t *testing.T) {
 	ds.dnsWildcardEnabled = true
 	ds.dnsWildcardLimit = 1
 
-	result := ds.Query("foo.test.com.com")
+	result := ds.Query("test.com.com")
+	assert.Equal(t, "1.2.3.4", result)
+
+	result = ds.Query("foo.test.com.com")
 	assert.Equal(t, "1.2.3.4", result)
 
 	result = ds.Query("foo.bar.test.com.com")

--- a/dns_server_test.go
+++ b/dns_server_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParsequery(t *testing.T) {
@@ -16,4 +17,40 @@ func TestParsequery(t *testing.T) {
 	m.SetQuestion("test.com.com", dns.TypeA)
 
 	//parseQuery(m)
+}
+
+func TestDnsWildcardLookup(t *testing.T) {
+	hostMap := &HostMap{}
+	ds := newDnsRecords(hostMap)
+	ds.Add("test.com.com", "1.2.3.4")
+	ds.dnsWildcardEnabled = true
+
+	result := ds.Query("foo.test.com.com")
+	assert.Equal(t, "1.2.3.4", result)
+}
+
+func TestDnsWildcardDisabled(t *testing.T) {
+	hostMap := &HostMap{}
+	ds := newDnsRecords(hostMap)
+	ds.Add("test.com.com", "1.2.3.4")
+
+	result := ds.Query("test.com.com")
+	assert.Equal(t, "1.2.3.4", result)
+
+	result = ds.Query("foo.test.com.com")
+	assert.Equal(t, "", result)
+}
+
+func TestDnsWildcardLookupLimit(t *testing.T) {
+	hostMap := &HostMap{}
+	ds := newDnsRecords(hostMap)
+	ds.Add("test.com.com", "1.2.3.4")
+	ds.dnsWildcardEnabled = true
+	ds.dnsWildcardLimit = 1
+
+	result := ds.Query("foo.test.com.com")
+	assert.Equal(t, "1.2.3.4", result)
+
+	result = ds.Query("foo.bar.test.com.com")
+	assert.Equal(t, "", result)
 }

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -33,6 +33,8 @@ lighthouse:
     # The DNS host defines the IP to bind the dns listener to. This also allows binding to the nebula node IP.
     #host: 0.0.0.0
     #port: 53
+    #wildcard: true # Enable wildcarding on hosts e.g allowing my-app.my-host.nebula to resolve to the IP for my-host.nebula
+    #wildcard_limit: 5 # Limit of number of possible subdomains
   # interval is the number of seconds between updates from this node to a lighthouse.
   # during updates, a node sends information about its current IP addresses to each node.
   interval: 60


### PR DESCRIPTION
This PR is an attempt at implementing DNS wildcard support. The use case in mind is for those of us who wish to use nebula's DNS in conjunction with virtual hosts.

At the moment, say we have a server `my-server.nebula`, it is not possible to use virtual hosts to have, for example multiple apps served at `app-1.my-server.nebula`, `app-2.my-server.nebula` etc.

This initial (naive) implementation can be enabled with the new config options as seen below.

```
# ...
lighthouse:
  # ...
  dns:
    # ...
    wildcard: true
    wildcard_limit: 5 # recursion limit used when searching for a matching host
```

This config is global and doesn't support per-host or per-group enabling. I welcome discussion on the proposed feature and its implementation as-is as well as commentary around the desired configuration of the feature.

Relevant slack discussion: https://nebulaoss.slack.com/archives/CRWJJM52B/p1639478617050700