### PR TITLE
Add nss-lookup to the systemd Wants targets

### DIFF
--- a/dist/arch/nebula.service
+++ b/dist/arch/nebula.service
@@ -1,6 +1,6 @@
 [Unit]
-Description=nebula
-Wants=basic.target network-online.target
+Description=Nebula overlay networking tool
+Wants=basic.target network-online.target nss-lookup.target
 After=basic.target network.target network-online.target
 
 [Service]

--- a/dist/fedora/nebula.service
+++ b/dist/fedora/nebula.service
@@ -1,15 +1,14 @@
 [Unit]
 Description=Nebula overlay networking tool
-
+Wants=basic.target network-online.target nss-lookup.target
 After=basic.target network.target network-online.target
 Before=sshd.service
-Wants=basic.target network-online.target
 
 [Service]
+SyslogIdentifier=nebula
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/bin/nebula -config /etc/nebula/config.yml
 Restart=always
-SyslogIdentifier=nebula
 
 [Install]
 WantedBy=multi-user.target

--- a/examples/quickstart-vagrant/ansible/roles/nebula/files/systemd.nebula.service
+++ b/examples/quickstart-vagrant/ansible/roles/nebula/files/systemd.nebula.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=nebula
-Wants=basic.target
+Wants=basic.target nss-lookup.target
 After=basic.target network.target
 
 [Service]

--- a/examples/service_scripts/nebula.service
+++ b/examples/service_scripts/nebula.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=nebula
-Wants=basic.target
+Wants=basic.target nss-lookup.target
 After=basic.target network.target
 Before=sshd.service
 


### PR DESCRIPTION
This builds on #791 but hits two more `.service` files in the repository. Thanks @Fale!

I did notice that there are some other differences in these files:
- example and ansible scripts do not reference `network-online.target`, unlike Arch and Fedora.
- Arch and ansible do not have a `Before=sshd.target`, Fedora and example do.