### PR TITLE
Add nebula-cert.exe and cert files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@
 **.key
 **.pem
 !/examples/quickstart-vagrant/ansible/roles/nebula/files/vagrant-test-ca.key
-$/examples/quickstart-vagrant/ansible/roles/nebula/files/vagrant-test-ca.crt
+!/examples/quickstart-vagrant/ansible/roles/nebula/files/vagrant-test-ca.crt

--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,12 @@
 /nebula-arm6
 /nebula-darwin
 /nebula.exe
-/cert/*.crt
-/cert/*.key
+/nebula-cert.exe
 /coverage.out
 /cpu.pprof
 /build
 /*.tar.gz
 /e2e/mermaid/
+**.crt
+**.key
+**.pem

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 **.crt
 **.key
 **.pem
+!/examples/quickstart-vagrant/ansible/roles/nebula/files/vagrant-test-ca.key
+$/examples/quickstart-vagrant/ansible/roles/nebula/files/vagrant-test-ca.crt


### PR DESCRIPTION
I'm not sure what, if anything, created `/cert/*.crt` and `/cert/*.key` but the `**` entries should help avoid accidental commits anywhere in the tree. (I find myself often creating test CAs, certs, etc.)

`make bin-windows` creates `nebula.exe` and `nebula-cert.exe` yet only the former previously appeared in the gitignore.