### PR TITLE
QueryServer needs to be done outside of the lock

### DIFF
--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -318,13 +318,13 @@ func (hm *HandshakeManager) GetOrHandshake(vpnIp iputil.VpnIp, cacheCb func(*Hos
 // StartHandshake will ensure a handshake is currently being attempted for the provided vpn ip
 func (hm *HandshakeManager) StartHandshake(vpnIp iputil.VpnIp, cacheCb func(*HostInfo)) *HostInfo {
 	hm.Lock()
-	defer hm.Unlock()
 
 	if hostinfo, ok := hm.vpnIps[vpnIp]; ok {
 		// We are already trying to handshake with this vpn ip
 		if cacheCb != nil {
 			cacheCb(hostinfo)
 		}
+		hm.Unlock()
 		return hostinfo
 	}
 
@@ -361,6 +361,7 @@ func (hm *HandshakeManager) StartHandshake(vpnIp iputil.VpnIp, cacheCb func(*Hos
 		}
 	}
 
+	hm.Unlock()
 	hm.lightHouse.QueryServer(vpnIp, hm.f)
 	return hostinfo
 }


### PR DESCRIPTION
Fixes a regression introduced in #954 

Querying lighthouses for ip information can't be done with the handshake manager lock held since it may cause a handshake to occur with a lighthouse.

Ideally this would happen outside of the hot path but this is the simplest solution for now.