### PR TITLE
Update config to show aes cipher instead of chacha

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -133,7 +133,7 @@ punchy:
 
 # Cipher allows you to choose between the available ciphers for your network. Options are chachapoly or aes
 # IMPORTANT: this value must be identical on ALL NODES/LIGHTHOUSES. We do not/will not support use of different ciphers simultaneously!
-#cipher: chachapoly
+#cipher: aes
 
 # Preferred ranges is used to define a hint about the local network ranges, which speeds up discovering the fastest
 # path to a network adjacent nebula node.


### PR DESCRIPTION
Fixes #777.

I think aes is the better recommendation anyway given AES hardware acceleration in most devices.