### PR TITLE
main: fix dropped error

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,6 +71,9 @@ func Main(c *config.C, configTest bool, buildVersion string, logger *logrus.Logg
 	tunCidr := certificate.Details.Ips[0]
 
 	ssh, err := sshd.NewSSHServer(l.WithField("subsystem", "sshd"))
+	if err != nil {
+		return nil, util.ContextualizeIfNeeded("Error while creating SSH server", err)
+	}
 	wireSSHReload(l, ssh, c)
 	var sshStart func()
 	if c.GetBool("sshd.enabled", false) {


### PR DESCRIPTION
This fixes a dropped `err` variable in the `nebula` package