### PR TITLE
Add TimerWheel fuzz test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
 	github.com/stretchr/testify v1.8.1
+	github.com/thepudds/fzgen v0.4.2
 	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/crypto v0.3.0
 	golang.org/x/net v0.2.0
@@ -39,6 +40,7 @@ require (
 	github.com/prometheus/client_model v0.3.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
+	github.com/sanity-io/litter v1.5.1 // indirect
 	github.com/vishvananda/netns v0.0.1 // indirect
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/term v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,7 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cyberdelia/go-metrics-graphite v0.0.0-20161219230853-39f87cc3b432 h1:M5QgkYacWj0Xs8MhpIK/5uwU02icXpEoSo9sM2aRCps=
 github.com/cyberdelia/go-metrics-graphite v0.0.0-20161219230853-39f87cc3b432/go.mod h1:xwIwAxMvYnVrGJPe2FKx5prTrnAjGOD8zvDOnxnrrkM=
+github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -180,6 +181,7 @@ github.com/nbrownus/go-metrics-prometheus v0.0.0-20210712211119-974a6260965f/go.
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -211,6 +213,8 @@ github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0ua
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/sanity-io/litter v1.5.1 h1:dwnrSypP6q56o3lFxTU+t2fwQ9A+U5qrXVO4Qg9KwVU=
+github.com/sanity-io/litter v1.5.1/go.mod h1:5Z71SvaYy5kcGtyglXOC9rrUi3c1E8CamFWjQsazTh0=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
@@ -224,6 +228,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v0.0.0-20161117074351-18a02ba4a312/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -232,6 +237,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/thepudds/fzgen v0.4.2 h1:HlEHl5hk2/cqEomf2uK5SA/FeJc12s/vIHmOG+FbACw=
+github.com/thepudds/fzgen v0.4.2/go.mod h1:kHCWdsv5tdnt32NIHYDdgq083m6bMtaY0M+ipiO9xWE=
 github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=

--- a/testdata/fuzz/Fuzz_TimerWheel_NewTimerWheel/582528ddfad69eb57775199a43e0f9fd5c94bba343ce7bb6724d4ebafe311ed4
+++ b/testdata/fuzz/Fuzz_TimerWheel_NewTimerWheel/582528ddfad69eb57775199a43e0f9fd5c94bba343ce7bb6724d4ebafe311ed4
@@ -1,0 +1,2 @@
+go test fuzz v1
+[]byte("0")

--- a/testdata/fuzz/Fuzz_TimerWheel_NewTimerWheel/582528ddfad69eb57775199a43e0f9fd5c94bba343ce7bb6724d4ebafe311ed4
+++ b/testdata/fuzz/Fuzz_TimerWheel_NewTimerWheel/582528ddfad69eb57775199a43e0f9fd5c94bba343ce7bb6724d4ebafe311ed4
@@ -1,2 +1,0 @@
-go test fuzz v1
-[]byte("0")

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -42,10 +42,8 @@ func Fuzz_TimerWheel_NewTimerWheel(f *testing.F) {
 			t.Skip("We expect min and max to be positive durations")
 		}
 
-		fuzzingMax := time.Second * 5
 		wLen := int((max / min) + 2)
-		t.Log(wLen)
-		if max > fuzzingMax || wLen > int(fuzzingMax) {
+		if max > time.Second*5 || wLen > 50_000_000 {
 			t.Skip("Long time durations are not amenable to fuzzing")
 		}
 

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -219,6 +219,19 @@ func Fuzz_TimerWheel_Purge(f *testing.F) {
 		fz := fuzzer.NewFuzzer(data)
 		fz.Fill(&min, &max)
 
+		if min == 0 || max == 0 {
+			t.Skip("We don't expect to handle a divide by zero")
+		}
+
+		if min < 0 || max < 0 {
+			t.Skip("We expect min and max to be positive durations")
+		}
+
+		wLen := int((max / min) + 2)
+		if max > time.Second*5 || wLen > 50_000_000 {
+			t.Skip("Long time durations are not amenable to fuzzing")
+		}
+
 		tw := NewTimerWheel(min, max)
 		tw.Purge()
 	})

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -47,8 +47,6 @@ func Fuzz_TimerWheel_NewTimerWheel(f *testing.F) {
 			t.Skip("Long time durations are not amenable to fuzzing")
 		}
 
-		t.Logf("min: %v\nmax: %v", min, max)
-
 		NewTimerWheel(min, max)
 	})
 }
