### PR TITLE
Fix re-entrant `GetOrHandshake` issues

### DIFF
--- a/connection_manager_test.go
+++ b/connection_manager_test.go
@@ -21,8 +21,9 @@ var vpnIp iputil.VpnIp
 
 func newTestLighthouse() *LightHouse {
 	lh := &LightHouse{
-		l:       test.NewLogger(),
-		addrMap: map[iputil.VpnIp]*RemoteList{},
+		l:         test.NewLogger(),
+		addrMap:   map[iputil.VpnIp]*RemoteList{},
+		queryChan: make(chan iputil.VpnIp, 10),
 	}
 	lighthouses := map[iputil.VpnIp]struct{}{}
 	staticList := map[iputil.VpnIp]struct{}{}

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -289,6 +289,10 @@ logging:
   # A 100ms interval with the default 10 retries will give a handshake 5.5 seconds to resolve before timing out
   #try_interval: 100ms
   #retries: 20
+
+  # query_buffer is the size of the buffer channel for querying lighthouses
+  #query_buffer: 64
+
   # trigger_buffer is the size of the buffer channel for quickly sending handshakes
   # after receiving the response for lighthouse queries
   #trigger_buffer: 64

--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -367,7 +367,7 @@ func (hm *HandshakeManager) GetOrHandshake(vpnIp iputil.VpnIp, cacheCb func(*Han
 		return h, true
 	}
 
-	defer hm.mainHostMap.RUnlock()
+	hm.mainHostMap.RUnlock()
 	return hm.StartHandshake(vpnIp, cacheCb), false
 }
 

--- a/hostmap.go
+++ b/hostmap.go
@@ -561,7 +561,7 @@ func (i *HostInfo) TryPromoteBest(preferredRanges []*net.IPNet, ifce *Interface)
 		}
 
 		i.nextLHQuery.Store(now + ifce.reQueryWait.Load())
-		ifce.lightHouse.QueryServer(i.vpnIp, ifce)
+		ifce.lightHouse.QueryServer(i.vpnIp)
 	}
 }
 

--- a/inside.go
+++ b/inside.go
@@ -288,7 +288,7 @@ func (f *Interface) sendNoMetrics(t header.MessageType, st header.MessageSubType
 	if t != header.CloseTunnel && hostinfo.lastRebindCount != f.rebindCount {
 		//NOTE: there is an update hole if a tunnel isn't used and exactly 256 rebinds occur before the tunnel is
 		// finally used again. This tunnel would eventually be torn down and recreated if this action didn't help.
-		f.lightHouse.QueryServer(hostinfo.vpnIp, f)
+		f.lightHouse.QueryServer(hostinfo.vpnIp)
 		hostinfo.lastRebindCount = f.rebindCount
 		if f.l.Level >= logrus.DebugLevel {
 			f.l.WithField("vpnIp", hostinfo.vpnIp).Debug("Lighthouse update triggered for punch due to rebind counter")

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -466,14 +466,7 @@ func (lh *LightHouse) QueryServer(ip iputil.VpnIp) {
 	if lh.amLighthouse {
 		return
 	}
-	select {
-	case lh.queryChan <- ip:
-		return
-	default:
-		if lh.l.Level >= logrus.DebugLevel {
-			lh.l.WithField("vpnIp", ip).Debug("Lighthouse query buffer was full, dropping request")
-		}
-	}
+	lh.queryChan <- ip
 }
 
 func (lh *LightHouse) QueryCache(ip iputil.VpnIp) *RemoteList {

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -463,9 +463,11 @@ func (lh *LightHouse) Query(ip iputil.VpnIp) *RemoteList {
 
 // QueryServer is asynchronous so no reply should be expected
 func (lh *LightHouse) QueryServer(ip iputil.VpnIp) {
-	if lh.amLighthouse {
+	// Don't put lighthouse ips in the query channel because we can't query lighthouses about lighthouses
+	if lh.amLighthouse || lh.IsLighthouseIP(ip) {
 		return
 	}
+
 	lh.queryChan <- ip
 }
 

--- a/ssh.go
+++ b/ssh.go
@@ -518,7 +518,7 @@ func sshQueryLighthouse(ifce *Interface, fs interface{}, a []string, w sshd.Stri
 	}
 
 	var cm *CacheMap
-	rl := ifce.lightHouse.Query(vpnIp, ifce)
+	rl := ifce.lightHouse.Query(vpnIp)
 	if rl != nil {
 		cm = rl.CopyCache()
 	}


### PR DESCRIPTION
@wadey got a deadlock with v1.8.0 and was able to pull the stack trace. `HandshakeManager.GetOrHandshake` can be re-entrant via `HandshakeManager.StartHandshake` through a call to `hm.lightHouse.QueryServer()`. Aside from the double read lock on the main hostmap not being great, the `ConnectionManager` go routine had fired between the 1st and 2nd calls to `HandshakeManager.GetOrHandshake` and was waiting on a write lock for the main hostmap while blocking any future read locks. 

This is fixed by adding a channel and handling the actual lighthouse queries in a go routine. Should also speed up the hot path when many handshakes are occurring.

There is also a case when a tunnel is being tested and is using a relay for a double read lock in `ConnectionManager`.

This is fixed by turning the test packet into a traffic decision result and handling outside of the read lock.

My primary concern is in handling the `QueryServer` writes on a nonblocking buffered channel. I think we will want to block when full but I am leaving as nonblocking for now to review.