### PR TITLE
Enforce a minimum golang version with a nice error message.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-GOMINVERSION = 1.18
 NEBULA_CMD_PATH = "./cmd/nebula"
 GO111MODULE = on
 export GO111MODULE
@@ -7,14 +6,9 @@ export CGO_ENABLED
 
 # Set up OS specific bits
 ifeq ($(OS),Windows_NT)
-	#TODO: we should be able to ditch awk as well
-	GOVERSION := $(shell go version | awk "{print substr($$3, 3)}")
-	GOISMIN := $(shell IF "$(GOVERSION)" GEQ "$(GOMINVERSION)" ECHO 1)
 	NEBULA_CMD_SUFFIX = .exe
 	NULL_FILE = nul
 else
-	GOVERSION := $(shell go version | awk '{print substr($$3, 3)}')
-	GOISMIN := $(shell expr "$(GOVERSION)" ">=" "$(GOMINVERSION)")
 	NEBULA_CMD_SUFFIX =
 	NULL_FILE = /dev/null
 endif

--- a/minimum_go.go
+++ b/minimum_go.go
@@ -1,0 +1,8 @@
+//go:build !go1.18
+// +build !go1.18
+
+package nebula
+
+func init() {
+	"You need Go 1.18 or newer to compile Nebula"
+}


### PR DESCRIPTION
Only works for major versions.