### PR TITLE
Guard e2e tun and udp channels on close

### DIFF
--- a/e2e/handshakes_test.go
+++ b/e2e/handshakes_test.go
@@ -410,6 +410,8 @@ func TestStage1RaceRelays(t *testing.T) {
 	p := r.RouteForAllUntilTxTun(myControl)
 	_ = p
 
+	r.FlushAll()
+
 	myControl.Stop()
 	theirControl.Stop()
 	relayControl.Stop()


### PR DESCRIPTION
Instead of throwing a panic in a write after close in e2e tests, return an error or fail silently.

In the beginning there was a desire to tightly control packet flow in the e2e tests but as more complicated test cases arose that desire became very difficult to maintain. This led to tests with more automated packet shuffling than originally intended.

As a result some complicated tests can get into a situation where instances had just received a packet when we determine the test complete and close the nebula instance. The instance processing the packet determines it doesn't have a tunnel and tries to send a `recv_error` on the now closed fake udp socket. 