### PR TITLE
Make hostinfo remote atomic, for consistent data access synchronization.

### DIFF
--- a/control.go
+++ b/control.go
@@ -172,7 +172,7 @@ func (c *Control) CloseAllTunnels(excludeLighthouses bool) (closed int) {
 		c.f.send(header.CloseTunnel, 0, h.ConnectionState, h, []byte{}, make([]byte, 12, 12), make([]byte, mtu))
 		c.f.closeTunnel(h)
 
-		c.l.WithField("vpnIp", h.vpnIp).WithField("udpAddr", h.remote).
+		c.l.WithField("vpnIp", h.vpnIp).WithField("udpAddr", h.remote.Load()).
 			Debug("Sending close tunnel message")
 		closed++
 	}
@@ -225,8 +225,9 @@ func copyHostInfo(h *HostInfo, preferredRanges []*net.IPNet) ControlHostInfo {
 		chi.Cert = c.Copy()
 	}
 
-	if h.remote != nil {
-		chi.CurrentRemote = h.remote.Copy()
+	r := h.remote.Load()
+	if r != nil {
+		chi.CurrentRemote = r.Copy()
 	}
 
 	return chi

--- a/control_test.go
+++ b/control_test.go
@@ -50,8 +50,7 @@ func TestControl_GetHostInfoByVpnIp(t *testing.T) {
 	remotes := NewRemoteList()
 	remotes.unlockedPrependV4(0, NewIp4AndPort(remote1.IP, uint32(remote1.Port)))
 	remotes.unlockedPrependV6(0, NewIp6AndPort(remote2.IP, uint32(remote2.Port)))
-	hm.Add(iputil.Ip2VpnIp(ipNet.IP), &HostInfo{
-		remote:  remote1,
+	hi := &HostInfo{
 		remotes: remotes,
 		ConnectionState: &ConnectionState{
 			peerCert: crt,
@@ -64,10 +63,11 @@ func TestControl_GetHostInfoByVpnIp(t *testing.T) {
 			relayForByIp:  map[iputil.VpnIp]*Relay{},
 			relayForByIdx: map[uint32]*Relay{},
 		},
-	})
+	}
+	hi.remote.Store(remote1)
+	hm.Add(iputil.Ip2VpnIp(ipNet.IP), hi)
 
-	hm.Add(iputil.Ip2VpnIp(ipNet2.IP), &HostInfo{
-		remote:  remote1,
+	hi = &HostInfo{
 		remotes: remotes,
 		ConnectionState: &ConnectionState{
 			peerCert: nil,
@@ -80,7 +80,9 @@ func TestControl_GetHostInfoByVpnIp(t *testing.T) {
 			relayForByIp:  map[iputil.VpnIp]*Relay{},
 			relayForByIdx: map[uint32]*Relay{},
 		},
-	})
+	}
+	hi.remote.Store(remote1)
+	hm.Add(iputil.Ip2VpnIp(ipNet2.IP), hi)
 
 	c := Control{
 		f: &Interface{

--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -17,7 +17,7 @@ func ixHandshakeStage0(f *Interface, vpnIp iputil.VpnIp, hostinfo *HostInfo) {
 	// This queries the lighthouse if we don't know a remote for the host
 	// We do it here to provoke the lighthouse to preempt our timer wheel and trigger the stage 1 packet to send
 	// more quickly, effect is a quicker handshake.
-	if hostinfo.remote == nil {
+	if hostinfo.remote.Load() == nil {
 		f.lightHouse.QueryServer(vpnIp, f)
 	}
 

--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -194,7 +194,7 @@ func (c *HandshakeManager) handleOutbound(vpnIp iputil.VpnIp, f udp.EncWriter, l
 				continue
 			}
 			relayHostInfo, err := c.mainHostMap.QueryVpnIp(*relay)
-			if err != nil || relayHostInfo.remote == nil {
+			if err != nil || relayHostInfo.remote.Load() == nil {
 				hostinfo.logger(c.l).WithError(err).WithField("relay", relay.String()).Info("Establish tunnel to relay target.")
 				f.Handshake(*relay)
 				continue
@@ -231,7 +231,7 @@ func (c *HandshakeManager) handleOutbound(vpnIp iputil.VpnIp, f udp.EncWriter, l
 				}
 			} else {
 				// No relays exist or requested yet.
-				if relayHostInfo.remote != nil {
+				if relayHostInfo.remote.Load() != nil {
 					idx, err := AddRelay(c.l, relayHostInfo, c.mainHostMap, vpnIp, nil, TerminalType, Requested)
 					if err != nil {
 						hostinfo.logger(c.l).WithField("relay", relay.String()).WithError(err).Info("Failed to add relay to hostmap")

--- a/relay_manager.go
+++ b/relay_manager.go
@@ -217,7 +217,7 @@ func (rm *relayManager) handleCreateRelayRequest(h *HostInfo, f *Interface, m *N
 			f.getOrHandshake(target)
 			return
 		}
-		if peer.remote == nil {
+		if peer.remote.Load() == nil {
 			// Only create relays to peers for whom I have a direct connection
 			return
 		}


### PR DESCRIPTION
When working on [746](https://github.com/slackhq/nebula/pull/746) I noticed that there was inconsistent lock access to HostInfo.remote pointer.

Inspired by [728](https://github.com/slackhq/nebula/pull/728) this PR makes HostInfo.remote an atomicPointer.