### PR TITLE
Fix a hang when shutting down Android

### DIFF
--- a/overlay/tun_android.go
+++ b/overlay/tun_android.go
@@ -28,11 +28,13 @@ func newTunFromFd(l *logrus.Logger, deviceFd int, cidr *net.IPNet, _ int, routes
 		return nil, err
 	}
 
+	// XXX Android returns an fd in non-blocking mode which is necessary for shutdown to work properly.
+	// Be sure not to call file.Fd() as it will set the fd to blocking mode.
 	file := os.NewFile(uintptr(deviceFd), "/dev/net/tun")
 
 	return &tun{
 		ReadWriteCloser: file,
-		fd:              int(file.Fd()),
+		fd:              deviceFd,
 		cidr:            cidr,
 		l:               l,
 		routeTree:       routeTree,


### PR DESCRIPTION
This fixes a hang in Android when shutting down the VPN process.

Per #771 we observed that the Read() call in Interface.listenIn() was blocking even after we called Close() on the underlying file descriptor. This was confusing because the fd was returned to us by the Android system in non-blocking mode and we were able to see that this was true by checking the fd prior to returning in newTunFromFd.

However, the return statement calls `file.Fd()` right after I confirmed that it was in non-blocking mode. @nbrownus discovered that this call has a side effect of setting the fd to blocking mode: https://github.com/golang/go/issues/29277

After removing this call and leaving it in non-blocking mode the shutdown behavior appears to be working correctly.