### PR TITLE
log network as String to match the other log event that emits network

### DIFF
--- a/main.go
+++ b/main.go
@@ -202,7 +202,10 @@ func Main(c *config.C, configTest bool, buildVersion string, logger *logrus.Logg
 	hostMap := NewHostMap(l, "main", tunCidr, preferredRanges)
 	hostMap.metricsEnabled = c.GetBool("stats.message_metrics", false)
 
-	l.WithField("network", hostMap.vpnCIDR).WithField("preferredRanges", hostMap.preferredRanges).Info("Main HostMap created")
+	l.
+		WithField("network", hostMap.vpnCIDR.String()).
+		WithField("preferredRanges", hostMap.preferredRanges).
+		Info("Main HostMap created")
 
 	/*
 		config.SetDefault("promoter.interval", 10)


### PR DESCRIPTION
Hi! Small change for consistency in structured logging. We have two log calls that emit a `network` field. Currently one of them is a String and the other one is the object itself (which gets encoded as a JSON object for JSON logging). This changes the latter call to emit a String.

Happy to go the other direction, too, if we think that's better, but I'll note that the structure of `Mask` in the resulting log entry is not super great (at least after logstash is done with it):

```json
{"IP": "10.219.11.104", "Mask": "/4AAAA=="}
```