### PR TITLE
Use config.yml consistently (not config.yaml)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,13 @@ Download a copy of the nebula [example configuration](https://github.com/slackhq
 
 #### 6. Copy nebula credentials, configuration, and binaries to each host
 
-For each host, copy the nebula binary to the host, along with `config.yaml` from step 5, and the files `ca.crt`, `{host}.crt`, and `{host}.key` from step 4.
+For each host, copy the nebula binary to the host, along with `config.yml` from step 5, and the files `ca.crt`, `{host}.crt`, and `{host}.key` from step 4.
 
 **DO NOT COPY `ca.key` TO INDIVIDUAL NODES.**
 
 #### 7. Run nebula on each host
 ```
-./nebula -config /path/to/config.yaml
+./nebula -config /path/to/config.yml
 ```
 
 ## Building Nebula from source

--- a/cmd/nebula-service/service.go
+++ b/cmd/nebula-service/service.go
@@ -55,7 +55,7 @@ func doService(configPath *string, configTest *bool, build string, serviceFlag *
 		if err != nil {
 			panic(err)
 		}
-		*configPath = filepath.Dir(ex) + "/config.yaml"
+		*configPath = filepath.Dir(ex) + "/config.yml"
 	}
 
 	svcConfig := &service.Config{


### PR DESCRIPTION
The inconsistency between the actual filename and the instructions tripped me up - it seems that _nearly_ everywhere uses `yml` rather than `yaml`, let's make it consistent :)