### PR TITLE
explicitly reload config from ssh command

### DIFF
--- a/main.go
+++ b/main.go
@@ -327,7 +327,7 @@ func Main(c *config.C, configTest bool, buildVersion string, logger *logrus.Logg
 	//TODO: check if we _should_ be emitting stats
 	go ifce.emitStats(ctx, c.GetDuration("stats.interval", time.Second*10))
 
-	attachCommands(l, ssh, hostMap, handshakeManager.pendingHostMap, lightHouse, ifce)
+	attachCommands(l, c, ssh, hostMap, handshakeManager.pendingHostMap, lightHouse, ifce)
 
 	// Start DNS server last to allow using the nebula IP as lighthouse.dns.host
 	var dnsStart func()

--- a/ssh.go
+++ b/ssh.go
@@ -877,6 +877,7 @@ func sshPrintTunnel(ifce *Interface, fs interface{}, a []string, w sshd.StringWr
 }
 
 func sshReload(c *config.C, w sshd.StringWriter) error {
+    err := w.WriteLine("Config reloaded")
     c.ReloadConfig()
-	return w.WriteLine("Config reloaded")
+	return err
 }

--- a/ssh.go
+++ b/ssh.go
@@ -877,7 +877,7 @@ func sshPrintTunnel(ifce *Interface, fs interface{}, a []string, w sshd.StringWr
 }
 
 func sshReload(c *config.C, w sshd.StringWriter) error {
-	err := w.WriteLine("Config reloaded")
+	err := w.WriteLine("Reloading config")
 	c.ReloadConfig()
 	return err
 }

--- a/ssh.go
+++ b/ssh.go
@@ -12,7 +12,6 @@ import (
 	"runtime/pprof"
 	"sort"
 	"strings"
-	"syscall"
 
 	"github.com/sirupsen/logrus"
 	"github.com/slackhq/nebula/config"
@@ -166,7 +165,7 @@ func configSSH(l *logrus.Logger, ssh *sshd.SSHServer, c *config.C) (func(), erro
 	return runner, nil
 }
 
-func attachCommands(l *logrus.Logger, ssh *sshd.SSHServer, hostMap *HostMap, pendingHostMap *HostMap, lightHouse *LightHouse, ifce *Interface) {
+func attachCommands(l *logrus.Logger, c *config.C, ssh *sshd.SSHServer, hostMap *HostMap, pendingHostMap *HostMap, lightHouse *LightHouse, ifce *Interface) {
 	ssh.RegisterCommand(&sshd.Command{
 		Name:             "list-hostmap",
 		ShortDescription: "List all known previously connected hosts",
@@ -215,7 +214,9 @@ func attachCommands(l *logrus.Logger, ssh *sshd.SSHServer, hostMap *HostMap, pen
 	ssh.RegisterCommand(&sshd.Command{
 		Name:             "reload",
 		ShortDescription: "Reloads configuration from disk, same as sending HUP to the process",
-		Callback:         sshReload,
+		Callback:         func (fs interface{}, a []string, w sshd.StringWriter) error {
+                            return sshReload(c, w)
+                        },
 	})
 
 	ssh.RegisterCommand(&sshd.Command{
@@ -875,16 +876,7 @@ func sshPrintTunnel(ifce *Interface, fs interface{}, a []string, w sshd.StringWr
 	return enc.Encode(copyHostInfo(hostInfo, ifce.hostMap.preferredRanges))
 }
 
-func sshReload(fs interface{}, a []string, w sshd.StringWriter) error {
-	p, err := os.FindProcess(os.Getpid())
-	if err != nil {
-		return w.WriteLine(err.Error())
-		//TODO
-	}
-	err = p.Signal(syscall.SIGHUP)
-	if err != nil {
-		return w.WriteLine(err.Error())
-		//TODO
-	}
-	return w.WriteLine("HUP sent")
+func sshReload(c *config.C, w sshd.StringWriter) error {
+    c.ReloadConfig()
+	return w.WriteLine("Config reloaded")
 }

--- a/ssh.go
+++ b/ssh.go
@@ -214,9 +214,9 @@ func attachCommands(l *logrus.Logger, c *config.C, ssh *sshd.SSHServer, hostMap 
 	ssh.RegisterCommand(&sshd.Command{
 		Name:             "reload",
 		ShortDescription: "Reloads configuration from disk, same as sending HUP to the process",
-		Callback:         func (fs interface{}, a []string, w sshd.StringWriter) error {
-                            return sshReload(c, w)
-                        },
+		Callback: func(fs interface{}, a []string, w sshd.StringWriter) error {
+			return sshReload(c, w)
+		},
 	})
 
 	ssh.RegisterCommand(&sshd.Command{
@@ -877,7 +877,7 @@ func sshPrintTunnel(ifce *Interface, fs interface{}, a []string, w sshd.StringWr
 }
 
 func sshReload(c *config.C, w sshd.StringWriter) error {
-    err := w.WriteLine("Config reloaded")
-    c.ReloadConfig()
+	err := w.WriteLine("Config reloaded")
+	c.ReloadConfig()
 	return err
 }


### PR DESCRIPTION
The `reload` command sends SIGHUP to the process to let it reload the config, but SIGHUP is not implemented in windows. Rather than indirectly reloading via SIGHUP, this PR explicitly invokes `c.ReloadConfig()` when the `reload` command is given in ssh.

Previous behavior on windows:
```
user@nebula > reload
not supported by windows
```
The new behavior immediately closes the ssh connection once `reload` is given because the sshd server closes, so the user never sees a message, which is probably ok but the ssh handler for `reload` could write a message back to the client just before calling `c.ReloadConfig()`

Resolves https://github.com/slackhq/nebula/issues/694