### PR TITLE
emit certificate.expiration_ttl_seconds metric

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -380,7 +380,7 @@ func (f *Interface) emitStats(ctx context.Context, i time.Duration) {
 
 	udpStats := udp.NewUDPStatsEmitter(f.writers)
 
-	certExpirationGauge := metrics.GetOrRegisterGauge("certificate.expiration_ttl_seconds", nil)
+	certExpirationGauge := metrics.GetOrRegisterGauge("certificate.ttl_seconds", nil)
 
 	for {
 		select {
@@ -390,7 +390,7 @@ func (f *Interface) emitStats(ctx context.Context, i time.Duration) {
 			f.firewall.EmitStats()
 			f.handshakeManager.EmitStats()
 			udpStats()
-			certExpirationGauge.Update(int64(f.certState.certificate.Details.NotAfter.Sub(time.Now()) / time.Second))
+			certExpirationGauge.Update(int64(f.certState.Load().certificate.Details.NotAfter.Sub(time.Now()) / time.Second))
 		}
 	}
 }

--- a/interface.go
+++ b/interface.go
@@ -380,6 +380,8 @@ func (f *Interface) emitStats(ctx context.Context, i time.Duration) {
 
 	udpStats := udp.NewUDPStatsEmitter(f.writers)
 
+	certExpirationGauge := metrics.GetOrRegisterGauge("certificate.expiration_ttl_seconds", nil)
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -388,6 +390,7 @@ func (f *Interface) emitStats(ctx context.Context, i time.Duration) {
 			f.firewall.EmitStats()
 			f.handshakeManager.EmitStats()
 			udpStats()
+			certExpirationGauge.Update(int64(f.certState.certificate.Details.NotAfter.Sub(time.Now()) / time.Second))
 		}
 	}
 }


### PR DESCRIPTION
This change emits a gauge metric indicating how much time until the certificate expires. The value will go negative once the certificate has expired.

I welcome feedback on the metric name, perhaps `certificate.expiration_seconds` would be better?