### PR TITLE
github actions smoke-test: run with data race detector

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -26,7 +26,7 @@ jobs:
         check-latest: true
 
     - name: build
-      run: make bin-docker
+      run: make bin-docker CGO_ENABLED=1 BUILD_ARGS=-race
 
     - name: setup docker image
       working-directory: ./.github/workflows/smoke

--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,7 @@ smoke-relay-docker: bin-docker
 	cd .github/workflows/smoke/ && ./smoke-relay.sh
 
 smoke-docker-race: BUILD_ARGS = -race
+smoke-docker-race: CGO_ENABLED = 1
 smoke-docker-race: smoke-docker
 
 .FORCE:


### PR DESCRIPTION
Run the github actions smoke tests with data race detector enabled, so we can detect if a PR introduces a simple data race.

(also fix `make smoke-docker-race` to set CGO_ENABLED correctly)