### PR TITLE
Dockerfile support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# The .dockerignore file excludes files from the container build process.
+#
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+
+# Exclude locally vendored dependencies.
+vendor/
+
+# Exclude "build-time" ignore files.
+.dockerignore
+.gcloudignore
+
+# Exclude git history and configuration.
+.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,7 @@ vendor/
 
 # Exclude git history and configuration.
 .gitignore
+
+# Ignore Dockerfile itself
+Dockerfile
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN make bin-docker
 
 FROM golang as runtime
 WORKDIR /config
-EXPOSE 4242
+EXPOSE 4242/udp
 COPY --from=builder /src/build/linux-amd64/nebula /app/
 
 VOLUME ["/config"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN make bin-docker
 FROM golang as runtime
 WORKDIR /app
 EXPOSE 4242
-COPY --from=builder /src/build/linux-amd64/nebula /src/build/linux-amd64/nebula /app/
+COPY --from=builder /src/build/linux-amd64/nebula /app/
 
 VOLUME ["/config"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang as builder
+WORKDIR /src
+COPY . .
+RUN make bin-docker
+
+FROM golang as runtime
+WORKDIR /app
+EXPOSE 4242
+COPY --from=builder /src/build/linux-amd64/nebula /src/build/linux-amd64/nebula /app/
+
+VOLUME ["/config"]
+
+ENTRYPOINT ["./nebula", "-config", "/config/config.yaml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,11 @@ COPY . .
 RUN make bin-docker
 
 FROM golang as runtime
-WORKDIR /app
+WORKDIR /config
 EXPOSE 4242
 COPY --from=builder /src/build/linux-amd64/nebula /app/
 
 VOLUME ["/config"]
 
-ENTRYPOINT ["./nebula", "-config", "/config/config.yaml"]
+ENTRYPOINT ["/app/nebula"]
+CMD ["-config", "config.yaml"]

--- a/README.md
+++ b/README.md
@@ -114,6 +114,24 @@ To build nebula for a specific platform (ex, Windows):
 
 See the [Makefile](Makefile) for more details on build targets
 
+## Docker
+### Building Nebula Docker image from source
+
+Ensure Docker is installed and clone this repo. Change to the nebula directory.
+
+To build nebula Docker image:
+```
+docker build -t nebula .
+```
+
+### Running
+
+To run nebula Docker image, ensure correct network permission is given and network is in **host** mode:
+```
+docker run -dt --name=nebula -v=/path/to/config/on/host:/config --cap-add=NET_ADMIN --network=host --device=/dev/net/tun --restart=unless-stopped <image>
+```
+Where **\<image\>** is either `nebula` if source built or image from provider like Dockerhub.
+
 ## Credits
 
 Nebula was created at Slack Technologies, Inc by Nate Brown and Ryan Huber, with contributions from Oliver Fross, Alan Lam, Wade Simmons, and Lining Wang.


### PR DESCRIPTION
Hey all!

I felt the need to add a **Dockerfile** (and **.dockerignore**) to this repo seeing as how I'd want to run this on a Docker container where it can persist and restart with the host machine. Personally, this makes it so much easier than downloading the binary and creating a system service whereas a simple container can be loaded on the go.

Do note that with this **Dockerfile**, `nebula-cert` is not included, though that can be changed within the `COPY` command. Also, this uses the latest tag of `golang` for building and runtime, just to note for later if a stable release tag needs to be used if any.

Also, it would be ideal if some automated Dockerhub image publishing happens so users don't have to clone this repo and build image locally but instead, use something like `docker pull slackhq/nebula`.

I recommend trying this on different platforms too (macOS and Windows) just to ensure this works and doesn't break anything.

Tried with nebula lighthouse node deployed on Ubuntu 22.04.1 LTS Docker with current example configuration and Windows client (1 lighthouse and one client on local network). 