### PR TITLE
Add template systemd service files

### DIFF
--- a/dist/arch/nebula.service
+++ b/dist/arch/nebula.service
@@ -4,8 +4,9 @@ Wants=basic.target network-online.target
 After=basic.target network.target network-online.target
 
 [Service]
+WorkingDirectory=/etc/nebula
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/bin/nebula -config /etc/nebula/config.yml
+ExecStart=/usr/bin/nebula -config config.yml
 Restart=always
 
 [Install]

--- a/dist/arch/nebula@.service
+++ b/dist/arch/nebula@.service
@@ -4,8 +4,9 @@ Wants=basic.target network-online.target
 After=basic.target network.target network-online.target
 
 [Service]
+WorkingDirectory=/etc/nebula/%i
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/bin/nebula -config /etc/nebula/%i/config.yml
+ExecStart=/usr/bin/nebula -config config.yml
 Restart=always
 
 [Install]

--- a/dist/arch/nebula@.service
+++ b/dist/arch/nebula@.service
@@ -1,11 +1,11 @@
 [Unit]
-Description=Nebula Mesh VPN
+Description=Nebula Mesh VPN for %I
 Wants=basic.target network-online.target
 After=basic.target network.target network-online.target
 
 [Service]
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/bin/nebula -config /etc/nebula/config.yml
+ExecStart=/usr/bin/nebula -config /etc/nebula/%i/config.yml
 Restart=always
 
 [Install]

--- a/dist/fedora/nebula.service
+++ b/dist/fedora/nebula.service
@@ -6,8 +6,9 @@ Before=sshd.service
 Wants=basic.target network-online.target
 
 [Service]
+WorkingDirectory=/etc/nebula
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/bin/nebula -config /etc/nebula/config.yml
+ExecStart=/usr/bin/nebula -config config.yml
 Restart=always
 
 [Install]

--- a/dist/fedora/nebula@.service
+++ b/dist/fedora/nebula@.service
@@ -6,8 +6,9 @@ Before=sshd.service
 Wants=basic.target network-online.target
 
 [Service]
+WorkingDirectory=/etc/nebula/%i
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/bin/nebula -config /etc/nebula/%i/config.yml
+ExecStart=/usr/bin/nebula -config config.yml
 Restart=always
 
 [Install]

--- a/dist/fedora/nebula@.service
+++ b/dist/fedora/nebula@.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Nebula overlay networking tool
+Description=Nebula overlay networking tool, for %I
 
 After=basic.target network.target network-online.target
 Before=sshd.service
@@ -7,7 +7,7 @@ Wants=basic.target network-online.target
 
 [Service]
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/bin/nebula -config /etc/nebula/config.yml
+ExecStart=/usr/bin/nebula -config /etc/nebula/%i/config.yml
 Restart=always
 
 [Install]

--- a/examples/quickstart-vagrant/ansible/roles/nebula/files/systemd.nebula.service
+++ b/examples/quickstart-vagrant/ansible/roles/nebula/files/systemd.nebula.service
@@ -4,8 +4,9 @@ Wants=basic.target
 After=basic.target network.target
 
 [Service]
+WorkingDirectory=/etc/nebula
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/local/bin/nebula -config /etc/nebula/config.yml
+ExecStart=/usr/local/bin/nebula -config config.yml
 Restart=always
 
 [Install]

--- a/examples/quickstart-vagrant/ansible/roles/nebula/files/systemd.nebula.service
+++ b/examples/quickstart-vagrant/ansible/roles/nebula/files/systemd.nebula.service
@@ -4,7 +4,6 @@ Wants=basic.target
 After=basic.target network.target
 
 [Service]
-SyslogIdentifier=nebula
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/local/bin/nebula -config /etc/nebula/config.yml
 Restart=always

--- a/examples/quickstart-vagrant/ansible/roles/nebula/files/systemd.nebula@.service
+++ b/examples/quickstart-vagrant/ansible/roles/nebula/files/systemd.nebula@.service
@@ -1,12 +1,11 @@
 [Unit]
-Description=Nebula Mesh VPN
+Description=Nebula Mesh VPN for %I
 Wants=basic.target
 After=basic.target network.target
-Before=sshd.service
 
 [Service]
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/local/bin/nebula -config /etc/nebula/config.yml
+ExecStart=/usr/local/bin/nebula -config /etc/nebula/%i/config.yml
 Restart=always
 
 [Install]

--- a/examples/quickstart-vagrant/ansible/roles/nebula/files/systemd.nebula@.service
+++ b/examples/quickstart-vagrant/ansible/roles/nebula/files/systemd.nebula@.service
@@ -4,8 +4,9 @@ Wants=basic.target
 After=basic.target network.target
 
 [Service]
+WorkingDirectory=/etc/nebula/%i
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/local/bin/nebula -config /etc/nebula/%i/config.yml
+ExecStart=/usr/local/bin/nebula -config config.yml
 Restart=always
 
 [Install]

--- a/examples/quickstart-vagrant/ansible/roles/nebula/tasks/main.yml
+++ b/examples/quickstart-vagrant/ansible/roles/nebula/tasks/main.yml
@@ -54,6 +54,10 @@
   register: addconf
   notify: restart nebula
 
+- name: nebula systemd (template)
+  copy: src=systemd.nebula@.service dest="/etc/systemd/system/nebula@.service" mode=0644 owner=root group=root
+  register: addconf
+
 - name: maybe reload systemd
   shell: systemctl daemon-reload
   when: addconf.changed

--- a/examples/service_scripts/nebula.service
+++ b/examples/service_scripts/nebula.service
@@ -5,8 +5,9 @@ After=basic.target network.target
 Before=sshd.service
 
 [Service]
+WorkingDirectory=/etc/nebula
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/local/bin/nebula -config /etc/nebula/config.yml
+ExecStart=/usr/local/bin/nebula -config config.yml
 Restart=always
 
 [Install]

--- a/examples/service_scripts/nebula@.service
+++ b/examples/service_scripts/nebula@.service
@@ -1,12 +1,12 @@
 [Unit]
-Description=Nebula Mesh VPN
+Description=Nebula Mesh VPN for %I
 Wants=basic.target
 After=basic.target network.target
 Before=sshd.service
 
 [Service]
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/local/bin/nebula -config /etc/nebula/config.yml
+ExecStart=/usr/local/bin/nebula -config /etc/nebula/%i/config.yml
 Restart=always
 
 [Install]

--- a/examples/service_scripts/nebula@.service
+++ b/examples/service_scripts/nebula@.service
@@ -5,8 +5,9 @@ After=basic.target network.target
 Before=sshd.service
 
 [Service]
+WorkingDirectory=/etc/nebula/%i
 ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/local/bin/nebula -config /etc/nebula/%i/config.yml
+ExecStart=/usr/local/bin/nebula -config config.yml
 Restart=always
 
 [Install]


### PR DESCRIPTION
These allow hosts to easily join multiple different Nebula networks.

Also, I have removed the `SyslogIdentifier=nebula` option, it's unnecessary because the logs already get tagged `nebula` by default.