### PR TITLE
Add support for SSH CAs

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -181,12 +181,15 @@ punchy:
   # A file containing the ssh host private key to use
   # A decent way to generate one: ssh-keygen -t ed25519 -f ssh_host_ed25519_key -N "" < /dev/null
   #host_key: ./ssh_host_ed25519_key
-  # A file containing a list of authorized public keys
+  # Authorized users and their public keys
   #authorized_users:
     #- user: steeeeve
       # keys can be an array of strings or single string
       #keys:
         #- "ssh public key string"
+  # Trusted SSH CA public keys. These are the public keys of the CAs that are allowed to sign SSH keys for access.
+  #trusted_cas:
+    #- "ssh public key string"
 
 # EXPERIMENTAL: relay support for networks that can't establish direct connections.
 relay:

--- a/ssh.go
+++ b/ssh.go
@@ -110,6 +110,15 @@ func configSSH(l *logrus.Logger, ssh *sshd.SSHServer, c *config.C) (func(), erro
 		return nil, fmt.Errorf("error while adding sshd.host_key: %s", err)
 	}
 
+	rawCAs := c.GetStringSlice("sshd.trusted_cas", []string{})
+	for _, caAuthorizedKey := range rawCAs {
+		err := ssh.AddTrustedCA(caAuthorizedKey)
+		if err != nil {
+			l.WithError(err).WithField("sshCA", caAuthorizedKey).Warn("SSH CA had an error, ignoring")
+			continue
+		}
+	}
+
 	rawKeys := c.Get("sshd.authorized_users")
 	keys, ok := rawKeys.([]interface{})
 	if ok {

--- a/sshd/server.go
+++ b/sshd/server.go
@@ -1,6 +1,7 @@
 package sshd
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"net"
@@ -15,8 +16,11 @@ type SSHServer struct {
 	config *ssh.ServerConfig
 	l      *logrus.Entry
 
+	certChecker *ssh.CertChecker
+
 	// Map of user -> authorized keys
 	trustedKeys map[string]map[string]bool
+	trustedCAs  []ssh.PublicKey
 
 	// List of available commands
 	helpCommand *Command
@@ -31,6 +35,7 @@ type SSHServer struct {
 
 // NewSSHServer creates a new ssh server rigged with default commands and prepares to listen
 func NewSSHServer(l *logrus.Entry) (*SSHServer, error) {
+
 	s := &SSHServer{
 		trustedKeys: make(map[string]map[string]bool),
 		l:           l,
@@ -38,8 +43,44 @@ func NewSSHServer(l *logrus.Entry) (*SSHServer, error) {
 		conns:       make(map[int]*session),
 	}
 
+	cc := ssh.CertChecker{
+		IsUserAuthority: func(auth ssh.PublicKey) bool {
+			for _, ca := range s.trustedCAs {
+				if bytes.Equal(ca.Marshal(), auth.Marshal()) {
+					return true
+				}
+				fmt.Println("didn't pass ca check")
+			}
+
+			return false
+		},
+		UserKeyFallback: func(c ssh.ConnMetadata, pubKey ssh.PublicKey) (*ssh.Permissions, error) {
+			pk := string(pubKey.Marshal())
+			fp := ssh.FingerprintSHA256(pubKey)
+
+			tk, ok := s.trustedKeys[c.User()]
+			if !ok {
+				return nil, fmt.Errorf("unknown user %s", c.User())
+			}
+
+			_, ok = tk[pk]
+			if !ok {
+				return nil, fmt.Errorf("unknown public key for %s (%s)", c.User(), fp)
+			}
+
+			return &ssh.Permissions{
+				// Record the public key used for authentication.
+				Extensions: map[string]string{
+					"fp":   fp,
+					"user": c.User(),
+				},
+			}, nil
+
+		},
+	}
+
 	s.config = &ssh.ServerConfig{
-		PublicKeyCallback: s.matchPubKey,
+		PublicKeyCallback: cc.Authenticate,
 		//TODO: AuthLogCallback: s.authAttempt,
 		//TODO: version string
 		ServerVersion: fmt.Sprintf("SSH-2.0-Nebula???"),
@@ -66,8 +107,24 @@ func (s *SSHServer) SetHostKey(hostPrivateKey []byte) error {
 	return nil
 }
 
+func (s *SSHServer) ClearTrustedCAs() {
+	s.trustedCAs = []ssh.PublicKey{}
+}
+
 func (s *SSHServer) ClearAuthorizedKeys() {
 	s.trustedKeys = make(map[string]map[string]bool)
+}
+
+// AddTrustedCA adds a trusted CA for user certificates
+func (s *SSHServer) AddTrustedCA(pubKey string) error {
+	pk, _, _, _, err := ssh.ParseAuthorizedKey([]byte(pubKey))
+	if err != nil {
+		return err
+	}
+
+	s.trustedCAs = append(s.trustedCAs, pk)
+	s.l.WithField("sshKey", pubKey).Info("Trusted CA key")
+	return nil
 }
 
 // AddAuthorizedKey adds an ssh public key for a user


### PR DESCRIPTION
This adds support for configuring SSH CAs. The SSH server will accept authentication for any valid certificate signed by an SSH CA, assuming that the user they connect with matches a principal in the certificate.

This would close #1076 if merged.