### PR TITLE
Typo in README.md: ca.cert -> ca.crt

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Nebula lighthouses allow nodes to find each other, anywhere in the world. A ligh
   ```
   ./nebula-cert ca -name "Myorganization, Inc"
   ```
-  This will create files named `ca.key` and `ca.cert` in the current directory. The `ca.key` file is the most sensitive file you'll create, because it is the key used to sign the certificates for individual nebula nodes/hosts. Please store this file somewhere safe, preferably with strong encryption.
+  This will create files named `ca.key` and `ca.crt` in the current directory. The `ca.key` file is the most sensitive file you'll create, because it is the key used to sign the certificates for individual nebula nodes/hosts. Please store this file somewhere safe, preferably with strong encryption.
 
 #### 4. Nebula host keys and certificates generated from that certificate authority
 This assumes you have four nodes, named lighthouse1, laptop, server1, host3. You can name the nodes any way you'd like, including FQDN. You'll also need to choose IP addresses and the associated subnet. In this example, we are creating a nebula network that will use 192.168.100.x/24 as its network range. This example also demonstrates nebula groups, which can later be used to define traffic rules in a nebula network.


### PR DESCRIPTION
I noticed that one of the generated file names is not what the README describes. It is off by one character.