### PR TITLE
Immediately forward packets from self to self on FreeBSD

### DIFF
--- a/inside.go
+++ b/inside.go
@@ -25,8 +25,9 @@ func (f *Interface) consumeInsidePacket(packet []byte, fwPacket *firewall.Packet
 
 	if fwPacket.RemoteIP == f.myVpnIp {
 		// Immediately forward packets from self to self.
-		// This should only happen on Darwin-based hosts, which routes packets from
-		// the Nebula IP to the Nebula IP through the Nebula TUN device.
+		// This should only happen on Darwin-based and FreeBSD hosts, which
+		// routes packets from the Nebula IP to the Nebula IP through the Nebula
+		// TUN device.
 		if immediatelyForwardToSelf {
 			_, err := f.readers[q].Write(packet)
 			if err != nil {

--- a/inside_bsd.go
+++ b/inside_bsd.go
@@ -1,0 +1,6 @@
+//go:build darwin || dragonfly || freebsd || netbsd || openbsd
+// +build darwin dragonfly freebsd netbsd openbsd
+
+package nebula
+
+const immediatelyForwardToSelf bool = true

--- a/inside_darwin.go
+++ b/inside_darwin.go
@@ -1,3 +1,0 @@
-package nebula
-
-const immediatelyForwardToSelf bool = true

--- a/inside_freebsd.go
+++ b/inside_freebsd.go
@@ -1,3 +1,0 @@
-package nebula
-
-const immediatelyForwardToSelf bool = true

--- a/inside_freebsd.go
+++ b/inside_freebsd.go
@@ -1,0 +1,3 @@
+package nebula
+
+const immediatelyForwardToSelf bool = true

--- a/inside_generic.go
+++ b/inside_generic.go
@@ -1,5 +1,5 @@
-//go:build !darwin && !freebsd
-// +build !darwin,!freebsd
+//go:build !darwin && !dragonfly && !freebsd && !netbsd && !openbsd
+// +build !darwin,!dragonfly,!freebsd,!netbsd,!openbsd
 
 package nebula
 

--- a/inside_generic.go
+++ b/inside_generic.go
@@ -1,5 +1,5 @@
-//go:build !darwin
-// +build !darwin
+//go:build !darwin && !freebsd
+// +build !darwin,!freebsd
 
 package nebula
 


### PR DESCRIPTION
Fixes #493. This is borrowing the fix from #501 which was originally scoped to use this behavior for all OSes. During review, it was scoped down to just macOS which was known to be affected. Lacking support for FreeBSD at the time was an oversight.

There may be other OSes which are affected by this bug, but we will wait until we get reports to patch them.