### PR TITLE
Update Arch Linux package link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,20 @@ Check the [releases](https://github.com/slackhq/nebula/releases/latest) page for
     ```
     $ sudo pacman -S nebula
     ```
+
 - [Fedora Linux](https://src.fedoraproject.org/rpms/nebula)
     ```
     $ sudo dnf install nebula
+    ```
+
+- [Debian Linux](https://packages.debian.org/source/stable/nebula)
+    ```
+    $ sudo apt install nebula
+    ```
+
+- [Alpine Linux](https://pkgs.alpinelinux.org/packages?name=nebula)
+    ```
+    $ sudo apk add nebula
     ```
 
 - [macOS Homebrew](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/nebula.rb)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Check the [releases](https://github.com/slackhq/nebula/releases/latest) page for
 
 #### Distribution Packages
 
-- [Arch Linux](https://archlinux.org/packages/community/x86_64/nebula/)
+- [Arch Linux](https://archlinux.org/packages/extra/x86_64/nebula/)
     ```
     $ sudo pacman -S nebula
     ```


### PR DESCRIPTION
The community repository was merged into extra during the Arch Linux [Git migration](https://archlinux.org/news/git-migration-announcement/) and no longer exists



PS: I've noticed there is a package for nebula in [Alpine Linux](https://pkgs.alpinelinux.org/packages?name=nebula), Wouldn't it be a good idea to add it to the list as well?