### PR TITLE
Attempt to notify systemd of service readiness on linux

### DIFF
--- a/cmd/nebula/main.go
+++ b/cmd/nebula/main.go
@@ -65,6 +65,7 @@ func main() {
 
 	if !*configTest {
 		ctrl.Start()
+		notifyReady(l)
 		ctrl.ShutdownBlock()
 	}
 

--- a/cmd/nebula/notify_linux.go
+++ b/cmd/nebula/notify_linux.go
@@ -22,19 +22,19 @@ func notifyReady(l *logrus.Logger) {
 
 	conn, err := net.DialTimeout("unixgram", sockName, time.Second)
 	if err != nil {
-		l.WithError(err).Debugln("failed to connect to systemd notification socket")
+		l.WithError(err).Error("failed to connect to systemd notification socket")
 		return
 	}
 	defer conn.Close()
 
 	err = conn.SetWriteDeadline(time.Now().Add(time.Second))
 	if err != nil {
-		l.WithError(err).Debugln("failed to set the write deadline for the systemd notification socket")
+		l.WithError(err).Error("failed to set the write deadline for the systemd notification socket")
 		return
 	}
 
 	if _, err = conn.Write([]byte(SdNotifyReady)); err != nil {
-		l.WithError(err).Debugln("failed to signal the systemd notification socket")
+		l.WithError(err).Error("failed to signal the systemd notification socket")
 		return
 	}
 

--- a/cmd/nebula/notify_linux.go
+++ b/cmd/nebula/notify_linux.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"net"
+	"os"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// SdNotifyReady tells systemd the service is ready and dependent services can now be started
+// https://www.freedesktop.org/software/systemd/man/sd_notify.html
+// https://www.freedesktop.org/software/systemd/man/systemd.service.html
+const SdNotifyReady = "READY=1"
+
+func notifyReady(l *logrus.Logger) {
+	sockName := os.Getenv("NOTIFY_SOCKET")
+	if sockName == "" {
+		l.Debugln("NOTIFY_SOCKET systemd env var not set, not sending ready signal")
+		return
+	}
+
+	conn, err := net.DialTimeout("unixgram", sockName, time.Second)
+	if err != nil {
+		l.WithError(err).Debugln("failed to connect to systemd notification socket")
+		return
+	}
+	defer conn.Close()
+
+	err = conn.SetWriteDeadline(time.Now().Add(time.Second))
+	if err != nil {
+		l.WithError(err).Debugln("failed to set the write deadline for the systemd notification socket")
+		return
+	}
+
+	if _, err = conn.Write([]byte(SdNotifyReady)); err != nil {
+		l.WithError(err).Debugln("failed to signal the systemd notification socket")
+		return
+	}
+
+	l.Debugln("notified systemd the service is ready")
+}

--- a/cmd/nebula/notify_notlinux.go
+++ b/cmd/nebula/notify_notlinux.go
@@ -1,0 +1,10 @@
+//go:build !linux
+// +build !linux
+
+package main
+
+import "github.com/sirupsen/logrus"
+
+func notifyReady(_ *logrus.Logger) {
+	// No init service to notify
+}

--- a/dist/arch/nebula.service
+++ b/dist/arch/nebula.service
@@ -4,6 +4,8 @@ Wants=basic.target network-online.target nss-lookup.target time-sync.target
 After=basic.target network.target network-online.target
 
 [Service]
+Type=notify
+NotifyAccess=main
 SyslogIdentifier=nebula
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/bin/nebula -config /etc/nebula/config.yml

--- a/dist/fedora/nebula.service
+++ b/dist/fedora/nebula.service
@@ -5,6 +5,8 @@ After=basic.target network.target network-online.target
 Before=sshd.service
 
 [Service]
+Type=notify
+NotifyAccess=main
 SyslogIdentifier=nebula
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/bin/nebula -config /etc/nebula/config.yml

--- a/examples/service_scripts/nebula.service
+++ b/examples/service_scripts/nebula.service
@@ -5,6 +5,8 @@ After=basic.target network.target network-online.target
 Before=sshd.service
 
 [Service]
+Type=notify
+NotifyAccess=main
 SyslogIdentifier=nebula
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart=/usr/local/bin/nebula -config /etc/nebula/config.yml


### PR DESCRIPTION
This will send `READY=1` to the unix domain socket described by the `NOTIFY_SOCKET` environment variable, if it was provided, after we have called `Control.Activate()`.

Should resolve timing issues with services that depend on nebulas udp listener(s) and tun device being up.

Closes #921 
