### PR TITLE
Return full error context from ContextualError.Error()

### DIFF
--- a/util/error.go
+++ b/util/error.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 )
@@ -40,7 +41,7 @@ func (ce *ContextualError) Error() string {
 	if ce.RealError == nil {
 		return ce.Context
 	}
-	return ce.RealError.Error()
+	return fmt.Errorf("%s (%v): %w", ce.Context, ce.Fields, ce.RealError).Error()
 }
 
 func (ce *ContextualError) Unwrap() error {


### PR DESCRIPTION
Fix #1068 to provide more information from the `Error()` method of ContextualError objects.

I manually tested to force inject an error and context into Nebula, and printed the error from a client program.

With this change, a full error message is output:
`WARN[2024-01-30T11:43:05-05:00] Failed to initialize Nebula                   error="failed to start nebula: Failed to get a tun/tap device due to manufactured error (map[]): lol wat"`

 Without this change, only the underlying error is output:
`WARN[2024-01-30T11:43:30-05:00] Failed to initialize Nebula                   error="failed to start nebula: lol wat"`

I'm on the fence wrt the extra fields.