### PR TITLE
avoid deadlock in lighthouse queryWorker

### DIFF
--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -376,11 +376,11 @@ func (hm *HandshakeManager) StartHandshake(vpnIp iputil.VpnIp, cacheCb func(*Han
 	hm.Lock()
 
 	if hh, ok := hm.vpnIps[vpnIp]; ok {
-		hm.Unlock()
 		// We are already trying to handshake with this vpn ip
 		if cacheCb != nil {
 			cacheCb(hh)
 		}
+		hm.Unlock()
 		return hh.hostinfo
 	}
 
@@ -422,9 +422,7 @@ func (hm *HandshakeManager) StartHandshake(vpnIp iputil.VpnIp, cacheCb func(*Han
 	}
 
 	hm.Unlock()
-	if !hm.lightHouse.IsLighthouseIP(vpnIp) {
-		hm.lightHouse.QueryServer(vpnIp)
-	}
+	hm.lightHouse.QueryServer(vpnIp)
 	return hostinfo
 }
 

--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -374,9 +374,9 @@ func (hm *HandshakeManager) GetOrHandshake(vpnIp iputil.VpnIp, cacheCb func(*Han
 // StartHandshake will ensure a handshake is currently being attempted for the provided vpn ip
 func (hm *HandshakeManager) StartHandshake(vpnIp iputil.VpnIp, cacheCb func(*HandshakeHostInfo)) *HostInfo {
 	hm.Lock()
-	defer hm.Unlock()
 
 	if hh, ok := hm.vpnIps[vpnIp]; ok {
+		hm.Unlock()
 		// We are already trying to handshake with this vpn ip
 		if cacheCb != nil {
 			cacheCb(hh)
@@ -421,7 +421,10 @@ func (hm *HandshakeManager) StartHandshake(vpnIp iputil.VpnIp, cacheCb func(*Han
 		}
 	}
 
-	hm.lightHouse.QueryServer(vpnIp)
+	hm.Unlock()
+	if !hm.lightHouse.IsLighthouseIP(vpnIp) {
+		hm.lightHouse.QueryServer(vpnIp)
+	}
 	return hostinfo
 }
 


### PR DESCRIPTION
If the lighthouse queryWorker tries to call StartHandshake on a lighthouse vpnIp, we can deadlock on the handshake_manager lock. This change drops the handshake_manager lock before we send on the lighthouse queryChan (which could block), and also avoids sending to the channel if this is a lighthouse IP itself.

we added this in #996 but removed it in #1044 