### PR TITLE
GitHub actions update setup-go

### DIFF
--- a/.github/workflows/gofmt.yml
+++ b/.github/workflows/gofmt.yml
@@ -14,21 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.20
-      uses: actions/setup-go@v2
-      with:
-        go-version: "1.20"
-      id: go
+    - uses: actions/checkout@v3
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-
-    - uses: actions/cache@v2
+    - uses: actions/setup-go@v4
       with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-gofmt1.20-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-gofmt1.20-
+        go-version-file: 'go.mod'
+        check-latest: true
 
     - name: Install goimports
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,12 @@ jobs:
     name: Build Linux All
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.20
-        uses: actions/setup-go@v2
-        with:
-          go-version: "1.20"
+      - uses: actions/checkout@v3
 
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+          check-latest: true
 
       - name: Build
         run: |
@@ -34,13 +33,12 @@ jobs:
     name: Build Windows
     runs-on: windows-latest
     steps:
-      - name: Set up Go 1.20
-        uses: actions/setup-go@v2
-        with:
-          go-version: "1.20"
+      - uses: actions/checkout@v3
 
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+          check-latest: true
 
       - name: Build
         run: |
@@ -68,13 +66,12 @@ jobs:
       HAS_SIGNING_CREDS: ${{ secrets.AC_USERNAME != '' }}
     runs-on: macos-11
     steps:
-      - name: Set up Go 1.20
-        uses: actions/setup-go@v2
-        with:
-          go-version: "1.20"
+      - uses: actions/checkout@v3
 
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+          check-latest: true
 
       - name: Import certificates
         if: env.HAS_SIGNING_CREDS == 'true'

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - uses: actions/checkout@v3
+
     - uses: actions/setup-go@v4
       with:
         go-version-file: 'go.mod'

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -18,21 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.20
-      uses: actions/setup-go@v2
+    - uses: actions/setup-go@v4
       with:
-        go-version: "1.20"
-      id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-
-    - uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go1.20-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go1.20-
+        go-version-file: 'go.mod'
+        check-latest: true
 
     - name: build
       run: make bin-docker

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,21 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.20
-      uses: actions/setup-go@v2
-      with:
-        go-version: "1.20"
-      id: go
+    - uses: actions/checkout@v3
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-
-    - uses: actions/cache@v2
+    - uses: actions/setup-go@v4
       with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go1.20-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go1.20-
+        go-version-file: 'go.mod'
+        check-latest: true
 
     - name: Build
       run: make all
@@ -57,21 +48,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.20
-      uses: actions/setup-go@v2
-      with:
-        go-version: "1.20"
-      id: go
+    - uses: actions/checkout@v3
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-
-    - uses: actions/cache@v2
+    - uses: actions/setup-go@v4
       with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go1.20-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go1.20-
+        go-version-file: 'go.mod'
+        check-latest: true
 
     - name: Build
       run: make bin-boringcrypto
@@ -90,21 +72,12 @@ jobs:
         os: [windows-latest, macos-11]
     steps:
 
-    - name: Set up Go 1.20
-      uses: actions/setup-go@v2
-      with:
-        go-version: "1.20"
-      id: go
+    - uses: actions/checkout@v3
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-
-    - uses: actions/cache@v2
+    - uses: actions/setup-go@v4
       with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go1.20-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go1.20-
+        go-version-file: 'go.mod'
+        check-latest: true
 
     - name: Build nebula
       run: go build ./cmd/nebula


### PR DESCRIPTION
This does caching for us, so we can remove our manual caching of modules. Also, we can have it pull the version of Go to use from `go.mod`, so less things to remember in the future.

From the logs, showing that caching is working correctly:

```
Run actions/setup-go@v4
Setup go version spec 1.20
Attempting to resolve the latest version from the manifest...
matching 1.20...
Resolved as '1.20.4'
Found in cache @ /opt/hostedtoolcache/go/1.20.4/x64
Added go to the path
Successfully set up Go version 1.20
/opt/hostedtoolcache/go/1.20.4/x64/bin/go env GOMODCACHE
/opt/hostedtoolcache/go/1.20.4/x64/bin/go env GOCACHE
/home/runner/go/pkg/mod
/home/runner/.cache/go-build
Received 21620006 of 21620006 (100.0%), 93.3 MBs/sec
Cache Size: ~21 MB (21620006 B)
/usr/bin/tar -xf /home/runner/work/_temp/84f32733-d649-4828-8fe7-fa03cbdb3500/cache.tzst -P -C /home/runner/work/nebula/nebula --use-compress-program unzstd
Cache restored successfully
Cache restored from key: setup-go-Linux-go-1.20.4-5fc07f5e5cbdc8be2c1c16afa16f7b85b7a373e280e871b032e4c416c06c4ced
go version go1.20.4 linux/amd64
```