### PR TITLE
Fix handshake retry regression

### DIFF
--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -53,10 +53,6 @@ type HandshakeManager struct {
 	metricTimedOut         metrics.Counter
 	l                      *logrus.Logger
 
-	// vpnIps is another map similar to the pending hostmap but tracks entries in the wheel instead
-	// this is to avoid situations where the same vpn ip enters the wheel and causes rapid fire handshaking
-	vpnIps map[iputil.VpnIp]struct{}
-
 	// can be used to trigger outbound handshake for the given vpnIp
 	trigger chan iputil.VpnIp
 }
@@ -70,7 +66,6 @@ func NewHandshakeManager(l *logrus.Logger, tunCidr *net.IPNet, preferredRanges [
 		config:                 config,
 		trigger:                make(chan iputil.VpnIp, config.triggerBuffer),
 		OutboundHandshakeTimer: NewLockingTimerWheel[iputil.VpnIp](config.tryInterval, hsTimeout(config.retries, config.tryInterval)),
-		vpnIps:                 map[iputil.VpnIp]struct{}{},
 		messageMetrics:         config.messageMetrics,
 		metricInitiated:        metrics.GetOrRegisterCounter("handshake_manager.initiated", nil),
 		metricTimedOut:         metrics.GetOrRegisterCounter("handshake_manager.timed_out", nil),
@@ -108,7 +103,6 @@ func (c *HandshakeManager) NextOutboundHandshakeTimerTick(now time.Time, f udp.E
 func (c *HandshakeManager) handleOutbound(vpnIp iputil.VpnIp, f udp.EncWriter, lighthouseTriggered bool) {
 	hostinfo, err := c.pendingHostMap.QueryVpnIp(vpnIp)
 	if err != nil {
-		delete(c.vpnIps, vpnIp)
 		return
 	}
 	hostinfo.Lock()
@@ -298,10 +292,7 @@ func (c *HandshakeManager) AddVpnIp(vpnIp iputil.VpnIp, init func(*HostInfo)) *H
 	hostinfo, created := c.pendingHostMap.AddVpnIp(vpnIp, init)
 
 	if created {
-		if _, ok := c.vpnIps[vpnIp]; !ok {
-			c.OutboundHandshakeTimer.Add(vpnIp, c.config.tryInterval)
-		}
-		c.vpnIps[vpnIp] = struct{}{}
+		c.OutboundHandshakeTimer.Add(vpnIp, c.config.tryInterval)
 		c.metricInitiated.Inc(1)
 	}
 


### PR DESCRIPTION
The `vpnIps` map I added to `HandshakeManager` in #820 is duplicative of the pending hostmap and was not correctly maintained which caused a handshake to only ever be tried once with a remote vpn ip.

This change reverts that and fixes the regression. 