### PR TITLE
Increase default `lookup_timeout` from 250ms to 5s

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -33,7 +33,7 @@ static_host_map:
   #network: ip4
 
   # lookup_timeout is the DNS query timeout.
-  #lookup_timeout: 250ms
+  #lookup_timeout: 5s
 
 lighthouse:
   # am_lighthouse is used to enable lighthouse functionality for a node. This should ONLY be true on nodes

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -383,7 +383,7 @@ func getStaticMapCadence(c *config.C) (time.Duration, error) {
 }
 
 func getStaticMapLookupTimeout(c *config.C) (time.Duration, error) {
-	lookupTimeout := c.GetString("static_map.lookup_timeout", "250ms")
+	lookupTimeout := c.GetString("static_map.lookup_timeout", "5s")
 	d, err := time.ParseDuration(lookupTimeout)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
I get a lot of errors in the logs like these, particularly when starting the service for the first time:

```
ERRO[0000] DNS resolution failed for static_map host     error="lookup example.com: i/o timeout" hostname=example.com network=ip4
```

When using multiple lighthouses some of them resolve ok, others timeout, and eventually they all resolve on future loops. The DNS resolution is working but the timeout is sometimes being reached before it has a time to finish. 

The timeout for these requests is current set at `250ms`. This is extremely low and can't see any reason why.

Here are some example defaults from elsewhere for some precedent:

https://github.com/istio/istio/blob/ac901c3ed1a2455705709bd5e81df781d7a63083/pilot/pkg/util/network/ip.go#L145
https://github.com/tailscale/tailscale/blob/a4a909a20b0f868de4870294e200e803f61589f7/ipn/localapi/debugderp.go#L161

This PR raises the default timeout to 5s. 