### PR TITLE
Remove dead code and re-order transit from pending to main hostmap on stage 2

### DIFF
--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -384,8 +384,9 @@ func (c *HandshakeManager) Complete(hostinfo *HostInfo, f *Interface) *HostInfo 
 	}
 
 	existingHostInfo := c.mainHostMap.Hosts[hostinfo.vpnIp]
-	c.mainHostMap.unlockedAddHostInfo(hostinfo, f)
+	// We need to remove from the pending hostmap first to avoid undoing work when after to the main hostmap.
 	c.pendingHostMap.unlockedDeleteHostInfo(hostinfo)
+	c.mainHostMap.unlockedAddHostInfo(hostinfo, f)
 	return existingHostInfo
 }
 


### PR DESCRIPTION
@brad-defined and I found multiple hostinfos for a given vpn ip were unlinked inappropriately by the handshake manager.

As part of the spelunking to discover what was unlinking the hostinfos I tripped over some dead code.

Longer term I think we should pull pending hostmap entirely into handshake manager since their needs are quite different anymore. 