### PR TITLE
Fix reconfig freeze attempting to send to an unbuffered, unread channel

### DIFF
--- a/lighthouse.go
+++ b/lighthouse.go
@@ -265,14 +265,13 @@ func (lh *LightHouse) reload(c *config.C, initial bool) error {
 		// Clean up. Entries still in the static_host_map will be re-built.
 		// Entries no longer present must have their (possible) background DNS goroutines stopped.
 		if existingStaticList := lh.staticList.Load(); existingStaticList != nil {
-			lh.Lock()
+			lh.RLock()
 			for staticVpnIp := range *existingStaticList {
-				am := lh.unlockedGetRemoteList(staticVpnIp)
-				if am != nil {
+				if am, ok := lh.addrMap[staticVpnIp]; ok && am != nil {
 					am.hr.Cancel()
 				}
 			}
-			lh.Unlock()
+			lh.RUnlock()
 		}
 		// Build a new list based on current config.
 		staticList := make(map[iputil.VpnIp]struct{})

--- a/lighthouse_test.go
+++ b/lighthouse_test.go
@@ -239,11 +239,14 @@ func TestLighthouse_reload(t *testing.T) {
 	c := config.NewC(l)
 	c.Settings["lighthouse"] = map[interface{}]interface{}{"am_lighthouse": true}
 	c.Settings["listen"] = map[interface{}]interface{}{"port": 4242}
+	c.Settings["static_host_map"] = map[interface{}]interface{}{"10.128.0.2": []interface{}{"1.1.1.1:4242"}}
 	lh, err := NewLightHouseFromConfig(context.Background(), l, c, &net.IPNet{IP: net.IP{10, 128, 0, 1}, Mask: net.IPMask{255, 255, 255, 0}}, nil, nil)
 	assert.NoError(t, err)
 
-	c.Settings["static_host_map"] = map[interface{}]interface{}{"10.128.0.2": []interface{}{"1.1.1.1:4242"}}
-	lh.reload(c, false)
+	c.Settings["static_host_map"] = map[interface{}]interface{}{"10.128.0.2": []interface{}{"1.1.1.1:4242", "2.2.2.2:4242"}}
+	// Send initial=true to force a reload. Otherwise, this call path doesn't adhere to the config cache tracking, resulting in
+	// the reload skipping everything.
+	lh.reload(c, true)
 }
 
 func newLHHostRequest(fromAddr *udp.Addr, myVpnIp, queryVpnIp iputil.VpnIp, lhh *LightHouseHandler) testLhReply {

--- a/lighthouse_test.go
+++ b/lighthouse_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/slackhq/nebula/test"
 	"github.com/slackhq/nebula/udp"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
 )
 
 //TODO: Add a test to ensure udpAddr is copied and not reused
@@ -239,14 +240,20 @@ func TestLighthouse_reload(t *testing.T) {
 	c := config.NewC(l)
 	c.Settings["lighthouse"] = map[interface{}]interface{}{"am_lighthouse": true}
 	c.Settings["listen"] = map[interface{}]interface{}{"port": 4242}
-	c.Settings["static_host_map"] = map[interface{}]interface{}{"10.128.0.2": []interface{}{"1.1.1.1:4242"}}
 	lh, err := NewLightHouseFromConfig(context.Background(), l, c, &net.IPNet{IP: net.IP{10, 128, 0, 1}, Mask: net.IPMask{255, 255, 255, 0}}, nil, nil)
 	assert.NoError(t, err)
 
-	c.Settings["static_host_map"] = map[interface{}]interface{}{"10.128.0.2": []interface{}{"1.1.1.1:4242", "2.2.2.2:4242"}}
-	// Send initial=true to force a reload. Otherwise, this call path doesn't adhere to the config cache tracking, resulting in
-	// the reload skipping everything.
-	lh.reload(c, true)
+	nc := map[interface{}]interface{}{
+		"static_host_map": map[interface{}]interface{}{
+			"10.128.0.2": []interface{}{"1.1.1.1:4242"},
+		},
+	}
+	rc, err := yaml.Marshal(nc)
+	assert.NoError(t, err)
+	c.ReloadConfigString(string(rc))
+
+	err = lh.reload(c, false)
+	assert.NoError(t, err)
 }
 
 func newLHHostRequest(fromAddr *udp.Addr, myVpnIp, queryVpnIp iputil.VpnIp, lhh *LightHouseHandler) testLhReply {

--- a/remote_list.go
+++ b/remote_list.go
@@ -80,7 +80,6 @@ func NewHostnameResults(ctx context.Context, l *logrus.Logger, d time.Duration, 
 		hostnames:     make([]hostnamePort, len(hostPorts)),
 		network:       network,
 		lookupTimeout: timeout,
-		stop:          make(chan (struct{})),
 		l:             l,
 	}
 
@@ -115,6 +114,7 @@ func NewHostnameResults(ctx context.Context, l *logrus.Logger, d time.Duration, 
 
 	// Time for the DNS lookup goroutine
 	if performBackgroundLookup {
+		r.stop = make(chan (struct{}), 1)
 		ticker := time.NewTicker(d)
 		go func() {
 			defer ticker.Stop()
@@ -169,7 +169,7 @@ func NewHostnameResults(ctx context.Context, l *logrus.Logger, d time.Duration, 
 }
 
 func (hr *hostnamesResults) Cancel() {
-	if hr != nil {
+	if hr != nil && hr.stop != nil {
 		hr.stop <- struct{}{}
 	}
 }


### PR DESCRIPTION
Only create stop channel when a DNS background goroutine is created. Only send the stop signal when the channel exists.
Also create the channel with a buffer to size 1 so that the stop message can be immediately sent even if the goroutine is busy doing DNS lookups.