@@ -129,6 +127,19 @@ func Fuzz_TimerWheel_Add(f *testing.F) {
 		var timeout time.Duration
 		fz := fuzzer.NewFuzzer(data)
 		fz.Fill(&min, &max, &v, &timeout)
+
+		if min == 0 || max == 0 {
+			t.Skip("We don't expect to handle a divide by zero")
+		}
+
+		if min < 0 || max < 0 {
+			t.Skip("We expect min and max to be positive durations")
+		}
+
+		wLen := int((max / min) + 2)
+		if max > time.Second*5 || wLen > 50_000_000 {
+			t.Skip("Long time durations are not amenable to fuzzing")
+		}
 
 		tw := NewTimerWheel(min, max)
 		tw.Add(v, timeout)

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/slackhq/nebula/firewall"
 	"github.com/stretchr/testify/assert"
+	"github.com/thepudds/fzgen/fuzzer"
 )
 
 func TestNewTimerWheel(t *testing.T) {
@@ -24,6 +25,17 @@ func TestNewTimerWheel(t *testing.T) {
 
 	tw = NewTimerWheel(time.Second*120, time.Minute*10)
 	assert.Equal(t, 7, tw.wheelLen)
+}
+
+func Fuzz_TimerWheel_NewTimerWheel(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var min time.Duration
+		var max time.Duration
+		fz := fuzzer.NewFuzzer(data)
+		fz.Fill(&min, &max)
+
+		NewTimerWheel(min, max)
+	})
 }
 
 func TestTimerWheel_findWheel(t *testing.T) {
@@ -94,6 +106,20 @@ func TestTimerWheel_Add(t *testing.T) {
 	}
 }
 
+func Fuzz_TimerWheel_Add(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var min time.Duration
+		var max time.Duration
+		var v firewall.Packet
+		var timeout time.Duration
+		fz := fuzzer.NewFuzzer(data)
+		fz.Fill(&min, &max, &v, &timeout)
+
+		tw := NewTimerWheel(min, max)
+		tw.Add(v, timeout)
+	})
+}
+
 func TestTimerWheel_Purge(t *testing.T) {
 	// First advance should set the lastTick and do nothing else
 	tw := NewTimerWheel(time.Second, time.Second*10)
@@ -158,4 +184,16 @@ func TestTimerWheel_Purge(t *testing.T) {
 	ta = ta.Add(time.Second * 1)
 	tw.advance(ta)
 	assert.Equal(t, 0, tw.current)
+}
+
+func Fuzz_TimerWheel_Purge(f *testing.F) {
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var min time.Duration
+		var max time.Duration
+		fz := fuzzer.NewFuzzer(data)
+		fz.Fill(&min, &max)
+
+		tw := NewTimerWheel(min, max)
+		tw.Purge()
+	})
 }

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -34,6 +34,10 @@ func Fuzz_TimerWheel_NewTimerWheel(f *testing.F) {
 		fz := fuzzer.NewFuzzer(data)
 		fz.Fill(&min, &max)
 
+		if min == 0 && max == 0 {
+			t.Skip("We don't expect to handle a divide by zero")
+		}
+
 		NewTimerWheel(min, max)
 	})
 }

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -34,9 +34,22 @@ func Fuzz_TimerWheel_NewTimerWheel(f *testing.F) {
 		fz := fuzzer.NewFuzzer(data)
 		fz.Fill(&min, &max)
 
-		if min == 0 && max == 0 {
+		if min == 0 || max == 0 {
 			t.Skip("We don't expect to handle a divide by zero")
 		}
+
+		if min < 0 || max < 0 {
+			t.Skip("We expect min and max to be positive durations")
+		}
+
+		fuzzingMax := time.Second * 5
+		wLen := int((max / min) + 2)
+		t.Log(wLen)
+		if max > fuzzingMax || wLen > int(fuzzingMax) {
+			t.Skip("Long time durations are not amenable to fuzzing")
+		}
+
+		t.Logf("min: %v\nmax: %v", min, max)
 
 		NewTimerWheel(min, max)
 	})


### PR DESCRIPTION
This was done using https://github.com/thepudds/fzgen using `fzgen slackhq/nebula` in a separate repo; It seems that I could have done so locally in a branch though?

Run tests via

```shell
go test . -fuzz=Fuzz_TimerWheel_NewTimerWheel
```

```shell
go test . -fuzz=Fuzz_TimerWheel_Add
```

```shell
go test . -fuzz=Fuzz_TimerWheel_Purge
```

```shell
go test . -fuzz=Fuzz_TimerWheel_Chain -race
```

This skips inputs that cause NewTimerWheel to throw or hang, such as `NewTimerWheel(0,0)` or numbers that make `wLen` unreasonably large.
