### PR TITLE
Add ability to skip installing unsafe routes on the os routing table

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -201,21 +201,24 @@ tun:
   tx_queue: 500
   # Default MTU for every packet, safe setting is (and the default) 1300 for internet based traffic
   mtu: 1300
+
   # Route based MTU overrides, you have known vpn ip paths that can support larger MTUs you can increase/decrease them here
   routes:
     #- mtu: 8800
     #  route: 10.0.0.0/16
+
   # Unsafe routes allows you to route traffic over nebula to non-nebula nodes
   # Unsafe routes should be avoided unless you have hosts/services that cannot run nebula
   # NOTE: The nebula certificate of the "via" node *MUST* have the "route" defined as a subnet in its certificate
-  # `mtu` will default to tun mtu if this option is not specified
-  # `metric` will default to 0 if this option is not specified
+  # `mtu`: will default to tun mtu if this option is not specified
+  # `metric`: will default to 0 if this option is not specified
+  # `install`: will default to true, controls whether this route is installed in the systems routing table.
   unsafe_routes:
     #- route: 172.16.1.0/24
     #  via: 192.168.100.99
     #  mtu: 1300
     #  metric: 100
-
+    #  install: true
 
 # TODO
 # Configure logging level

--- a/overlay/tun_darwin.go
+++ b/overlay/tun_darwin.go
@@ -287,7 +287,7 @@ func (t *tun) Activate() error {
 
 	// Unsafe path routes
 	for _, r := range t.Routes {
-		if r.Via == nil {
+		if r.Via == nil || !r.Install {
 			// We don't allow route MTUs so only install routes with a via
 			continue
 		}

--- a/overlay/tun_freebsd.go
+++ b/overlay/tun_freebsd.go
@@ -86,7 +86,7 @@ func (t *tun) Activate() error {
 	}
 	// Unsafe path routes
 	for _, r := range t.Routes {
-		if r.Via == nil {
+		if r.Via == nil || !r.Install {
 			// We don't allow route MTUs so only install routes with a via
 			continue
 		}

--- a/overlay/tun_linux.go
+++ b/overlay/tun_linux.go
@@ -279,6 +279,10 @@ func (t tun) Activate() error {
 
 	// Path routes
 	for _, r := range t.Routes {
+		if !r.Install {
+			continue
+		}
+
 		nr := netlink.Route{
 			LinkIndex: link.Attrs().Index,
 			Dst:       r.Cidr,

--- a/overlay/tun_water_windows.go
+++ b/overlay/tun_water_windows.go
@@ -80,7 +80,7 @@ func (t *waterTun) Activate() error {
 	}
 
 	for _, r := range t.Routes {
-		if r.Via == nil {
+		if r.Via == nil || !r.Install {
 			// We don't allow route MTUs so only install routes with a via
 			continue
 		}

--- a/overlay/tun_wintun_windows.go
+++ b/overlay/tun_wintun_windows.go
@@ -92,7 +92,7 @@ func (t *winTun) Activate() error {
 	routes := make([]*winipcfg.RouteData, 0, len(t.Routes)+1)
 
 	for _, r := range t.Routes {
-		if r.Via == nil {
+		if r.Via == nil || !r.Install {
 			// We don't allow route MTUs so only install routes with a via
 			continue
 		}


### PR DESCRIPTION
This allows informing nebula that it should handle a route but does not establish it on the os routing table. Helpful when doing a full 0.0.0.0/0 unsafe route.

Solves #810 