### PR TITLE
Windows: generate a nebula-windows-amd64-upx.zip on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,9 @@ jobs:
           curl -L -o upx.zip https://github.com/upx/upx/releases/download/v4.0.2/upx-4.0.2-win64.zip
           echo "325c58ea2ed375afbd4eeac0b26f15f98db0d75dea701205ca10d8bf4d2fdc24  upx.zip" | sha256sum -c
           unzip upx.zip
-          upx-4.0.2-win64/upx.exe build/windows-amd64/nebula{,-cert}.exe
+          mkdir build/windows-amd64-upx
+          upx-4.0.2-win64/upx.exe -o build/windows-amd64-upx/nebula.exe build/windows-amd64/nebula.exe
+          upx-4.0.2-win64/upx.exe -o build/windows-amd64-upx/nebula-cert.exe build/windows-amd64/nebula-cert.exe
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -134,6 +136,8 @@ jobs:
           cd artifacts/windows-latest
           cp windows-amd64/* .
           zip -r nebula-windows-amd64.zip nebula.exe nebula-cert.exe dist
+          cp windows-amd64-upx/* .
+          zip -r nebula-windows-amd64-upx.zip nebula.exe nebula-cert.exe dist
           cp windows-arm64/* .
           zip -r nebula-windows-arm64.zip nebula.exe nebula-cert.exe dist
 
@@ -148,9 +152,12 @@ jobs:
               then
                 sha256sum <windows-amd64/nebula.exe | sed 's=-$=nebula-windows-amd64.zip/nebula.exe='
                 sha256sum <windows-amd64/nebula-cert.exe | sed 's=-$=nebula-windows-amd64.zip/nebula-cert.exe='
+                sha256sum <windows-amd64-upx/nebula.exe | sed 's=-$=nebula-windows-amd64-upx.zip/nebula.exe='
+                sha256sum <windows-amd64-upx/nebula-cert.exe | sed 's=-$=nebula-windows-amd64-upx.zip/nebula-cert.exe='
                 sha256sum <windows-arm64/nebula.exe | sed 's=-$=nebula-windows-arm64.zip/nebula.exe='
                 sha256sum <windows-arm64/nebula-cert.exe | sed 's=-$=nebula-windows-arm64.zip/nebula-cert.exe='
                 sha256sum nebula-windows-amd64.zip
+                sha256sum nebula-windows-amd64-upx.zip
                 sha256sum nebula-windows-arm64.zip
               elif [ "$dir" = darwin-latest ]
               then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,16 @@ jobs:
           mkdir build\dist\windows
           mv dist\windows\wintun build\dist\windows\
 
+      - name: UPX
+        run: |
+          curl -L -o upx.zip https://github.com/upx/upx/releases/download/v4.0.2/upx-4.0.2-win64.zip
+          echo "325c58ea2ed375afbd4eeac0b26f15f98db0d75dea701205ca10d8bf4d2fdc24  upx.zip" | sha256sum -c
+          unzip upx.zip
+          upx-4.0.2-win64\upx.exe build\windows-amd64\nebula.exe
+          upx-4.0.2-win64\upx.exe build\windows-amd64\nebula-cert.exe
+          upx-4.0.2-win64\upx.exe build\windows-arm64\nebula.exe
+          upx-4.0.2-win64\upx.exe build\windows-arm64\nebula-cert.exe
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,7 @@ jobs:
           curl -L -o upx.zip https://github.com/upx/upx/releases/download/v4.0.2/upx-4.0.2-win64.zip
           echo "325c58ea2ed375afbd4eeac0b26f15f98db0d75dea701205ca10d8bf4d2fdc24  upx.zip" | sha256sum -c
           unzip upx.zip
-          upx-4.0.2-win64/upx.exe build/windows-amd64/nebula.exe
-          upx-4.0.2-win64/upx.exe build/windows-amd64/nebula-cert.exe
+          upx-4.0.2-win64/upx.exe build/windows-amd64/nebula{,-cert}.exe
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,14 +55,13 @@ jobs:
           mv dist\windows\wintun build\dist\windows\
 
       - name: UPX
+        shell: bash
         run: |
           curl -L -o upx.zip https://github.com/upx/upx/releases/download/v4.0.2/upx-4.0.2-win64.zip
           echo "325c58ea2ed375afbd4eeac0b26f15f98db0d75dea701205ca10d8bf4d2fdc24  upx.zip" | sha256sum -c
           unzip upx.zip
-          upx-4.0.2-win64\upx.exe build\windows-amd64\nebula.exe
-          upx-4.0.2-win64\upx.exe build\windows-amd64\nebula-cert.exe
-          upx-4.0.2-win64\upx.exe build\windows-arm64\nebula.exe
-          upx-4.0.2-win64\upx.exe build\windows-arm64\nebula-cert.exe
+          upx-4.0.2-win64/upx.exe build/windows-amd64/nebula.exe
+          upx-4.0.2-win64/upx.exe build/windows-amd64/nebula-cert.exe
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This change generates Windows binaries that are also ran through UPX to pack them.

Example build here:

- https://github.com/wadey/nebula/releases/tag/v1.7.2-upx4