### PR TITLE
fix multiple routines when listen.port is zero

### DIFF
--- a/main.go
+++ b/main.go
@@ -170,6 +170,16 @@ func Main(c *config.C, configTest bool, buildVersion string, logger *logrus.Logg
 			}
 			udpServer.ReloadConfig(c)
 			udpConns[i] = udpServer
+
+			// If port is dynamic, discover it before the next pass through the for loop
+			// This way all routines will use the same port correctly
+			if port == 0 {
+				uPort, err := udpServer.LocalAddr()
+				if err != nil {
+					return nil, util.NewContextualError("Failed to get listening port", nil, err)
+				}
+				port = int(uPort.Port)
+			}
 		}
 	}
 


### PR DESCRIPTION
This used to work correctly when the multiple routines work was first added in #382, but an important part to discover the listen port before opening the other listeners on the same socket was lost in this PR: #653.

This change should fix the regression and allow multiple routines to work correctly when listen.port is set to `0`.

Thanks to @rawdigits for tracking down and discovering this regression.