### PR TITLE
SIGHUP is only useful when config was loaded from a file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -121,6 +121,10 @@ func (c *C) HasChanged(k string) bool {
 // CatchHUP will listen for the HUP signal in a go routine and reload all configs found in the
 // original path provided to Load. The old settings are shallow copied for change detection after the reload.
 func (c *C) CatchHUP(ctx context.Context) {
+	if c.path == "" {
+		return
+	}
+
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, syscall.SIGHUP)
 


### PR DESCRIPTION
Have (*config.C).CatchHUP() return early when there is no file path available from which to reload.
This will allow wrapping service to manage their own signal trapping (which is particularly important if they've used config from a string.