### PR TITLE
Listen ports for nodes behind NAT

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -106,6 +106,8 @@ lighthouse:
 
 # Port Nebula will be listening on. The default here is 4242. For a lighthouse node, the port should be defined,
 # however using port 0 will dynamically assign a port and is recommended for roaming nodes.
+# If you run several nodes on the same local network behind a NAT router, e.g., residential DSL or mobile broadband,
+# you must set different ports for each node or use port 0 for dynamic assignment.
 listen:
   # To listen on both any ipv4 and ipv6 use "[::]"
   host: 0.0.0.0


### PR DESCRIPTION
If nodes on the same local network behind NAT are set to the same listen port, the router might not be able to correctly route the response packets from the lighthouse and other nodes outside the local network back to the correct node.

As a result, nodes on the local network will suddenly stop being able to access the Nebula network, if more than one node generates traffic at the same time. The issue is quite "mysterious", as each node works individually and there is no error indication other than timeouts.

Recommend adding a note to the sample configuration to help prevent others spending hours on figuring out why a configuration copied from a working node would suddenly not work on another.