### PR TITLE
Fix windows unsafe_routes regression

### DIFF
--- a/overlay/tun_windows.go
+++ b/overlay/tun_windows.go
@@ -19,10 +19,6 @@ func newTunFromFd(_ *logrus.Logger, _ int, _ *net.IPNet, _ int, _ []Route, _ int
 }
 
 func newTun(l *logrus.Logger, deviceName string, cidr *net.IPNet, defaultMTU int, routes []Route, _ int, _ bool) (Device, error) {
-	if len(routes) > 0 {
-		return nil, fmt.Errorf("route MTU not supported in Windows")
-	}
-
 	useWintun := true
 	if err := checkWinTunExists(); err != nil {
 		l.WithError(err).Warn("Check Wintun driver failed, fallback to wintap driver")


### PR DESCRIPTION
`routes` and `unsafeRoutes` were unified back in #581 which broke windows. A warning will be logged as intended with that PR.

https://github.com/slackhq/nebula/blob/b5b9d33ee753b510b316f15b503ecb11209fdf9b/overlay/route.go#L27

Closes #622 
Closes #647