### PR TITLE
Docs: Added instructions for storing your CA private key encrypted at rest with GPG

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ Nebula lighthouses allow nodes to find each other, anywhere in the world. A ligh
   ```
   This will create files named `ca.key` and `ca.cert` in the current directory. The `ca.key` file is the most sensitive file you'll create, because it is the key used to sign the certificates for individual nebula nodes/hosts. Please store this file somewhere safe, preferably with strong encryption.
 
+
+##### Optional - Storing your certificate authority key as a GPG encrypted file
+A simple way to keep your CA key safe and encrypted at rest is to store it as a GPG encrypted file and pipe the decrypted contents to `nebula-cert` at runtime via standard input. This avoids keeping your certificate authority private key from being stored in a readable plaintext format when not in use.
+
+Creating a new GPG key is outside the scope of this quickstart guide, but a good introductory guide to GPG can be found [here](https://help.ubuntu.com/community/GnuPrivacyGuardHowto). Assuming you have a GPG key set up already, you can encrypt your `ca.key` file to create an encrypted version `ca.key.asc`:
+```
+gpg --encrypt --armor -r yourgpgkey@example.com ca.key
+```
+
+You can then delete your plaintext `ca.key` and perform any signing operations directly from your encrypted `ca.key.asc` using the following command:
+```
+gpg -d ca.key.asc | nebula-cert sign -ca-key /dev/stdin [the rest of your signing command]
+```
+
+
 #### 4. Nebula host keys and certificates generated from that certificate authority
 This assumes you have four nodes, named lighthouse1, laptop, server1, host3. You can name the nodes any way you'd like, including FQDN. You'll also need to choose IP addresses and the associated subnet. In this example, we are creating a nebula network that will use 192.168.100.x/24 as its network range. This example also demonstrates nebula groups, which can later be used to define traffic rules in a nebula network.
 ```

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Nebula lighthouses allow nodes to find each other, anywhere in the world. A ligh
 
 
 ##### Optional - Storing your certificate authority key as a GPG encrypted file
-A simple way to keep your CA key safe and encrypted at rest is to store it as a GPG encrypted file and pipe the decrypted contents to `nebula-cert` at runtime via standard input. This avoids keeping your certificate authority private key from being stored in a readable plaintext format when not in use.
+A simple way to keep your CA key safe and encrypted at rest is to store it as a GPG encrypted file and pipe the decrypted contents to `nebula-cert` at runtime via standard input. This keeps your certificate authority private key from being stored in a readable cleartext format when not in use.
 
 Creating a new GPG key is outside the scope of this quickstart guide, but a good introductory guide to GPG can be found [here](https://help.ubuntu.com/community/GnuPrivacyGuardHowto). Assuming you have a GPG key set up already, you can encrypt your `ca.key` file to create an encrypted version `ca.key.asc`:
 ```


### PR DESCRIPTION
Storing a CA private key in plaintext is a terribly risky and unsafe practice. The existing documentation makes a mild suggestion to encrypt your CA private key, but does not provide any recommendations for a streamlined way to do so.

We can use GPG to store `ca.key` as an encrypted file that stays encrypted on disk at all times and only gets decrypted in memory at the time a signing operation is performed, which is a much safer way for an end user to maintain such a sensitive file.

This document update explains the command syntax for how to encrypt your `ca.key` with an existing gpg key and how to easily interface the encrypted key with `nebula-cert` for signing operations without having to write the decrypted file to disk.