### PR TITLE
Use fewer test packets

### DIFF
--- a/connection_manager_test.go
+++ b/connection_manager_test.go
@@ -98,6 +98,7 @@ func Test_NewConnectionManagerTest(t *testing.T) {
 	assert.NotContains(t, nc.in, hostinfo.localIndexId)
 
 	// Do another traffic check tick, this host should be pending deletion now
+	nc.Out(hostinfo.localIndexId)
 	nc.doTrafficCheck(hostinfo.localIndexId, p, nb, out, time.Now())
 	assert.Contains(t, nc.pendingDeletion, hostinfo.localIndexId)
 	assert.NotContains(t, nc.out, hostinfo.localIndexId)
@@ -175,6 +176,7 @@ func Test_NewConnectionManagerTest2(t *testing.T) {
 	assert.NotContains(t, nc.in, hostinfo.localIndexId)
 
 	// Do another traffic check tick, this host should be pending deletion now
+	nc.Out(hostinfo.localIndexId)
 	nc.doTrafficCheck(hostinfo.localIndexId, p, nb, out, time.Now())
 	assert.Contains(t, nc.pendingDeletion, hostinfo.localIndexId)
 	assert.NotContains(t, nc.out, hostinfo.localIndexId)


### PR DESCRIPTION
Old connection manager would only track connections with outbound traffic, if there was no inbound then a test packet would be sent to ensure the tunnel was still viable.

This change matches the previous behavior as well as allow for non primary lighthouse tunnels to be torn down eventually