### PR TITLE
Fix errant capitalisation in DNS TXT response

### DIFF
--- a/dns_server.go
+++ b/dns_server.go
@@ -56,7 +56,7 @@ func (d *dnsRecords) QueryCert(data string) string {
 		return ""
 	}
 	cert := q.Details
-	c := fmt.Sprintf("\"Name: %s\" \"Ips: %s\" \"Subnets %s\" \"Groups %s\" \"NotBefore %s\" \"NotAFter %s\" \"PublicKey %x\" \"IsCA %t\" \"Issuer %s\"", cert.Name, cert.Ips, cert.Subnets, cert.Groups, cert.NotBefore, cert.NotAfter, cert.PublicKey, cert.IsCA, cert.Issuer)
+	c := fmt.Sprintf("\"Name: %s\" \"Ips: %s\" \"Subnets %s\" \"Groups %s\" \"NotBefore %s\" \"NotAfter %s\" \"PublicKey %x\" \"IsCA %t\" \"Issuer %s\"", cert.Name, cert.Ips, cert.Subnets, cert.Groups, cert.NotBefore, cert.NotAfter, cert.PublicKey, cert.IsCA, cert.Issuer)
 	return c
 }
 


### PR DESCRIPTION
The DNS TXT record response mislabels the cert expiry as `NotAFter`, instead of `NotAfter`,  I don't *think* this is intentional.

This patch could technically be a breaking change to peoples infrastructure.