### PR TITLE
Docs: Update doc links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: 📘 Documentation
-    url: https://www.defined.net/nebula/
+    url: https://docs.defined.net/nebula/
     about: Review documentation.
 
   - name: 💁 Support/Chat

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: 📘 Documentation
-    url: https://docs.defined.net/nebula/
+    url: https://nebula.defined.net/docs/
     about: Review documentation.
 
   - name: 💁 Support/Chat

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and tunneling, and each of those individual pieces existed before Nebula in vari
 What makes Nebula different to existing offerings is that it brings all of these ideas together,
 resulting in a sum that is greater than its individual parts.
 
-Further documentation can be found [here](https://www.defined.net/nebula/).
+Further documentation can be found [here](https://docs.defined.net/nebula/).
 
 You can read more about Nebula [here](https://medium.com/p/884110a5579).
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and tunneling, and each of those individual pieces existed before Nebula in vari
 What makes Nebula different to existing offerings is that it brings all of these ideas together,
 resulting in a sum that is greater than its individual parts.
 
-Further documentation can be found [here](https://docs.defined.net/nebula/).
+Further documentation can be found [here](https://nebula.defined.net/docs/).
 
 You can read more about Nebula [here](https://medium.com/p/884110a5579).
 


### PR DESCRIPTION
We've created a nebula-specific documentation page at https://docs.defined.net/nebula/, and have improved the config reference docs.  This change links to the new site from the README and the issue template.