### PR TITLE
fix panic in handleInvalidCertificate

### DIFF
--- a/connection_manager.go
+++ b/connection_manager.go
@@ -286,6 +286,10 @@ func (n *connectionManager) handleInvalidCertificate(now time.Time, vpnIp iputil
 		return false
 	}
 
+	if hostinfo == nil {
+		return false
+	}
+
 	remoteCert := hostinfo.GetCert()
 	if remoteCert == nil {
 		return false

--- a/connection_manager.go
+++ b/connection_manager.go
@@ -230,12 +230,9 @@ func (n *connectionManager) HandleDeletionTick(now time.Time) {
 		hostinfo, err := n.hostMap.QueryVpnIp(vpnIp)
 		if err != nil {
 			n.l.Debugf("Not found in hostmap: %s", vpnIp)
-
-			if !n.intf.disconnectInvalid {
-				n.ClearIP(vpnIp)
-				n.ClearPendingDeletion(vpnIp)
-				continue
-			}
+			n.ClearIP(vpnIp)
+			n.ClearPendingDeletion(vpnIp)
+			continue
 		}
 
 		if n.handleInvalidCertificate(now, vpnIp, hostinfo) {
@@ -283,10 +280,6 @@ func (n *connectionManager) HandleDeletionTick(now time.Time) {
 // handleInvalidCertificates will destroy a tunnel if pki.disconnect_invalid is true and the certificate is no longer valid
 func (n *connectionManager) handleInvalidCertificate(now time.Time, vpnIp iputil.VpnIp, hostinfo *HostInfo) bool {
 	if !n.intf.disconnectInvalid {
-		return false
-	}
-
-	if hostinfo == nil {
 		return false
 	}
 


### PR DESCRIPTION
When HandleMonitorTick fires, the hostmap can be nil which causes a panic to occur when trying to clean up the hostmap in handleInvalidCertificate. This fix just stops the invalidation from continuing if the hostmap doesn't exist.