### PR TITLE
Add support for naming FreeBSD tun devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,13 @@ ALL_LINUX = linux-amd64 \
 	linux-mips-softfloat \
 	linux-riscv64
 
+ALL_FREEBSD = freebsd-amd64 \
+	freebsd-arm64
+
 ALL = $(ALL_LINUX) \
+	$(ALL_FREEBSD) \
 	darwin-amd64 \
 	darwin-arm64 \
-	freebsd-amd64 \
 	windows-amd64 \
 	windows-arm64
 
@@ -75,7 +78,7 @@ release: $(ALL:%=build/nebula-%.tar.gz)
 
 release-linux: $(ALL_LINUX:%=build/nebula-%.tar.gz)
 
-release-freebsd: build/nebula-freebsd-amd64.tar.gz
+release-freebsd: $(ALL_FREEBSD:%=build/nebula-%.tar.gz)
 
 release-boringcrypto: build/nebula-linux-$(shell go env GOARCH)-boringcrypto.tar.gz
 
@@ -91,6 +94,9 @@ bin-darwin: build/darwin-amd64/nebula build/darwin-amd64/nebula-cert
 	mv $? .
 
 bin-freebsd: build/freebsd-amd64/nebula build/freebsd-amd64/nebula-cert
+	mv $? .
+
+bin-freebsd-arm64: build/freebsd-arm64/nebula build/freebsd-arm64/nebula-cert
 	mv $? .
 
 bin-boringcrypto: build/linux-$(shell go env GOARCH)-boringcrypto/nebula build/linux-$(shell go env GOARCH)-boringcrypto/nebula-cert

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -194,7 +194,6 @@ tun:
   disabled: false
   # Name of the device. If not set, a default will be chosen by the OS.
   # For macOS: if set, must be in the form `utun[0-9]+`.
-  # For FreeBSD: Required to be set, must be in the form `tun[0-9]+`.
   dev: nebula1
   # Toggles forwarding of local broadcast packets, the address of which depends on the ip/mask encoded in pki.cert
   drop_local_broadcast: false

--- a/overlay/tun.go
+++ b/overlay/tun.go
@@ -2,7 +2,6 @@ package overlay
 
 import (
 	"net"
-	"syscall"
 
 	"github.com/sirupsen/logrus"
 	"github.com/slackhq/nebula/config"
@@ -51,12 +50,4 @@ func NewDeviceFromConfig(c *config.C, l *logrus.Logger, tunCidr *net.IPNet, fd *
 			c.GetBool("tun.use_system_route_table", false),
 		)
 	}
-}
-
-func ioctl(a1, a2, a3 uintptr) error {
-	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, a1, a2, a3)
-	if errno != 0 {
-		return errno
-	}
-	return nil
 }

--- a/overlay/tun.go
+++ b/overlay/tun.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/slackhq/nebula/config"
 	"github.com/slackhq/nebula/util"
+	"golang.org/x/sys/unix"
 )
 
 const DefaultMTU = 1300
@@ -50,4 +51,12 @@ func NewDeviceFromConfig(c *config.C, l *logrus.Logger, tunCidr *net.IPNet, fd *
 			c.GetBool("tun.use_system_route_table", false),
 		)
 	}
+}
+
+func ioctl(a1, a2, a3 uintptr) error {
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, a1, a2, a3)
+	if errno != 0 {
+		return errno
+	}
+	return nil
 }

--- a/overlay/tun.go
+++ b/overlay/tun.go
@@ -2,11 +2,11 @@ package overlay
 
 import (
 	"net"
+	"syscall"
 
 	"github.com/sirupsen/logrus"
 	"github.com/slackhq/nebula/config"
 	"github.com/slackhq/nebula/util"
-	"golang.org/x/sys/unix"
 )
 
 const DefaultMTU = 1300
@@ -54,7 +54,7 @@ func NewDeviceFromConfig(c *config.C, l *logrus.Logger, tunCidr *net.IPNet, fd *
 }
 
 func ioctl(a1, a2, a3 uintptr) error {
-	_, _, errno := unix.Syscall(unix.SYS_IOCTL, a1, a2, a3)
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, a1, a2, a3)
 	if errno != 0 {
 		return errno
 	}

--- a/overlay/tun_darwin.go
+++ b/overlay/tun_darwin.go
@@ -47,14 +47,6 @@ type ifReq struct {
 	pad   [8]byte
 }
 
-func ioctl(a1, a2, a3 uintptr) error {
-	_, _, errno := unix.Syscall(unix.SYS_IOCTL, a1, a2, a3)
-	if errno != 0 {
-		return errno
-	}
-	return nil
-}
-
 var sockaddrCtlSize uintptr = 32
 
 const (
@@ -194,10 +186,10 @@ func (t *tun) Activate() error {
 		unix.SOCK_DGRAM,
 		unix.IPPROTO_IP,
 	)
-
 	if err != nil {
 		return err
 	}
+	defer unix.Close(s)
 
 	fd := uintptr(s)
 

--- a/overlay/tun_freebsd.go
+++ b/overlay/tun_freebsd.go
@@ -22,6 +22,8 @@ import (
 )
 
 const (
+	// FIODGNAME is defined in sys/sys/filio.h on FreeBSD
+	// For 32-bit systems, use FIODGNAME_32 (not defined in this file: 0x80086678)
 	FIODGNAME = 0x80106678
 )
 
@@ -101,6 +103,7 @@ func newTun(l *logrus.Logger, deviceName string, cidr *net.IPNet, defaultMTU int
 	var name [16]byte
 	var ctrlErr error
 	rawConn.Control(func(fd uintptr) {
+		// Read the name of the interface
 		arg := fiodgnameArg{length: 16, buf: unsafe.Pointer(&name)}
 		ctrlErr = ioctl(fd, FIODGNAME, uintptr(unsafe.Pointer(&arg)))
 	})
@@ -113,6 +116,7 @@ func newTun(l *logrus.Logger, deviceName string, cidr *net.IPNet, defaultMTU int
 		deviceName = ifName
 	}
 
+	// If the name doesn't match the desired interface name, rename it now
 	if ifName != deviceName {
 		s, err := syscall.Socket(
 			syscall.AF_INET,

--- a/overlay/tun_linux.go
+++ b/overlay/tun_linux.go
@@ -43,14 +43,6 @@ type ifReq struct {
 	pad   [8]byte
 }
 
-func ioctl(a1, a2, a3 uintptr) error {
-	_, _, errno := unix.Syscall(unix.SYS_IOCTL, a1, a2, a3)
-	if errno != 0 {
-		return errno
-	}
-	return nil
-}
-
 type ifreqAddr struct {
 	Name [16]byte
 	Addr unix.RawSockaddrInet4

--- a/overlay/tun_notwin.go
+++ b/overlay/tun_notwin.go
@@ -1,0 +1,14 @@
+//go:build !windows
+// +build !windows
+
+package overlay
+
+import "syscall"
+
+func ioctl(a1, a2, a3 uintptr) error {
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, a1, a2, a3)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}


### PR DESCRIPTION
Fixes #309.

If no name is specified, the system chooses one. If a name _is_ specified, and the tun exists already, we'll try to use it. If it doesn't exist, we'll rename the one the system gives us.

This could've been done with ifconfig, but I figured this was a good start towards syscalls for FreeBSD.