### PR TITLE
Make nebula advertise its dynamic port to lighthouses

### DIFF
--- a/lighthouse.go
+++ b/lighthouse.go
@@ -78,6 +78,15 @@ func NewLightHouseFromConfig(l *logrus.Logger, c *config.C, myVpnNet *net.IPNet,
 		return nil, util.NewContextualError("lighthouse.am_lighthouse enabled on node but no port number is set in config", nil, nil)
 	}
 
+	// If port is dynamic, discover it
+	if nebulaPort == 0 && pc != nil {
+		uPort, err := pc.LocalAddr()
+		if err != nil {
+			return nil, util.NewContextualError("Failed to get listening port", nil, err)
+		}
+		nebulaPort = uint32(uPort.Port)
+	}
+
 	ones, _ := myVpnNet.Mask.Size()
 	h := LightHouse{
 		amLighthouse:      amLighthouse,

--- a/main.go
+++ b/main.go
@@ -158,15 +158,6 @@ func Main(c *config.C, configTest bool, buildVersion string, logger *logrus.Logg
 			}
 			udpServer.ReloadConfig(c)
 			udpConns[i] = udpServer
-
-			// If port is dynamic, discover it
-			if port == 0 {
-				uPort, err := udpServer.LocalAddr()
-				if err != nil {
-					return nil, util.NewContextualError("Failed to get listening port", nil, err)
-				}
-				port = int(uPort.Port)
-			}
 		}
 	}
 


### PR DESCRIPTION
Nebula is advertising port '0' to the lighthouse, when configured to dynamically choose a port.

This PR moves the dynamic port discovery code into NewLighthouseFromConfig, to fix the issue.