### PR TITLE
Refuse to process underlay packets received from overlay ips

### DIFF
--- a/inside.go
+++ b/inside.go
@@ -86,8 +86,7 @@ func (f *Interface) Handshake(vpnIp iputil.VpnIp) {
 
 // getOrHandshake returns nil if the vpnIp is not routable
 func (f *Interface) getOrHandshake(vpnIp iputil.VpnIp) *HostInfo {
-	//TODO: we can find contains without converting back to bytes
-	if f.hostMap.vpnCIDR.Contains(vpnIp.ToIP()) == false {
+	if !ipMaskContains(f.lightHouse.myVpnIp, f.lightHouse.myVpnZeros, vpnIp) {
 		vpnIp = f.inside.RouteFor(vpnIp)
 		if vpnIp == 0 {
 			return nil

--- a/outside.go
+++ b/outside.go
@@ -34,6 +34,16 @@ func (f *Interface) readOutsidePackets(addr *udp.Addr, via interface{}, out []by
 	}
 
 	//l.Error("in packet ", header, packet[HeaderLen:])
+	if addr != nil {
+		if ip4 := addr.IP.To4(); ip4 != nil {
+			if ipMaskContains(f.lightHouse.myVpnIp, f.lightHouse.myVpnZeros, iputil.VpnIp(binary.BigEndian.Uint32(ip4))) {
+				if f.l.Level >= logrus.DebugLevel {
+					f.l.WithField("udpAddr", addr).Debug("Refusing to process double encrypted packet")
+				}
+				return
+			}
+		}
+	}
 
 	var hostinfo *HostInfo
 	// verify if we've seen this index before, otherwise respond to the handshake initiation


### PR DESCRIPTION
The intent of this change is to block the processing of packets that may have been sent over an unsafe route.

Host A is an unsafe router serving its local network 172.17.0.0/16 to remote nebula hosts.
Host B is on a remote network, has a nebula ip of 192.168.1.2, and uses 172.17.0.0/16 as an unsafe route.

If Host B uses a relay to connect to Host A OR has `preferred_ranges` set to include `172.17.0.0/16`, it will eventually try to roam the connection to that unsafe route. The result is the Host A receives a packet with a source ip on the nebula network, 192.168.1.2 in this case, which breaks the tunnel since now Host A believes Host B can be sent underlay traffic on the nebula ip and that isn't true.

This change also makes detecting and choosing an unsafe router faster on the overlay which washes out the added time on the underlay.