### PR TITLE
add boringcrypto Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,8 @@ release-linux: $(ALL_LINUX:%=build/nebula-%.tar.gz)
 
 release-freebsd: build/nebula-freebsd-amd64.tar.gz
 
+release-boringcrypto: build/nebula-linux-$(shell go env GOARCH)-boringcrypto.tar.gz
+
 BUILD_ARGS = -trimpath
 
 bin-windows: build/windows-amd64/nebula.exe build/windows-amd64/nebula-cert.exe
@@ -89,6 +91,9 @@ bin-darwin: build/darwin-amd64/nebula build/darwin-amd64/nebula-cert
 	mv $? .
 
 bin-freebsd: build/freebsd-amd64/nebula build/freebsd-amd64/nebula-cert
+	mv $? .
+
+bin-boringcrypto: build/linux-$(shell go env GOARCH)-boringcrypto/nebula build/linux-$(shell go env GOARCH)-boringcrypto/nebula-cert
 	mv $? .
 
 bin:
@@ -104,6 +109,10 @@ build/linux-mips-%: GOENV += GOMIPS=$(word 3, $(subst -, ,$*))
 
 # Build an extra small binary for mips-softfloat
 build/linux-mips-softfloat/%: LDFLAGS += -s -w
+
+# boringcrypto
+build/linux-amd64-boringcrypto/%: GOENV += GOEXPERIMENT=boringcrypto CGO_ENABLED=1
+build/linux-arm64-boringcrypto/%: GOENV += GOEXPERIMENT=boringcrypto CGO_ENABLED=1
 
 build/%/nebula: .FORCE
 	GOOS=$(firstword $(subst -, , $*)) \

--- a/boring.go
+++ b/boring.go
@@ -1,0 +1,8 @@
+//go:build boringcrypto
+// +build boringcrypto
+
+package nebula
+
+import "crypto/boring"
+
+var boringEnabled = boring.Enabled

--- a/interface.go
+++ b/interface.go
@@ -204,6 +204,7 @@ func (f *Interface) activate() {
 
 	f.l.WithField("interface", f.inside.Name()).WithField("network", f.inside.Cidr().String()).
 		WithField("build", f.version).WithField("udpAddr", addr).
+		WithField("boringcrypto", boringEnabled()).
 		Info("Nebula interface is active")
 
 	metrics.GetOrRegisterGauge("routines", nil).Update(int64(f.routines))

--- a/notboring.go
+++ b/notboring.go
@@ -1,0 +1,6 @@
+//go:build !boringcrypto
+// +build !boringcrypto
+
+package nebula
+
+var boringEnabled = func() bool { return false }

--- a/stats.go
+++ b/stats.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"runtime"
+	"strconv"
 	"time"
 
 	graphite "github.com/cyberdelia/go-metrics-graphite"
@@ -105,8 +106,9 @@ func startPrometheusStats(l *logrus.Logger, i time.Duration, c *config.C, buildV
 		Name:      "info",
 		Help:      "Version information for the Nebula binary",
 		ConstLabels: prometheus.Labels{
-			"version":   buildVersion,
-			"goversion": runtime.Version(),
+			"version":      buildVersion,
+			"goversion":    runtime.Version(),
+			"boringcrypto": strconv.FormatBool(boringEnabled()),
 		},
 	})
 	pr.MustRegister(g)


### PR DESCRIPTION
This adds a few build targets to compile with `GOEXPERIMENT=boringcrypto`:

- `bin-boringcrypto`
- `release-boringcrypto`

It also adds a field to the intial start up log indicating if boringcrypto is enabled in the binary.