### PR TITLE
Support inlined sshd host key

### DIFF
--- a/ssh.go
+++ b/ssh.go
@@ -90,14 +90,19 @@ func configSSH(l *logrus.Logger, ssh *sshd.SSHServer, c *config.C) (func(), erro
 	}
 
 	//TODO: no good way to reload this right now
-	hostKeyFile := c.GetString("sshd.host_key", "")
-	if hostKeyFile == "" {
+	hostKeyPathOrKey := c.GetString("sshd.host_key", "")
+	if hostKeyPathOrKey == "" {
 		return nil, fmt.Errorf("sshd.host_key must be provided")
 	}
 
-	hostKeyBytes, err := os.ReadFile(hostKeyFile)
-	if err != nil {
-		return nil, fmt.Errorf("error while loading sshd.host_key file: %s", err)
+	var hostKeyBytes []byte
+	if strings.Contains(hostKeyPathOrKey, "-----BEGIN") {
+		hostKeyBytes = []byte(hostKeyPathOrKey)
+	} else {
+		hostKeyBytes, err = os.ReadFile(hostKeyPathOrKey)
+		if err != nil {
+			return nil, fmt.Errorf("error while loading sshd.host_key file: %s", err)
+		}
 	}
 
 	err = ssh.SetHostKey(hostKeyBytes)


### PR DESCRIPTION
Make `sshd.host_key` accept inlined key like `pki.ca`.

``` yaml
sshd:
  host_key: |
    -----BEGIN OPENSSH PRIVATE KEY-----
    ...
```