### PR TITLE
Fix "any" firewall rules for unsafe_routes

### DIFF
--- a/firewall.go
+++ b/firewall.go
@@ -876,13 +876,15 @@ func (fr *FirewallRule) match(p firewall.Packet, c *cert.NebulaCertificate) bool
 }
 
 func (flc *firewallLocalCIDR) addRule(f *Firewall, localIp *net.IPNet) error {
-	if localIp == nil || (localIp != nil && localIp.Contains(net.IPv4(0, 0, 0, 0))) {
+	if localIp == nil {
 		if !f.hasSubnets || f.defaultLocalCIDRAny {
 			flc.Any = true
 			return nil
 		}
 
 		localIp = f.assignedCIDR
+	} else if localIp.Contains(net.IPv4(0, 0, 0, 0)) {
+		flc.Any = true
 	}
 
 	flc.LocalCIDR.AddCIDR(localIp, struct{}{})


### PR DESCRIPTION
When `default_local_cidr_any` is set to false, firewall rules that don't include a `local_ip` are treated as though they have a `local_ip` set to the Nebula IP address of the host. This ensures that firewall rules targeting ports on the host don't inadvertently allow traffic to unsafe_routes.

However, the conditional was a big over-eager, and treated explicit `0.0.0.0/0` the same as missing `local_ip`. This was a bug - we want users to be able to create "any" rules explicitly.