### PR TITLE
When interpreting DNS lookup results, create the IPv4 address with ne…

### DIFF
--- a/remote_list.go
+++ b/remote_list.go
@@ -586,7 +586,7 @@ func (r *RemoteList) unlockedCollect() {
 			case addr.Addr().Is4():
 				v4 := addr.Addr().As4()
 				addrs = append(addrs, &udp.Addr{
-					IP:   v4[:],
+					IP:   net.IPv4(v4[0], v4[1], v4[2], v4[3]),
 					Port: addr.Port(),
 				})
 			case addr.Addr().Is6():

--- a/remote_list.go
+++ b/remote_list.go
@@ -582,20 +582,11 @@ func (r *RemoteList) unlockedCollect() {
 	dnsAddrs := r.hr.GetIPs()
 	for _, addr := range dnsAddrs {
 		if r.shouldAdd == nil || r.shouldAdd(addr.Addr()) {
-			switch {
-			case addr.Addr().Is4():
-				v4 := addr.Addr().As4()
-				addrs = append(addrs, &udp.Addr{
-					IP:   net.IPv4(v4[0], v4[1], v4[2], v4[3]),
-					Port: addr.Port(),
-				})
-			case addr.Addr().Is6():
-				v6 := addr.Addr().As16()
-				addrs = append(addrs, &udp.Addr{
-					IP:   v6[:],
-					Port: addr.Port(),
-				})
-			}
+			v6 := addr.Addr().As16()
+			addrs = append(addrs, &udp.Addr{
+				IP:   v6[:],
+				Port: addr.Port(),
+			})
 		}
 	}
 


### PR DESCRIPTION
…t.IPv4 instead of directly copying.

Fix #875 