### PR TITLE
test: build all non-main modules for mobile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,9 @@ jobs:
     - name: End 2 end
       run: make e2evv
 
+    - name: Build test mobile
+      run: make build-test-mobile
+
     - uses: actions/upload-artifact@v3
       with:
         name: e2e packet flow

--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,12 @@ test-cov-html:
 	go test -coverprofile=coverage.out
 	go tool cover -html=coverage.out
 
+build-test-mobile:
+	GOARCH=amd64 GOOS=ios go build $(shell go list ./... | grep -v '/cmd/\|/examples/')
+	GOARCH=arm64 GOOS=ios go build $(shell go list ./... | grep -v '/cmd/\|/examples/')
+	GOARCH=amd64 GOOS=android go build $(shell go list ./... | grep -v '/cmd/\|/examples/')
+	GOARCH=arm64 GOOS=android go build $(shell go list ./... | grep -v '/cmd/\|/examples/')
+
 bench:
 	go test -bench=.
 
@@ -214,5 +220,5 @@ smoke-docker-race: CGO_ENABLED = 1
 smoke-docker-race: smoke-docker
 
 .FORCE:
-.PHONY: e2e e2ev e2evv e2evvv e2evvvv test test-cov-html bench bench-cpu bench-cpu-long bin proto release service smoke-docker smoke-docker-race
+.PHONY: e2e e2ev e2evv e2evvv e2evvvv test test-cov-html bench bench-cpu bench-cpu-long bin proto release service build-test-mobile smoke-docker smoke-docker-race
 .DEFAULT_GOAL := bin

--- a/Makefile
+++ b/Makefile
@@ -220,5 +220,5 @@ smoke-docker-race: CGO_ENABLED = 1
 smoke-docker-race: smoke-docker
 
 .FORCE:
-.PHONY: e2e e2ev e2evv e2evvv e2evvvv test test-cov-html bench bench-cpu bench-cpu-long bin proto release service build-test-mobile smoke-docker smoke-docker-race
+.PHONY: bench bench-cpu bench-cpu-long bin build-test-mobile e2e e2ev e2evv e2evvv e2evvvv proto release service smoke-docker smoke-docker-race test test-cov-html
 .DEFAULT_GOAL := bin


### PR DESCRIPTION
Ensure that we don't break the build for mobile by doing a `go build` for all of the non-main modules in the repo. Should hopefully catch issues like #1035 sooner.