### PR TITLE
Cache cert verification methods

### DIFF
--- a/cert/ca.go
+++ b/cert/ca.go
@@ -91,7 +91,8 @@ func (ncp *NebulaCAPool) ResetCertBlocklist() {
 	ncp.certBlocklist = make(map[string]struct{})
 }
 
-// IsBlocklisted returns true if the fingerprint fails to generate or has been explicitly blocklisted
+// NOTE: This uses an internal cache for Sha256Sum() that will not be invalidated
+// automatically if you manually change any fields in the NebulaCertificate.
 func (ncp *NebulaCAPool) IsBlocklisted(c *NebulaCertificate) bool {
 	return ncp.isBlocklistedWithCache(c, false)
 }

--- a/cert/ca.go
+++ b/cert/ca.go
@@ -93,7 +93,12 @@ func (ncp *NebulaCAPool) ResetCertBlocklist() {
 
 // IsBlocklisted returns true if the fingerprint fails to generate or has been explicitly blocklisted
 func (ncp *NebulaCAPool) IsBlocklisted(c *NebulaCertificate) bool {
-	h, err := c.Sha256Sum()
+	return ncp.isBlocklistedWithCache(c, false)
+}
+
+// IsBlocklisted returns true if the fingerprint fails to generate or has been explicitly blocklisted
+func (ncp *NebulaCAPool) isBlocklistedWithCache(c *NebulaCertificate, useCache bool) bool {
+	h, err := c.sha256SumWithCache(useCache)
 	if err != nil {
 		return true
 	}

--- a/cert/cert.go
+++ b/cert/cert.go
@@ -558,7 +558,6 @@ func (nc *NebulaCertificate) CheckSignature(key []byte) bool {
 	if err != nil {
 		return false
 	}
-
 	switch nc.Details.Curve {
 	case Curve_CURVE25519:
 		return ed25519.Verify(ed25519.PublicKey(key), b, nc.Signature)

--- a/connection_manager.go
+++ b/connection_manager.go
@@ -427,7 +427,7 @@ func (n *connectionManager) isInvalidCertificate(now time.Time, hostinfo *HostIn
 		return false
 	}
 
-	valid, err := remoteCert.Verify(now, n.intf.caPool)
+	valid, err := remoteCert.VerifyWithCache(now, n.intf.caPool)
 	if valid {
 		return false
 	}


### PR DESCRIPTION
CheckSignature and Verify are expensive methods, and certificates are static. Cache the results now that we are calling these methods much more often during the connection_manager runs.