### PR TITLE
Exploration of making config loading more errorful

### DIFF
--- a/allow_list.go
+++ b/allow_list.go
@@ -220,13 +220,16 @@ func getAllowListInterfaces(k string, v interface{}) ([]AllowListNameRule, error
 
 func getRemoteAllowRanges(c *config.C, k string) (*cidr.Tree6[*AllowList], error) {
 	value := c.Get(k)
-	if value == nil {
+	if value.IsError() {
+		return nil, value.Error()
+	}
+	if value.Unwrap() == nil {
 		return nil, nil
 	}
 
 	remoteAllowRanges := cidr.NewTree6[*AllowList]()
 
-	rawMap, ok := value.(map[interface{}]interface{})
+	rawMap, ok := value.Unwrap().(map[interface{}]interface{})
 	if !ok {
 		return nil, fmt.Errorf("config `%s` has invalid type: %T", k, value)
 	}

--- a/allow_list.go
+++ b/allow_list.go
@@ -73,11 +73,14 @@ func NewRemoteAllowListFromConfig(c *config.C, k, rangesKey string) (*RemoteAllo
 // for this key. This allows parsing of special values like `interfaces`.
 func newAllowListFromConfig(c *config.C, k string, handleKey func(key string, value interface{}) (bool, error)) (*AllowList, error) {
 	r := c.Get(k)
-	if r == nil {
+	if r.IsError() {
+		return nil, r.Error()
+	}
+	if r.Unwrap() == nil {
 		return nil, nil
 	}
 
-	return newAllowList(k, r, handleKey)
+	return newAllowList(k, r.Unwrap(), handleKey)
 }
 
 // If the handleKey func returns true, the rest of the parsing is skipped

--- a/allow_list.go
+++ b/allow_list.go
@@ -72,15 +72,13 @@ func NewRemoteAllowListFromConfig(c *config.C, k, rangesKey string) (*RemoteAllo
 // If the handleKey func returns true, the rest of the parsing is skipped
 // for this key. This allows parsing of special values like `interfaces`.
 func newAllowListFromConfig(c *config.C, k string, handleKey func(key string, value interface{}) (bool, error)) (*AllowList, error) {
-	r := c.Get(k)
-	if r.IsError() {
-		return nil, r.Error()
-	}
-	if r.Unwrap() == nil {
+	r := c.Get(k).UnwrapOrDefault()
+
+	if r == nil {
 		return nil, nil
 	}
 
-	return newAllowList(k, r.Unwrap(), handleKey)
+	return newAllowList(k, r, handleKey)
 }
 
 // If the handleKey func returns true, the rest of the parsing is skipped
@@ -222,17 +220,15 @@ func getAllowListInterfaces(k string, v interface{}) ([]AllowListNameRule, error
 }
 
 func getRemoteAllowRanges(c *config.C, k string) (*cidr.Tree6[*AllowList], error) {
-	value := c.Get(k)
-	if value.IsError() {
-		return nil, value.Error()
-	}
-	if value.Unwrap() == nil {
+	value := c.Get(k).UnwrapOrDefault()
+
+	if value == nil {
 		return nil, nil
 	}
 
 	remoteAllowRanges := cidr.NewTree6[*AllowList]()
 
-	rawMap, ok := value.Unwrap().(map[interface{}]interface{})
+	rawMap, ok := value.(map[interface{}]interface{})
 	if !ok {
 		return nil, fmt.Errorf("config `%s` has invalid type: %T", k, value)
 	}

--- a/calculated_remote.go
+++ b/calculated_remote.go
@@ -52,17 +52,15 @@ func (c *calculatedRemote) Apply(ip iputil.VpnIp) *Ip4AndPort {
 }
 
 func NewCalculatedRemotesFromConfig(c *config.C, k string) (*cidr.Tree4[[]*calculatedRemote], error) {
-	value := c.Get(k)
-	if value.IsError() {
-		return nil, value.Error()
-	}
-	if value.Unwrap() == nil {
+	value := c.Get(k).UnwrapOrDefault()
+
+	if value == nil {
 		return nil, nil
 	}
 
 	calculatedRemotes := cidr.NewTree4[[]*calculatedRemote]()
 
-	rawMap, ok := value.Unwrap().(map[any]any)
+	rawMap, ok := value.(map[any]any)
 	if !ok {
 		return nil, fmt.Errorf("config `%s` has invalid type: %T", k, value)
 	}

--- a/calculated_remote.go
+++ b/calculated_remote.go
@@ -53,13 +53,16 @@ func (c *calculatedRemote) Apply(ip iputil.VpnIp) *Ip4AndPort {
 
 func NewCalculatedRemotesFromConfig(c *config.C, k string) (*cidr.Tree4[[]*calculatedRemote], error) {
 	value := c.Get(k)
-	if value == nil {
+	if value.IsError() {
+		return nil, value.Error()
+	}
+	if value.Unwrap() == nil {
 		return nil, nil
 	}
 
 	calculatedRemotes := cidr.NewTree4[[]*calculatedRemote]()
 
-	rawMap, ok := value.(map[any]any)
+	rawMap, ok := value.Unwrap().(map[any]any)
 	if !ok {
 		return nil, fmt.Errorf("config `%s` has invalid type: %T", k, value)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -102,8 +102,8 @@ func (c *C) HasChanged(k string) bool {
 		ov = c.oldSettings
 		k = "all settings"
 	} else {
-		nv = c.get(k, c.Settings)
-		ov = c.get(k, c.oldSettings)
+		nv = c.get(k, c.Settings).Unwrap()
+		ov = c.get(k, c.oldSettings).Unwrap()
 	}
 
 	newVals, err := yaml.Marshal(nv)
@@ -192,7 +192,7 @@ func (c *C) GetString(k string) goresult.Result[string] {
 		return goresult.Error[string](r.Error())
 	}
 
-	return goresult.Ok(fmt.Sprintf("%v", r))
+	return goresult.Ok(fmt.Sprintf("%v", r.Unwrap()))
 }
 
 // GetStringSlice will get the slice of strings for k or return an error
@@ -262,15 +262,16 @@ func (c *C) GetBool(k string) goresult.Result[bool] {
 	if r.IsError() {
 		return goresult.Error[bool](r.Error())
 	}
-	v, err := strconv.ParseBool(strings.ToLower(r.Unwrap()))
+	x := strings.ToLower(r.Unwrap())
+	v, err := strconv.ParseBool(x)
 	if err != nil {
-		switch r.Unwrap() {
+		switch x {
 		case "y", "yes":
 			return goresult.Ok(true)
 		case "n", "no":
 			return goresult.Ok(false)
 		}
-		return goresult.Error[bool](errors.New("failed to parse"))
+		return goresult.Error[bool](err)
 	}
 
 	return goresult.Ok(v)

--- a/config/config.go
+++ b/config/config.go
@@ -102,8 +102,8 @@ func (c *C) HasChanged(k string) bool {
 		ov = c.oldSettings
 		k = "all settings"
 	} else {
-		nv = c.get(k, c.Settings).Unwrap()
-		ov = c.get(k, c.oldSettings).Unwrap()
+		nv = c.get(k, c.Settings).UnwrapOrDefault()
+		ov = c.get(k, c.oldSettings).UnwrapOrDefault()
 	}
 
 	newVals, err := yaml.Marshal(nv)

--- a/config/config.go
+++ b/config/config.go
@@ -304,12 +304,12 @@ func (c *C) get(k string, v any) goresult.Result[any] {
 	for _, p := range parts {
 		m, ok := v.(map[any]any)
 		if !ok {
-			return goresult.Error[any](errors.New("failed to parse"))
+			return goresult.Error[any](errors.New("failed to parse config"))
 		}
 
 		v, ok = m[p]
 		if !ok {
-			return goresult.Error[any](errors.New("failed to parse"))
+			return goresult.Error[any](fmt.Errorf("did not find key \"%s\" in config", k))
 		}
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -57,7 +57,7 @@ func TestConfig_Get(t *testing.T) {
 	assert.EqualValues(t, inner, c.Get("firewall.outbound").Unwrap())
 
 	// test missing
-	assert.Equal(t, errors.New("failed to parse"), c.Get("firewall.nope").Error())
+	assert.Equal(t, errors.New("did not find key \"firewall.nope\" in config"), c.Get("firewall.nope").Error())
 }
 
 func TestConfig_GetStringSlice(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -48,50 +49,50 @@ func TestConfig_Get(t *testing.T) {
 	// test simple type
 	c := NewC(l)
 	c.Settings["firewall"] = map[interface{}]interface{}{"outbound": "hi"}
-	assert.Equal(t, "hi", c.Get("firewall.outbound"))
+	assert.Equal(t, "hi", c.Get("firewall.outbound").Unwrap())
 
 	// test complex type
 	inner := []map[interface{}]interface{}{{"port": "1", "code": "2"}}
 	c.Settings["firewall"] = map[interface{}]interface{}{"outbound": inner}
-	assert.EqualValues(t, inner, c.Get("firewall.outbound"))
+	assert.EqualValues(t, inner, c.Get("firewall.outbound").Unwrap())
 
 	// test missing
-	assert.Nil(t, c.Get("firewall.nope"))
+	assert.Equal(t, errors.New("failed to parse"), c.Get("firewall.nope").Error())
 }
 
 func TestConfig_GetStringSlice(t *testing.T) {
 	l := test.NewLogger()
 	c := NewC(l)
 	c.Settings["slice"] = []interface{}{"one", "two"}
-	assert.Equal(t, []string{"one", "two"}, c.GetStringSlice("slice", []string{}))
+	assert.Equal(t, []string{"one", "two"}, c.GetStringSlice("slice").UnwrapOr([]string{}))
 }
 
 func TestConfig_GetBool(t *testing.T) {
 	l := test.NewLogger()
 	c := NewC(l)
 	c.Settings["bool"] = true
-	assert.Equal(t, true, c.GetBool("bool", false))
+	assert.Equal(t, true, c.GetBool("bool").Unwrap())
 
 	c.Settings["bool"] = "true"
-	assert.Equal(t, true, c.GetBool("bool", false))
+	assert.Equal(t, true, c.GetBool("bool").Unwrap())
 
 	c.Settings["bool"] = false
-	assert.Equal(t, false, c.GetBool("bool", true))
+	assert.Equal(t, false, c.GetBool("bool").Unwrap())
 
 	c.Settings["bool"] = "false"
-	assert.Equal(t, false, c.GetBool("bool", true))
+	assert.Equal(t, false, c.GetBool("bool").Unwrap())
 
 	c.Settings["bool"] = "Y"
-	assert.Equal(t, true, c.GetBool("bool", false))
+	assert.Equal(t, true, c.GetBool("bool").Unwrap())
 
 	c.Settings["bool"] = "yEs"
-	assert.Equal(t, true, c.GetBool("bool", false))
+	assert.Equal(t, true, c.GetBool("bool").Unwrap())
 
 	c.Settings["bool"] = "N"
-	assert.Equal(t, false, c.GetBool("bool", true))
+	assert.Equal(t, false, c.GetBool("bool").Unwrap())
 
 	c.Settings["bool"] = "nO"
-	assert.Equal(t, false, c.GetBool("bool", true))
+	assert.Equal(t, false, c.GetBool("bool").Unwrap())
 }
 
 func TestConfig_HasChanged(t *testing.T) {

--- a/dns_server.go
+++ b/dns_server.go
@@ -129,7 +129,7 @@ func dnsMain(l *logrus.Logger, hostMap *HostMap, c *config.C) func() {
 }
 
 func getDnsServerAddr(c *config.C) string {
-	return c.GetString("lighthouse.dns.host", "") + ":" + strconv.Itoa(c.GetInt("lighthouse.dns.port", 53))
+	return c.GetString("lighthouse.dns.host").UnwrapOrDefault() + ":" + strconv.Itoa(c.GetInt("lighthouse.dns.port").UnwrapOr(53))
 }
 
 func startDns(l *logrus.Logger, c *config.C) {

--- a/firewall.go
+++ b/firewall.go
@@ -325,15 +325,13 @@ func AddFirewallRulesFromConfig(l *logrus.Logger, inbound bool, c *config.C, fw 
 		table = "firewall.outbound"
 	}
 
-	r := c.Get(table)
-	if r.IsError() {
-		return r.Error()
-	}
-	if r.Unwrap() == nil {
+	r := c.Get(table).UnwrapOrDefault()
+
+	if r == nil {
 		return nil
 	}
 
-	rs, ok := r.Unwrap().([]interface{})
+	rs, ok := r.([]interface{})
 	if !ok {
 		return fmt.Errorf("%s failed to parse, should be an array of rules", table)
 	}

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
+	github.com/siriusa51/goresult v0.0.0-20230806092515-9908fe5eb376 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3c
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/siriusa51/goresult v0.0.0-20230806092515-9908fe5eb376 h1:yfl2N7caPKzbGXmRzXJOnzySHYih1hcOB7XnO+vwDJk=
+github.com/siriusa51/goresult v0.0.0-20230806092515-9908fe5eb376/go.mod h1:qgCXsSAgtH31/ZmiSg6mQz9bXErrIrggP7X1aJ6PeyA=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=

--- a/interface.go
+++ b/interface.go
@@ -303,7 +303,7 @@ func (f *Interface) RegisterConfigChangeCallbacks(c *config.C) {
 func (f *Interface) reloadDisconnectInvalid(c *config.C) {
 	initial := c.InitialLoad()
 	if initial || c.HasChanged("pki.disconnect_invalid") {
-		f.disconnectInvalid.Store(c.GetBool("pki.disconnect_invalid", true))
+		f.disconnectInvalid.Store(c.GetBool("pki.disconnect_invalid").UnwrapOr(true))
 		if !initial {
 			f.l.Infof("pki.disconnect_invalid changed to %v", f.disconnectInvalid.Load())
 		}
@@ -351,7 +351,7 @@ func (f *Interface) reloadFirewall(c *config.C) {
 
 func (f *Interface) reloadSendRecvError(c *config.C) {
 	if c.InitialLoad() || c.HasChanged("listen.send_recv_error") {
-		stringValue := c.GetString("listen.send_recv_error", "always")
+		stringValue := c.GetString("listen.send_recv_error").UnwrapOr("always")
 
 		switch stringValue {
 		case "always":
@@ -361,7 +361,7 @@ func (f *Interface) reloadSendRecvError(c *config.C) {
 		case "private":
 			f.sendRecvErrorConfig = sendRecvErrorPrivate
 		default:
-			if c.GetBool("listen.send_recv_error", true) {
+			if c.GetBool("listen.send_recv_error").UnwrapOr(true) {
 				f.sendRecvErrorConfig = sendRecvErrorAlways
 			} else {
 				f.sendRecvErrorConfig = sendRecvErrorNever
@@ -375,19 +375,19 @@ func (f *Interface) reloadSendRecvError(c *config.C) {
 
 func (f *Interface) reloadMisc(c *config.C) {
 	if c.HasChanged("counters.try_promote") {
-		n := c.GetUint32("counters.try_promote", defaultPromoteEvery)
+		n := c.GetUint32("counters.try_promote").UnwrapOr(defaultPromoteEvery)
 		f.tryPromoteEvery.Store(n)
 		f.l.Info("counters.try_promote has changed")
 	}
 
 	if c.HasChanged("counters.requery_every_packets") {
-		n := c.GetUint32("counters.requery_every_packets", defaultReQueryEvery)
+		n := c.GetUint32("counters.requery_every_packets").UnwrapOr(defaultReQueryEvery)
 		f.reQueryEvery.Store(n)
 		f.l.Info("counters.requery_every_packets has changed")
 	}
 
 	if c.HasChanged("timers.requery_wait_duration") {
-		n := c.GetDuration("timers.requery_wait_duration", defaultReQueryWait)
+		n := c.GetDuration("timers.requery_wait_duration").UnwrapOr(defaultReQueryWait)
 		f.reQueryWait.Store(int64(n))
 		f.l.Info("timers.requery_wait_duration has changed")
 	}

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -181,7 +181,7 @@ func (lh *LightHouse) GetUpdateInterval() int64 {
 
 func (lh *LightHouse) reload(c *config.C, initial bool) error {
 	if initial || c.HasChanged("lighthouse.advertise_addrs") {
-		rawAdvAddrs := c.GetStringSlice("lighthouse.advertise_addrs").UnwrapOrDefault()
+		rawAdvAddrs := c.GetStringSlice("lighthouse.advertise_addrs").UnwrapOr([]string{})
 		advAddrs := make([]netIpAndPort, 0)
 
 		for i, rawAddr := range rawAdvAddrs {

--- a/logger.go
+++ b/logger.go
@@ -11,20 +11,20 @@ import (
 
 func configLogger(l *logrus.Logger, c *config.C) error {
 	// set up our logging level
-	logLevel, err := logrus.ParseLevel(strings.ToLower(c.GetString("logging.level", "info")))
+	logLevel, err := logrus.ParseLevel(strings.ToLower(c.GetString("logging.level").UnwrapOr("info")))
 	if err != nil {
 		return fmt.Errorf("%s; possible levels: %s", err, logrus.AllLevels)
 	}
 	l.SetLevel(logLevel)
 
-	disableTimestamp := c.GetBool("logging.disable_timestamp", false)
-	timestampFormat := c.GetString("logging.timestamp_format", "")
+	disableTimestamp := c.GetBool("logging.disable_timestamp").UnwrapOr(false)
+	timestampFormat := c.GetString("logging.timestamp_format").UnwrapOrDefault()
 	fullTimestamp := (timestampFormat != "")
 	if timestampFormat == "" {
 		timestampFormat = time.RFC3339
 	}
 
-	logFormat := strings.ToLower(c.GetString("logging.format", "text"))
+	logFormat := strings.ToLower(c.GetString("logging.format").UnwrapOr("text"))
 	switch logFormat {
 	case "text":
 		l.Formatter = &logrus.TextFormatter{

--- a/overlay/route.go
+++ b/overlay/route.go
@@ -38,15 +38,12 @@ func makeRouteTree(l *logrus.Logger, routes []Route, allowMTU bool) (*cidr.Tree4
 func parseRoutes(c *config.C, network *net.IPNet) ([]Route, error) {
 	var err error
 
-	r := c.Get("tun.routes")
-	if r.IsError() {
-		return nil, r.Error()
-	}
-	if r.Unwrap() == nil {
+	r := c.Get("tun.routes").UnwrapOrDefault()
+	if r == nil {
 		return []Route{}, nil
 	}
 
-	rawRoutes, ok := r.Unwrap().([]interface{})
+	rawRoutes, ok := r.([]interface{})
 	if !ok {
 		return nil, fmt.Errorf("tun.routes is not an array")
 	}
@@ -112,15 +109,12 @@ func parseRoutes(c *config.C, network *net.IPNet) ([]Route, error) {
 func parseUnsafeRoutes(c *config.C, network *net.IPNet) ([]Route, error) {
 	var err error
 
-	r := c.Get("tun.unsafe_routes")
-	if r.IsError() {
-		return nil, r.Error()
-	}
-	if r.Unwrap() == nil {
+	r := c.Get("tun.unsafe_routes").UnwrapOrDefault()
+	if r == nil {
 		return []Route{}, nil
 	}
 
-	rawRoutes, ok := r.Unwrap().([]interface{})
+	rawRoutes, ok := r.([]interface{})
 	if !ok {
 		return nil, fmt.Errorf("tun.unsafe_routes is not an array")
 	}

--- a/overlay/route.go
+++ b/overlay/route.go
@@ -39,11 +39,14 @@ func parseRoutes(c *config.C, network *net.IPNet) ([]Route, error) {
 	var err error
 
 	r := c.Get("tun.routes")
-	if r == nil {
+	if r.IsError() {
+		return nil, r.Error()
+	}
+	if r.Unwrap() == nil {
 		return []Route{}, nil
 	}
 
-	rawRoutes, ok := r.([]interface{})
+	rawRoutes, ok := r.Unwrap().([]interface{})
 	if !ok {
 		return nil, fmt.Errorf("tun.routes is not an array")
 	}
@@ -110,11 +113,14 @@ func parseUnsafeRoutes(c *config.C, network *net.IPNet) ([]Route, error) {
 	var err error
 
 	r := c.Get("tun.unsafe_routes")
-	if r == nil {
+	if r.IsError() {
+		return nil, r.Error()
+	}
+	if r.Unwrap() == nil {
 		return []Route{}, nil
 	}
 
-	rawRoutes, ok := r.([]interface{})
+	rawRoutes, ok := r.Unwrap().([]interface{})
 	if !ok {
 		return nil, fmt.Errorf("tun.unsafe_routes is not an array")
 	}

--- a/overlay/tun.go
+++ b/overlay/tun.go
@@ -25,20 +25,20 @@ func NewDeviceFromConfig(c *config.C, l *logrus.Logger, tunCidr *net.IPNet, rout
 	routes = append(routes, unsafeRoutes...)
 
 	switch {
-	case c.GetBool("tun.disabled", false):
-		tun := newDisabledTun(tunCidr, c.GetInt("tun.tx_queue", 500), c.GetBool("stats.message_metrics", false), l)
+	case c.GetBool("tun.disabled").UnwrapOr(false):
+		tun := newDisabledTun(tunCidr, c.GetInt("tun.tx_queue").UnwrapOr(500), c.GetBool("stats.message_metrics").UnwrapOr(false), l)
 		return tun, nil
 
 	default:
 		return newTun(
 			l,
-			c.GetString("tun.dev", ""),
+			c.GetString("tun.dev").UnwrapOrDefault(),
 			tunCidr,
-			c.GetInt("tun.mtu", DefaultMTU),
+			c.GetInt("tun.mtu").UnwrapOr(DefaultMTU),
 			routes,
-			c.GetInt("tun.tx_queue", 500),
+			c.GetInt("tun.tx_queue").UnwrapOr(500),
 			routines > 1,
-			c.GetBool("tun.use_system_route_table", false),
+			c.GetBool("tun.use_system_route_table").UnwrapOr(false),
 		)
 	}
 }
@@ -59,10 +59,10 @@ func NewFdDeviceFromConfig(fd *int) DeviceFactory {
 			l,
 			*fd,
 			tunCidr,
-			c.GetInt("tun.mtu", DefaultMTU),
+			c.GetInt("tun.mtu").UnwrapOr(DefaultMTU),
 			routes,
-			c.GetInt("tun.tx_queue", 500),
-			c.GetBool("tun.use_system_route_table", false),
+			c.GetInt("tun.tx_queue").UnwrapOr(500),
+			c.GetBool("tun.use_system_route_table").UnwrapOr(false),
 		)
 
 	}

--- a/pki.go
+++ b/pki.go
@@ -143,7 +143,7 @@ func newCertStateFromConfig(c *config.C) (*CertState, error) {
 	var pemPrivateKey []byte
 	var err error
 
-	privPathOrPEM := c.GetString("pki.key", "")
+	privPathOrPEM := c.GetString("pki.key").UnwrapOrDefault()
 	if privPathOrPEM == "" {
 		return nil, errors.New("no pki.key path or PEM data provided")
 	}
@@ -166,7 +166,7 @@ func newCertStateFromConfig(c *config.C) (*CertState, error) {
 
 	var rawCert []byte
 
-	pubPathOrPEM := c.GetString("pki.cert", "")
+	pubPathOrPEM := c.GetString("pki.cert").UnwrapOrDefault()
 	if pubPathOrPEM == "" {
 		return nil, errors.New("no pki.cert path or PEM data provided")
 	}
@@ -206,7 +206,7 @@ func loadCAPoolFromConfig(l *logrus.Logger, c *config.C) (*cert.NebulaCAPool, er
 	var rawCA []byte
 	var err error
 
-	caPathOrPEM := c.GetString("pki.ca", "")
+	caPathOrPEM := c.GetString("pki.ca").UnwrapOrDefault()
 	if caPathOrPEM == "" {
 		return nil, errors.New("no pki.ca path or PEM data provided")
 	}
@@ -239,7 +239,7 @@ func loadCAPoolFromConfig(l *logrus.Logger, c *config.C) (*cert.NebulaCAPool, er
 		return nil, fmt.Errorf("error while adding CA certificate to CA trust store: %s", err)
 	}
 
-	for _, fp := range c.GetStringSlice("pki.blocklist", []string{}) {
+	for _, fp := range c.GetStringSlice("pki.blocklist").UnwrapOrDefault() {
 		l.WithField("fingerprint", fp).Info("Blocklisting cert")
 		caPool.BlocklistFingerprint(fp)
 	}

--- a/punchy.go
+++ b/punchy.go
@@ -32,10 +32,10 @@ func (p *Punchy) reload(c *config.C, initial bool) {
 	if initial {
 		var yes bool
 		if c.IsSet("punchy.punch") {
-			yes = c.GetBool("punchy.punch", false)
+			yes = c.GetBool("punchy.punch").UnwrapOr(false)
 		} else {
 			// Deprecated fallback
-			yes = c.GetBool("punchy", false)
+			yes = c.GetBool("punchy").UnwrapOr(false)
 		}
 
 		p.punch.Store(yes)
@@ -53,10 +53,10 @@ func (p *Punchy) reload(c *config.C, initial bool) {
 	if initial || c.HasChanged("punchy.respond") || c.HasChanged("punch_back") {
 		var yes bool
 		if c.IsSet("punchy.respond") {
-			yes = c.GetBool("punchy.respond", false)
+			yes = c.GetBool("punchy.respond").UnwrapOr(false)
 		} else {
 			// Deprecated fallback
-			yes = c.GetBool("punch_back", false)
+			yes = c.GetBool("punch_back").UnwrapOr(false)
 		}
 
 		p.respond.Store(yes)
@@ -68,21 +68,21 @@ func (p *Punchy) reload(c *config.C, initial bool) {
 
 	//NOTE: this will not apply to any in progress operations, only the next one
 	if initial || c.HasChanged("punchy.delay") {
-		p.delay.Store((int64)(c.GetDuration("punchy.delay", time.Second)))
+		p.delay.Store((int64)(c.GetDuration("punchy.delay").UnwrapOr(time.Second)))
 		if !initial {
 			p.l.Infof("punchy.delay changed to %s", p.GetDelay())
 		}
 	}
 
 	if initial || c.HasChanged("punchy.target_all_remotes") {
-		p.punchEverything.Store(c.GetBool("punchy.target_all_remotes", false))
+		p.punchEverything.Store(c.GetBool("punchy.target_all_remotes").UnwrapOr(false))
 		if !initial {
 			p.l.WithField("target_all_remotes", p.GetTargetEverything()).Info("punchy.target_all_remotes changed")
 		}
 	}
 
 	if initial || c.HasChanged("punchy.respond_delay") {
-		p.respondDelay.Store((int64)(c.GetDuration("punchy.respond_delay", 5*time.Second)))
+		p.respondDelay.Store((int64)(c.GetDuration("punchy.respond_delay").UnwrapOr(5 * time.Second)))
 		if !initial {
 			p.l.Infof("punchy.respond_delay changed to %s", p.GetRespondDelay())
 		}

--- a/relay_manager.go
+++ b/relay_manager.go
@@ -35,7 +35,7 @@ func NewRelayManager(ctx context.Context, l *logrus.Logger, hostmap *HostMap, c 
 
 func (rm *relayManager) reload(c *config.C, initial bool) error {
 	if initial || c.HasChanged("relay.am_relay") {
-		rm.setAmRelay(c.GetBool("relay.am_relay", false))
+		rm.setAmRelay(c.GetBool("relay.am_relay").UnwrapOr(false))
 	}
 	return nil
 }

--- a/stats.go
+++ b/stats.go
@@ -23,14 +23,14 @@ import (
 // is needed to serve stats, it returns a func to handle that work. If no
 // work is needed, it'll return nil. On failure, it returns nil, error.
 func startStats(l *logrus.Logger, c *config.C, buildVersion string, configTest bool) (func(), error) {
-	mType := c.GetString("stats.type", "")
+	mType := c.GetString("stats.type").UnwrapOrDefault()
 	if mType == "" || mType == "none" {
 		return nil, nil
 	}
 
-	interval := c.GetDuration("stats.interval", 0)
+	interval := c.GetDuration("stats.interval").UnwrapOr(0)
 	if interval == 0 {
-		return nil, fmt.Errorf("stats.interval was an invalid duration: %s", c.GetString("stats.interval", ""))
+		return nil, fmt.Errorf("stats.interval was an invalid duration: %s", c.GetString("stats.interval").UnwrapOrDefault())
 	}
 
 	var startFn func()
@@ -60,13 +60,13 @@ func startStats(l *logrus.Logger, c *config.C, buildVersion string, configTest b
 }
 
 func startGraphiteStats(l *logrus.Logger, i time.Duration, c *config.C, configTest bool) error {
-	proto := c.GetString("stats.protocol", "tcp")
-	host := c.GetString("stats.host", "")
+	proto := c.GetString("stats.protocol").UnwrapOr("tcp")
+	host := c.GetString("stats.host").UnwrapOrDefault()
 	if host == "" {
 		return errors.New("stats.host can not be empty")
 	}
 
-	prefix := c.GetString("stats.prefix", "nebula")
+	prefix := c.GetString("stats.prefix").UnwrapOr("nebula")
 	addr, err := net.ResolveTCPAddr(proto, host)
 	if err != nil {
 		return fmt.Errorf("error while setting up graphite sink: %s", err)
@@ -80,15 +80,15 @@ func startGraphiteStats(l *logrus.Logger, i time.Duration, c *config.C, configTe
 }
 
 func startPrometheusStats(l *logrus.Logger, i time.Duration, c *config.C, buildVersion string, configTest bool) (func(), error) {
-	namespace := c.GetString("stats.namespace", "")
-	subsystem := c.GetString("stats.subsystem", "")
+	namespace := c.GetString("stats.namespace").UnwrapOrDefault()
+	subsystem := c.GetString("stats.subsystem").UnwrapOrDefault()
 
-	listen := c.GetString("stats.listen", "")
+	listen := c.GetString("stats.listen").UnwrapOrDefault()
 	if listen == "" {
 		return nil, fmt.Errorf("stats.listen should not be empty")
 	}
 
-	path := c.GetString("stats.path", "")
+	path := c.GetString("stats.path").UnwrapOrDefault()
 	if path == "" {
 		return nil, fmt.Errorf("stats.path should not be empty")
 	}

--- a/udp/udp_linux.go
+++ b/udp/udp_linux.go
@@ -285,7 +285,7 @@ func (u *StdConn) writeTo4(b []byte, addr *Addr) error {
 }
 
 func (u *StdConn) ReloadConfig(c *config.C) {
-	b := c.GetInt("listen.read_buffer", 0)
+	b := c.GetInt("listen.read_buffer").UnwrapOr(0)
 	if b > 0 {
 		err := u.SetRecvBuffer(b)
 		if err == nil {
@@ -300,7 +300,7 @@ func (u *StdConn) ReloadConfig(c *config.C) {
 		}
 	}
 
-	b = c.GetInt("listen.write_buffer", 0)
+	b = c.GetInt("listen.write_buffer").UnwrapOr(0)
 	if b > 0 {
 		err := u.SetSendBuffer(b)
 		if err == nil {


### PR DESCRIPTION
This PR pulls in https://github.com/siriusa51/goresult to allow returning an error from config-loading functions while also sticking with our existing behavior of setting a default value for options that fail to parse.

This has the advantage of allowing us to bubble up parse errors and to eventually make the config loading more strict, to provide better feedback when loading your `config.yml` and to better reflect the actual loaded config in nebula w.r.t. the on-disk representation.