### PR TITLE
add PKCS11 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,24 @@ jobs:
     - name: End 2 end
       run: make e2evv GOEXPERIMENT=boringcrypto CGO_ENABLED=1
 
+  test-linux-pkcs11:
+    name: Build and test on linux with pkcs11
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '1.22'
+        check-latest: true
+
+    - name: Build
+      run: make bin-pkcs11
+
+    - name: Test
+      run: make test-pkcs11
+
   test:
     name: Build and test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@
 **.crt
 **.key
 **.pem
+**.pub
 !/examples/quickstart-vagrant/ansible/roles/nebula/files/vagrant-test-ca.key
 !/examples/quickstart-vagrant/ansible/roles/nebula/files/vagrant-test-ca.crt

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,7 @@ ALL_LINUX = linux-amd64 \
 	linux-mips-softfloat \
 	linux-riscv64 \
 	linux-loong64 \
-	linux-amd64-pkcs11 \
-	linux-arm64-pkcs11
+	linux-amd64-pkcs11
 
 ALL_FREEBSD = freebsd-amd64 \
 	freebsd-arm64

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,9 @@ ALL_LINUX = linux-amd64 \
 	linux-mips64le \
 	linux-mips-softfloat \
 	linux-riscv64 \
-        linux-loong64
+	linux-loong64 \
+	linux-amd64-pkcs11 \
+	linux-arm64-pkcs11
 
 ALL_FREEBSD = freebsd-amd64 \
 	freebsd-arm64
@@ -116,6 +118,9 @@ bin-freebsd-arm64: build/freebsd-arm64/nebula build/freebsd-arm64/nebula-cert
 bin-boringcrypto: build/linux-$(shell go env GOARCH)-boringcrypto/nebula build/linux-$(shell go env GOARCH)-boringcrypto/nebula-cert
 	mv $? .
 
+bin-pkcs11: build/linux-$(shell go env GOARCH)-pkcs11/nebula build/linux-$(shell go env GOARCH)-pkcs11/nebula-cert
+	mv $? .
+
 bin:
 	go build $(BUILD_ARGS) -ldflags "$(LDFLAGS)" -o ./nebula${NEBULA_CMD_SUFFIX} ${NEBULA_CMD_PATH}
 	go build $(BUILD_ARGS) -ldflags "$(LDFLAGS)" -o ./nebula-cert${NEBULA_CMD_SUFFIX} ./cmd/nebula-cert
@@ -133,6 +138,13 @@ build/linux-mips-softfloat/%: LDFLAGS += -s -w
 # boringcrypto
 build/linux-amd64-boringcrypto/%: GOENV += GOEXPERIMENT=boringcrypto CGO_ENABLED=1
 build/linux-arm64-boringcrypto/%: GOENV += GOEXPERIMENT=boringcrypto CGO_ENABLED=1
+
+# pkcs11
+build/linux-amd64-pkcs11/%: BUILD_ARGS += -tags pkcs11
+build/linux-amd64-pkcs11/%: CGO_ENABLED=1
+build/linux-arm64-pkcs11/%: BUILD_ARGS += -tags pkcs11
+build/linux-arm64-pkcs11/%: CGO_ENABLED=1
+build/linux-arm64-pkcs11/%: GOENV += CC=aarch64-linux-gnu-gcc
 
 build/%/nebula: .FORCE
 	GOOS=$(firstword $(subst -, , $*)) \

--- a/cert/cert.go
+++ b/cert/cert.go
@@ -41,8 +41,9 @@ const (
 )
 
 type NebulaCertificate struct {
-	Details   NebulaCertificateDetails
-	Signature []byte
+	Details      NebulaCertificateDetails
+	Pkcs11Backed bool
+	Signature    []byte
 
 	// the cached hex string of the calculated sha256sum
 	// for VerifyWithCache
@@ -693,6 +694,9 @@ func (nc *NebulaCertificate) CheckRootConstrains(signer *NebulaCertificate) erro
 
 // VerifyPrivateKey checks that the public key in the Nebula certificate and a supplied private key match
 func (nc *NebulaCertificate) VerifyPrivateKey(curve Curve, key []byte) error {
+	if nc.Pkcs11Backed {
+		return nil //todo!
+	}
 	if curve != nc.Details.Curve {
 		return fmt.Errorf("curve in cert and private key supplied don't match")
 	}

--- a/cmd/nebula-cert/ca_test.go
+++ b/cmd/nebula-cert/ca_test.go
@@ -52,8 +52,7 @@ func Test_caHelp(t *testing.T) {
 			"    \tOptional: path to write the private key to (default \"ca.key\")\n"+
 			"  -out-qr string\n"+
 			"    \tOptional: output a qr code image (png) of the certificate\n"+
-			optionalPkcs11String("  -pkcs11 string\n"+
-			"    \tOptional: PKCS#11 URI to an existing private key\n")+
+			optionalPkcs11String("  -pkcs11 string\n    \tOptional: PKCS#11 URI to an existing private key\n")+
 			"  -subnets string\n"+
 			"    \tOptional: comma separated list of ipv4 address and network in CIDR notation. This will limit which ipv4 addresses and networks subordinate certs can use in subnets\n",
 		ob.String(),

--- a/cmd/nebula-cert/ca_test.go
+++ b/cmd/nebula-cert/ca_test.go
@@ -52,6 +52,8 @@ func Test_caHelp(t *testing.T) {
 			"    \tOptional: path to write the private key to (default \"ca.key\")\n"+
 			"  -out-qr string\n"+
 			"    \tOptional: output a qr code image (png) of the certificate\n"+
+			optionalPkcs11String("  -pkcs11 string\n"+
+			"    \tOptional: PKCS#11 URI to an existing private key\n")+
 			"  -subnets string\n"+
 			"    \tOptional: comma separated list of ipv4 address and network in CIDR notation. This will limit which ipv4 addresses and networks subordinate certs can use in subnets\n",
 		ob.String(),

--- a/cmd/nebula-cert/keygen.go
+++ b/cmd/nebula-cert/keygen.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 
+	"github.com/slackhq/nebula/pkclient"
+
 	"github.com/slackhq/nebula/cert"
 )
 
@@ -13,8 +15,8 @@ type keygenFlags struct {
 	set        *flag.FlagSet
 	outKeyPath *string
 	outPubPath *string
-
-	curve *string
+	curve      *string
+	p11url     *string
 }
 
 func newKeygenFlags() *keygenFlags {
@@ -23,6 +25,7 @@ func newKeygenFlags() *keygenFlags {
 	cf.outPubPath = cf.set.String("out-pub", "", "Required: path to write the public key to")
 	cf.outKeyPath = cf.set.String("out-key", "", "Required: path to write the private key to")
 	cf.curve = cf.set.String("curve", "25519", "ECDH Curve (25519, P256)")
+	cf.p11url = cf.set.String("pkcs11", "", "Optional PKCS11 URL to an existing private key to obtain a nebula public key from")
 	return &cf
 }
 
@@ -33,10 +36,7 @@ func keygen(args []string, out io.Writer, errOut io.Writer) error {
 		return err
 	}
 
-	if err := mustFlagString("out-key", cf.outKeyPath); err != nil {
-		return err
-	}
-	if err := mustFlagString("out-pub", cf.outPubPath); err != nil {
+	if err = mustFlagString("out-pub", cf.outPubPath); err != nil {
 		return err
 	}
 
@@ -53,11 +53,27 @@ func keygen(args []string, out io.Writer, errOut io.Writer) error {
 		return fmt.Errorf("invalid curve: %s", *cf.curve)
 	}
 
-	err = os.WriteFile(*cf.outKeyPath, cert.MarshalPrivateKey(curve, rawPriv), 0600)
-	if err != nil {
-		return fmt.Errorf("error while writing out-key: %s", err)
+	if len(*cf.p11url) == 0 {
+		if err = mustFlagString("out-key", cf.outKeyPath); err != nil {
+			return err
+		}
+		err = os.WriteFile(*cf.outKeyPath, cert.MarshalPrivateKey(curve, rawPriv), 0600)
+		if err != nil {
+			return fmt.Errorf("error while writing out-key: %s", err)
+		}
+	} else {
+		client, err := pkclient.FromUrl(*cf.p11url)
+		if err != nil {
+			return fmt.Errorf("error while creating PKCS11 client: %w", err)
+		}
+		defer func(client *pkclient.PKClient) {
+			_ = client.Close()
+		}(client)
+		pub, err = client.GetPubKey()
+		if err != nil {
+			return fmt.Errorf("error while getting public key: %w", err)
+		}
 	}
-
 	err = os.WriteFile(*cf.outPubPath, cert.MarshalPublicKey(curve, pub), 0600)
 	if err != nil {
 		return fmt.Errorf("error while writing out-pub: %s", err)
@@ -72,7 +88,7 @@ func keygenSummary() string {
 
 func keygenHelp(out io.Writer) {
 	cf := newKeygenFlags()
-	out.Write([]byte("Usage of " + os.Args[0] + " " + keygenSummary() + "\n"))
+	_, _ = out.Write([]byte("Usage of " + os.Args[0] + " " + keygenSummary() + "\n"))
 	cf.set.SetOutput(out)
 	cf.set.PrintDefaults()
 }

--- a/cmd/nebula-cert/keygen.go
+++ b/cmd/nebula-cert/keygen.go
@@ -25,7 +25,7 @@ func newKeygenFlags() *keygenFlags {
 	cf.outPubPath = cf.set.String("out-pub", "", "Required: path to write the public key to")
 	cf.outKeyPath = cf.set.String("out-key", "", "Required: path to write the private key to")
 	cf.curve = cf.set.String("curve", "25519", "ECDH Curve (25519, P256)")
-	keygenP11flag(&cf)
+	cf.p11url = p11Flag(cf.set)
 	return &cf
 }
 
@@ -36,42 +36,55 @@ func keygen(args []string, out io.Writer, errOut io.Writer) error {
 		return err
 	}
 
+	isP11 := len(*cf.p11url) > 0
+
+	if !isP11 {
+		if err = mustFlagString("out-key", cf.outKeyPath); err != nil {
+			return err
+		}
+	}
 	if err = mustFlagString("out-pub", cf.outPubPath); err != nil {
 		return err
 	}
 
 	var pub, rawPriv []byte
 	var curve cert.Curve
-	switch *cf.curve {
-	case "25519", "X25519", "Curve25519", "CURVE25519":
-		pub, rawPriv = x25519Keypair()
-		curve = cert.Curve_CURVE25519
-	case "P256":
-		pub, rawPriv = p256Keypair()
-		curve = cert.Curve_P256
-	default:
-		return fmt.Errorf("invalid curve: %s", *cf.curve)
-	}
-
-	if len(*cf.p11url) == 0 {
-		if err = mustFlagString("out-key", cf.outKeyPath); err != nil {
-			return err
-		}
-		err = os.WriteFile(*cf.outKeyPath, cert.MarshalPrivateKey(curve, rawPriv), 0600)
-		if err != nil {
-			return fmt.Errorf("error while writing out-key: %s", err)
+	if isP11 {
+		switch *cf.curve {
+		case "P256":
+			curve = cert.Curve_P256
+		default:
+			return fmt.Errorf("invalid curve for PKCS#11: %s", *cf.curve)
 		}
 	} else {
-		client, err := pkclient.FromUrl(*cf.p11url)
+		switch *cf.curve {
+		case "25519", "X25519", "Curve25519", "CURVE25519":
+			pub, rawPriv = x25519Keypair()
+			curve = cert.Curve_CURVE25519
+		case "P256":
+			pub, rawPriv = p256Keypair()
+			curve = cert.Curve_P256
+		default:
+			return fmt.Errorf("invalid curve: %s", *cf.curve)
+		}
+	}
+
+	if isP11 {
+		p11Client, err := pkclient.FromUrl(*cf.p11url)
 		if err != nil {
-			return fmt.Errorf("error while creating PKCS11 client: %w", err)
+			return fmt.Errorf("error while creating PKCS#11 client: %w", err)
 		}
 		defer func(client *pkclient.PKClient) {
 			_ = client.Close()
-		}(client)
-		pub, err = client.GetPubKey()
+		}(p11Client)
+		pub, err = p11Client.GetPubKey()
 		if err != nil {
 			return fmt.Errorf("error while getting public key: %w", err)
+		}
+	} else {
+		err = os.WriteFile(*cf.outKeyPath, cert.MarshalPrivateKey(curve, rawPriv), 0600)
+		if err != nil {
+			return fmt.Errorf("error while writing out-key: %s", err)
 		}
 	}
 	err = os.WriteFile(*cf.outPubPath, cert.MarshalPublicKey(curve, pub), 0600)

--- a/cmd/nebula-cert/keygen.go
+++ b/cmd/nebula-cert/keygen.go
@@ -25,7 +25,7 @@ func newKeygenFlags() *keygenFlags {
 	cf.outPubPath = cf.set.String("out-pub", "", "Required: path to write the public key to")
 	cf.outKeyPath = cf.set.String("out-key", "", "Required: path to write the private key to")
 	cf.curve = cf.set.String("curve", "25519", "ECDH Curve (25519, P256)")
-	cf.p11url = cf.set.String("pkcs11", "", "Optional PKCS11 URL to an existing private key to obtain a nebula public key from")
+	keygenP11flag(&cf)
 	return &cf
 }
 

--- a/cmd/nebula-cert/keygen_cgo.go
+++ b/cmd/nebula-cert/keygen_cgo.go
@@ -1,7 +1,0 @@
-//go:build cgo && pkcs11
-
-package main
-
-func keygenP11flag(cf *keygenFlags) {
-	cf.p11url = cf.set.String("pkcs11", "", "Optional PKCS11 URL to an existing private key to obtain a nebula public key from")
-}

--- a/cmd/nebula-cert/keygen_cgo.go
+++ b/cmd/nebula-cert/keygen_cgo.go
@@ -1,0 +1,7 @@
+//go:build cgo && pkcs11
+
+package main
+
+func keygenP11flag(cf *keygenFlags) {
+	cf.p11url = cf.set.String("pkcs11", "", "Optional PKCS11 URL to an existing private key to obtain a nebula public key from")
+}

--- a/cmd/nebula-cert/keygen_stub.go
+++ b/cmd/nebula-cert/keygen_stub.go
@@ -1,0 +1,8 @@
+//go:build !cgo || !pkcs11
+
+package main
+
+func keygenP11flag(cf *keygenFlags) {
+	var e = ""
+	cf.p11url = &e
+}

--- a/cmd/nebula-cert/keygen_stub.go
+++ b/cmd/nebula-cert/keygen_stub.go
@@ -1,8 +1,0 @@
-//go:build !cgo || !pkcs11
-
-package main
-
-func keygenP11flag(cf *keygenFlags) {
-	var e = ""
-	cf.p11url = &e
-}

--- a/cmd/nebula-cert/keygen_test.go
+++ b/cmd/nebula-cert/keygen_test.go
@@ -26,7 +26,9 @@ func Test_keygenHelp(t *testing.T) {
 			"  -out-key string\n"+
 			"    \tRequired: path to write the private key to\n"+
 			"  -out-pub string\n"+
-			"    \tRequired: path to write the public key to\n",
+			"    \tRequired: path to write the public key to\n"+
+			optionalPkcs11String("  -pkcs11 string\n"+
+			"    \tOptional: PKCS#11 URI to an existing private key\n"),
 		ob.String(),
 	)
 }

--- a/cmd/nebula-cert/keygen_test.go
+++ b/cmd/nebula-cert/keygen_test.go
@@ -27,8 +27,7 @@ func Test_keygenHelp(t *testing.T) {
 			"    \tRequired: path to write the private key to\n"+
 			"  -out-pub string\n"+
 			"    \tRequired: path to write the public key to\n"+
-			optionalPkcs11String("  -pkcs11 string\n"+
-			"    \tOptional: PKCS#11 URI to an existing private key\n"),
+			optionalPkcs11String("  -pkcs11 string\n    \tOptional: PKCS#11 URI to an existing private key\n"),
 		ob.String(),
 	)
 }

--- a/cmd/nebula-cert/main_test.go
+++ b/cmd/nebula-cert/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -77,8 +78,16 @@ func assertHelpError(t *testing.T, err error, msg string) {
 	case *helpError:
 		// good
 	default:
-		t.Fatal("err was not a helpError")
+		t.Fatal(fmt.Sprintf("err was not a helpError: %q, expected %q", err, msg))
 	}
 
 	assert.EqualError(t, err, msg)
+}
+
+func optionalPkcs11String(msg string) string {
+	if p11Supported() {
+		return msg
+	} else {
+		return ""
+	}
 }

--- a/cmd/nebula-cert/p11_cgo.go
+++ b/cmd/nebula-cert/p11_cgo.go
@@ -1,0 +1,15 @@
+//go:build cgo && pkcs11
+
+package main
+
+import (
+	"flag"
+)
+
+func p11Supported() bool {
+	return true
+}
+
+func p11Flag(set *flag.FlagSet) *string {
+	return set.String("pkcs11", "", "Optional: PKCS#11 URI to an existing private key")
+}

--- a/cmd/nebula-cert/p11_stub.go
+++ b/cmd/nebula-cert/p11_stub.go
@@ -1,0 +1,16 @@
+//go:build !cgo || !pkcs11
+
+package main
+
+import (
+	"flag"
+)
+
+func p11Supported() bool {
+	return false
+}
+
+func p11Flag(set *flag.FlagSet) *string {
+	var ret = ""
+	return &ret
+}

--- a/cmd/nebula-cert/sign.go
+++ b/cmd/nebula-cert/sign.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/skip2/go-qrcode"
 	"github.com/slackhq/nebula/cert"
+	"github.com/slackhq/nebula/pkclient"
 	"golang.org/x/crypto/curve25519"
 )
 
@@ -29,6 +30,7 @@ type signFlags struct {
 	outQRPath   *string
 	groups      *string
 	subnets     *string
+	p11url      *string
 }
 
 func newSignFlags() *signFlags {
@@ -45,8 +47,8 @@ func newSignFlags() *signFlags {
 	sf.outQRPath = sf.set.String("out-qr", "", "Optional: output a qr code image (png) of the certificate")
 	sf.groups = sf.set.String("groups", "", "Optional: comma separated list of groups")
 	sf.subnets = sf.set.String("subnets", "", "Optional: comma separated list of ipv4 address and network in CIDR notation. Subnets this cert can serve for")
+	sf.p11url = p11Flag(sf.set)
 	return &sf
-
 }
 
 func signCert(args []string, out io.Writer, errOut io.Writer, pr PasswordReader) error {
@@ -56,8 +58,12 @@ func signCert(args []string, out io.Writer, errOut io.Writer, pr PasswordReader)
 		return err
 	}
 
-	if err := mustFlagString("ca-key", sf.caKeyPath); err != nil {
-		return err
+	isP11 := len(*sf.p11url) > 0
+
+	if !isP11 {
+		if err := mustFlagString("ca-key", sf.caKeyPath); err != nil {
+			return err
+		}
 	}
 	if err := mustFlagString("ca-crt", sf.caCertPath); err != nil {
 		return err
@@ -68,47 +74,49 @@ func signCert(args []string, out io.Writer, errOut io.Writer, pr PasswordReader)
 	if err := mustFlagString("ip", sf.ip); err != nil {
 		return err
 	}
-	if *sf.inPubPath != "" && *sf.outKeyPath != "" {
+	if !isP11 && *sf.inPubPath != "" && *sf.outKeyPath != "" {
 		return newHelpErrorf("cannot set both -in-pub and -out-key")
-	}
-
-	rawCAKey, err := os.ReadFile(*sf.caKeyPath)
-	if err != nil {
-		return fmt.Errorf("error while reading ca-key: %s", err)
 	}
 
 	var curve cert.Curve
 	var caKey []byte
-
-	// naively attempt to decode the private key as though it is not encrypted
-	caKey, _, curve, err = cert.UnmarshalSigningPrivateKey(rawCAKey)
-	if err == cert.ErrPrivateKeyEncrypted {
-		// ask for a passphrase until we get one
-		var passphrase []byte
-		for i := 0; i < 5; i++ {
-			out.Write([]byte("Enter passphrase: "))
-			passphrase, err = pr.ReadPassword()
-
-			if err == ErrNoTerminal {
-				return fmt.Errorf("ca-key is encrypted and must be decrypted interactively")
-			} else if err != nil {
-				return fmt.Errorf("error reading password: %s", err)
-			}
-
-			if len(passphrase) > 0 {
-				break
-			}
-		}
-		if len(passphrase) == 0 {
-			return fmt.Errorf("cannot open encrypted ca-key without passphrase")
-		}
-
-		curve, caKey, _, err = cert.DecryptAndUnmarshalSigningPrivateKey(passphrase, rawCAKey)
+	if !isP11 {
+		var rawCAKey []byte
+		rawCAKey, err := os.ReadFile(*sf.caKeyPath)
 		if err != nil {
-			return fmt.Errorf("error while parsing encrypted ca-key: %s", err)
+			return fmt.Errorf("error while reading ca-key: %s", err)
 		}
-	} else if err != nil {
-		return fmt.Errorf("error while parsing ca-key: %s", err)
+
+		// naively attempt to decode the private key as though it is not encrypted
+		caKey, _, curve, err = cert.UnmarshalSigningPrivateKey(rawCAKey)
+		if err == cert.ErrPrivateKeyEncrypted {
+			// ask for a passphrase until we get one
+			var passphrase []byte
+			for i := 0; i < 5; i++ {
+				out.Write([]byte("Enter passphrase: "))
+				passphrase, err = pr.ReadPassword()
+
+				if err == ErrNoTerminal {
+					return fmt.Errorf("ca-key is encrypted and must be decrypted interactively")
+				} else if err != nil {
+					return fmt.Errorf("error reading password: %s", err)
+				}
+
+				if len(passphrase) > 0 {
+					break
+				}
+			}
+			if len(passphrase) == 0 {
+				return fmt.Errorf("cannot open encrypted ca-key without passphrase")
+			}
+
+			curve, caKey, _, err = cert.DecryptAndUnmarshalSigningPrivateKey(passphrase, rawCAKey)
+			if err != nil {
+				return fmt.Errorf("error while parsing encrypted ca-key: %s", err)
+			}
+		} else if err != nil {
+			return fmt.Errorf("error while parsing ca-key: %s", err)
+		}
 	}
 
 	rawCACert, err := os.ReadFile(*sf.caCertPath)
@@ -121,8 +129,10 @@ func signCert(args []string, out io.Writer, errOut io.Writer, pr PasswordReader)
 		return fmt.Errorf("error while parsing ca-crt: %s", err)
 	}
 
-	if err := caCert.VerifyPrivateKey(curve, caKey); err != nil {
-		return fmt.Errorf("refusing to sign, root certificate does not match private key")
+	if !isP11 {
+		if err := caCert.VerifyPrivateKey(curve, caKey); err != nil {
+			return fmt.Errorf("refusing to sign, root certificate does not match private key")
+		}
 	}
 
 	issuer, err := caCert.Sha256Sum()
@@ -176,18 +186,36 @@ func signCert(args []string, out io.Writer, errOut io.Writer, pr PasswordReader)
 	}
 
 	var pub, rawPriv []byte
+	var p11Client *pkclient.PKClient
+
+	if isP11 {
+		curve = cert.Curve_P256
+		p11Client, err = pkclient.FromUrl(*sf.p11url)
+		if err != nil {
+			return fmt.Errorf("error while creating PKCS#11 client: %w", err)
+		}
+		defer func(client *pkclient.PKClient) {
+			_ = client.Close()
+		}(p11Client)
+	}
+
 	if *sf.inPubPath != "" {
+		var pubCurve cert.Curve
 		rawPub, err := os.ReadFile(*sf.inPubPath)
 		if err != nil {
 			return fmt.Errorf("error while reading in-pub: %s", err)
 		}
-		var pubCurve cert.Curve
 		pub, _, pubCurve, err = cert.UnmarshalPublicKey(rawPub)
 		if err != nil {
 			return fmt.Errorf("error while parsing in-pub: %s", err)
 		}
 		if pubCurve != curve {
 			return fmt.Errorf("curve of in-pub does not match ca")
+		}
+	} else if isP11 {
+		pub, err = p11Client.GetPubKey()
+		if err != nil {
+			return fmt.Errorf("error while getting public key with PKCS#11: %w", err)
 		}
 	} else {
 		pub, rawPriv = newKeypair(curve)
@@ -206,6 +234,19 @@ func signCert(args []string, out io.Writer, errOut io.Writer, pr PasswordReader)
 			Issuer:    issuer,
 			Curve:     curve,
 		},
+		Pkcs11Backed: isP11,
+	}
+
+	if p11Client == nil {
+		err = nc.Sign(curve, caKey)
+		if err != nil {
+			return fmt.Errorf("error while signing: %w", err)
+		}
+	} else {
+		err = nc.SignPkcs11(curve, p11Client)
+		if err != nil {
+			return fmt.Errorf("error while signing with PKCS#11: %w", err)
+		}
 	}
 
 	if err := nc.CheckRootConstrains(caCert); err != nil {
@@ -224,12 +265,7 @@ func signCert(args []string, out io.Writer, errOut io.Writer, pr PasswordReader)
 		return fmt.Errorf("refusing to overwrite existing cert: %s", *sf.outCertPath)
 	}
 
-	err = nc.Sign(curve, caKey)
-	if err != nil {
-		return fmt.Errorf("error while signing: %s", err)
-	}
-
-	if *sf.inPubPath == "" {
+	if !isP11 && *sf.inPubPath == "" {
 		if _, err := os.Stat(*sf.outKeyPath); err == nil {
 			return fmt.Errorf("refusing to overwrite existing key: %s", *sf.outKeyPath)
 		}

--- a/cmd/nebula-cert/sign_test.go
+++ b/cmd/nebula-cert/sign_test.go
@@ -48,6 +48,8 @@ func Test_signHelp(t *testing.T) {
 			"    \tOptional (if in-pub not set): path to write the private key to\n"+
 			"  -out-qr string\n"+
 			"    \tOptional: output a qr code image (png) of the certificate\n"+
+			optionalPkcs11String("  -pkcs11 string\n"+
+			"    \tOptional: PKCS#11 URI to an existing private key\n")+
 			"  -subnets string\n"+
 			"    \tOptional: comma separated list of ipv4 address and network in CIDR notation. Subnets this cert can serve for\n",
 		ob.String(),

--- a/cmd/nebula-cert/sign_test.go
+++ b/cmd/nebula-cert/sign_test.go
@@ -48,8 +48,7 @@ func Test_signHelp(t *testing.T) {
 			"    \tOptional (if in-pub not set): path to write the private key to\n"+
 			"  -out-qr string\n"+
 			"    \tOptional: output a qr code image (png) of the certificate\n"+
-			optionalPkcs11String("  -pkcs11 string\n"+
-			"    \tOptional: PKCS#11 URI to an existing private key\n")+
+			optionalPkcs11String("  -pkcs11 string\n    \tOptional: PKCS#11 URI to an existing private key\n")+
 			"  -subnets string\n"+
 			"    \tOptional: comma separated list of ipv4 address and network in CIDR notation. Subnets this cert can serve for\n",
 		ob.String(),

--- a/connection_state.go
+++ b/connection_state.go
@@ -32,7 +32,11 @@ func NewConnectionState(l *logrus.Logger, cipher string, certState *CertState, i
 	case cert.Curve_CURVE25519:
 		dhFunc = noise.DH25519
 	case cert.Curve_P256:
-		dhFunc = noiseutil.DHP256
+		if certState.Certificate.Pkcs11Backed {
+			dhFunc = noiseutil.DHP256PKCS11
+		} else {
+			dhFunc = noiseutil.DHP256
+		}
 	default:
 		l.Errorf("invalid curve: %s", certState.Certificate.Details.Curve)
 		return nil

--- a/go.mod
+++ b/go.mod
@@ -14,12 +14,14 @@ require (
 	github.com/google/gopacket v1.1.19
 	github.com/kardianos/service v1.2.2
 	github.com/miekg/dns v1.1.61
+	github.com/miekg/pkcs11 v1.1.2-0.20231115102856-9078ad6b9d4b
 	github.com/nbrownus/go-metrics-prometheus v0.0.0-20210712211119-974a6260965f
 	github.com/prometheus/client_golang v1.19.1
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/sirupsen/logrus v1.9.3
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
+	github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6
 	github.com/stretchr/testify v1.9.0
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	golang.org/x/crypto v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.1.61 h1:nLxbwF3XxhwVSm8g9Dghm9MHPaUZuqhPiGL+675ZmEs=
 github.com/miekg/dns v1.1.61/go.mod h1:mnAarhS3nWaW+NVP2wTkYVIZyHNJ098SJZUki3eykwQ=
+github.com/miekg/pkcs11 v1.1.2-0.20231115102856-9078ad6b9d4b h1:J/AzCvg5z0Hn1rqZUJjpbzALUmkKX0Zwbc/i4fw7Sfk=
+github.com/miekg/pkcs11 v1.1.2-0.20231115102856-9078ad6b9d4b/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
@@ -133,6 +135,8 @@ github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=
 github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8 h1:TG/diQgUe0pntT/2D9tmUCz4VNwm9MfrtPr0SU2qSX8=
 github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8/go.mod h1:P5HUIBuIWKbyjl083/loAegFkfbFNx5i2qEP4CNbm7E=
+github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6 h1:pnnLyeX7o/5aX8qUQ69P/mLojDqwda8hFOCBTmP/6hw=
+github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6/go.mod h1:39R/xuhNgVhi+K0/zst4TLrJrVmbm6LVgl4A0+ZFS5M=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/noiseutil/pkcs11.go
+++ b/noiseutil/pkcs11.go
@@ -1,0 +1,50 @@
+package noiseutil
+
+import (
+	"crypto/ecdh"
+	"fmt"
+	"strings"
+
+	"github.com/slackhq/nebula/pkclient"
+
+	"github.com/flynn/noise"
+)
+
+// DHP256PKCS11 is the NIST P-256 ECDH function
+var DHP256PKCS11 noise.DHFunc = newNISTP11Curve("P256", ecdh.P256(), 32)
+
+type nistP11Curve struct {
+	nistCurve
+}
+
+func newNISTP11Curve(name string, curve ecdh.Curve, byteLen int) nistP11Curve {
+	return nistP11Curve{
+		newNISTCurve(name, curve, byteLen),
+	}
+}
+
+func (c nistP11Curve) DH(privkey, pubkey []byte) ([]byte, error) {
+	//for this function "privkey" is actually a pkcs11 URI
+	pkStr := string(privkey)
+
+	//to set up a handshake, we need to also do non-pkcs11-DH. Handle that here.
+	if !strings.HasPrefix(pkStr, "pkcs11:") {
+		return DHP256.DH(privkey, pubkey)
+	}
+	ecdhPubKey, err := c.curve.NewPublicKey(pubkey)
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal pubkey: %w", err)
+	}
+
+	//this is not the most performant way to do this (a long-lived client would be better)
+	//but, it works, and helps avoid problems with stale sessions and HSMs used by multiple users.
+	client, err := pkclient.FromUrl(pkStr)
+	if err != nil {
+		return nil, err
+	}
+	defer func(client *pkclient.PKClient) {
+		_ = client.Close()
+	}(client)
+
+	return client.DeriveNoise(ecdhPubKey.Bytes())
+}

--- a/pkclient/pkclient.go
+++ b/pkclient/pkclient.go
@@ -50,6 +50,14 @@ func FromUrl(pkurl string) (*PKClient, error) {
 	return New(module, uint(slotid), pin, id, label)
 }
 
+func ecKeyToArray(key *ecdsa.PublicKey) []byte {
+	x := make([]byte, 32)
+	y := make([]byte, 32)
+	key.X.FillBytes(x)
+	key.Y.FillBytes(y)
+	return append([]byte{0x04}, append(x, y...)...)
+}
+
 func formatPubkeyFromPublicKeyInfoAttr(d []byte) ([]byte, error) {
 	e, err := x509.ParsePKIXPublicKey(d)
 	if err != nil {
@@ -57,7 +65,7 @@ func formatPubkeyFromPublicKeyInfoAttr(d []byte) ([]byte, error) {
 	}
 	switch t := e.(type) {
 	case *ecdsa.PublicKey:
-		return append([]byte{0x04}, append(t.X.Bytes(), t.Y.Bytes()...)...), nil
+		return ecKeyToArray(e.(*ecdsa.PublicKey)), nil
 	default:
 		return nil, fmt.Errorf("unknown public key type: %T", t)
 	}

--- a/pkclient/pkclient.go
+++ b/pkclient/pkclient.go
@@ -1,0 +1,267 @@
+package pkclient
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/miekg/pkcs11"
+	"github.com/miekg/pkcs11/p11"
+	"github.com/stefanberger/go-pkcs11uri"
+)
+
+const NoiseKeySize = 32
+
+type PKClient struct {
+	module     p11.Module
+	session    p11.Session
+	id         []byte
+	label      []byte
+	privKeyObj p11.Object
+	pubKeyObj  p11.Object
+}
+
+func FromUrl(pkurl string) (*PKClient, error) {
+	uri := pkcs11uri.New()
+	uri.SetAllowAnyModule(true) //todo
+	err := uri.Parse(pkurl)
+	if err != nil {
+		return nil, err
+	}
+
+	module, err := uri.GetModule()
+	if err != nil {
+		return nil, err
+	}
+
+	slotid := 0
+	slot, ok := uri.GetPathAttribute("slot-id", false)
+	if !ok {
+		slotid = 0
+	} else {
+		slotid, err = strconv.Atoi(slot)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	pin, _ := uri.GetPIN()
+	id, _ := uri.GetPathAttribute("id", false)
+	label, _ := uri.GetPathAttribute("object", false)
+
+	return New(module, uint(slotid), pin, id, label)
+}
+
+// New tries to open a session with the HSM, select the slot and login to it
+func New(hsmPath string, slotId uint, pin string, id string, label string) (*PKClient, error) {
+	module, err := p11.OpenModule(hsmPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load module library: %s", hsmPath)
+	}
+
+	slots, err := module.Slots()
+	if err != nil {
+		module.Destroy()
+		return nil, err
+	}
+
+	// Try to open a session on the slot
+	slotIdx := 0
+	for i, slot := range slots {
+		if slot.ID() == slotId {
+			slotIdx = i
+			break
+		}
+	}
+
+	client := &PKClient{
+		module: module,
+		id:     []byte(id),
+		label:  []byte(label),
+	}
+
+	client.session, err = slots[slotIdx].OpenWriteSession()
+	if err != nil {
+		module.Destroy()
+		return nil, fmt.Errorf("failed to open session on slot %d", slotId)
+	}
+
+	if len(pin) != 0 {
+		err = client.session.Login(pin)
+		if err != nil {
+			// ignore "already logged in"
+			if !errors.Is(err, pkcs11.Error(256)) {
+				_ = client.session.Close()
+				client.module.Destroy()
+				return nil, fmt.Errorf("unable to login. error: %w", err)
+			}
+		}
+	}
+
+	// Make sure the hsm has a private key for deriving
+	client.privKeyObj, err = client.findDeriveKey(client.id, client.label, true)
+	if err != nil {
+		_ = client.Close() //log out, close session, destroy module
+		return nil, fmt.Errorf("failed to find private key for deriving: %w", err)
+	}
+
+	return client, nil
+}
+
+// Close cleans up properly and logs out
+func (c *PKClient) Close() error {
+	if err := c.session.Logout(); err != nil {
+		return err
+	}
+
+	_ = c.session.Close()
+	c.module.Destroy()
+
+	return nil
+}
+
+// DeriveNoise derives a shared secret using the input public key against the private key that was found during setup.
+// Returns a fixed 32 byte array.
+func (c *PKClient) DeriveNoise(peerPubKey []byte) ([]byte, error) {
+	// Before we call derive, we need to have an array of attributes which specify the type of
+	// key to be returned, in our case, it's the shared secret key, produced via deriving
+	// This template pulled from OpenSC pkclient-tool.c line 4038
+	attrTemplate := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, false),
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_SECRET_KEY),
+		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, pkcs11.CKK_GENERIC_SECRET),
+		pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, false),
+		pkcs11.NewAttribute(pkcs11.CKA_EXTRACTABLE, true),
+		pkcs11.NewAttribute(pkcs11.CKA_ENCRYPT, true),
+		pkcs11.NewAttribute(pkcs11.CKA_DECRYPT, true),
+		pkcs11.NewAttribute(pkcs11.CKA_WRAP, true),
+		pkcs11.NewAttribute(pkcs11.CKA_UNWRAP, true),
+	}
+
+	// Set up the parameters which include the peer's public key
+	ecdhParams := pkcs11.NewECDH1DeriveParams(pkcs11.CKD_NULL, nil, peerPubKey)
+	mech := pkcs11.NewMechanism(pkcs11.CKM_ECDH1_DERIVE, ecdhParams)
+	sk := p11.PrivateKey(c.privKeyObj)
+
+	tmpKey, err := sk.Derive(*mech, attrTemplate)
+	if err != nil {
+		return nil, err
+	}
+	if tmpKey == nil || len(tmpKey) == 0 {
+		return nil, fmt.Errorf("got an empty secret key")
+	}
+	secret := make([]byte, NoiseKeySize)
+	copy(secret[:], tmpKey[:NoiseKeySize])
+	return secret, nil
+}
+
+// Try to find a suitable key on the hsm for key derivation
+// parameter GET_PUB_KEY sets the search pattern for a public or private key
+func (c *PKClient) findDeriveKey(id []byte, label []byte, private bool) (key p11.Object, err error) {
+	keyClass := pkcs11.CKO_PRIVATE_KEY
+	if !private {
+		keyClass = pkcs11.CKO_PUBLIC_KEY
+	}
+	keyAttrs := []*pkcs11.Attribute{
+		//todo, not all HSMs seem to report this, even if its true: pkcs11.NewAttribute(pkcs11.CKA_DERIVE, true),
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, keyClass),
+	}
+
+	if id != nil && len(id) != 0 {
+		keyAttrs = append(keyAttrs, pkcs11.NewAttribute(pkcs11.CKA_ID, id))
+	}
+	if label != nil && len(label) != 0 {
+		keyAttrs = append(keyAttrs, pkcs11.NewAttribute(pkcs11.CKA_LABEL, label))
+	}
+
+	return c.session.FindObject(keyAttrs)
+}
+
+func (c *PKClient) listDeriveKeys(id []byte, label []byte, private bool) {
+	keyClass := pkcs11.CKO_PRIVATE_KEY
+	if !private {
+		keyClass = pkcs11.CKO_PUBLIC_KEY
+	}
+	keyAttrs := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, keyClass),
+	}
+
+	if id != nil && len(id) != 0 {
+		keyAttrs = append(keyAttrs, pkcs11.NewAttribute(pkcs11.CKA_ID, id))
+	}
+	if label != nil && len(label) != 0 {
+		keyAttrs = append(keyAttrs, pkcs11.NewAttribute(pkcs11.CKA_LABEL, label))
+	}
+
+	objects, err := c.session.FindObjects(keyAttrs)
+	if err != nil {
+		return
+	}
+
+	for _, obj := range objects {
+		l, err := obj.Label()
+		log.Printf("%s, %v", l, err)
+		a, err := obj.Attribute(pkcs11.CKA_DERIVE)
+		log.Printf("DERIVE: %s %v, %v", l, a, err)
+	}
+}
+
+func formatPubkeyFromPublicKeyInfoAttr(d []byte) ([]byte, error) {
+	e, err := x509.ParsePKIXPublicKey(d)
+	if err != nil {
+		return nil, err
+	}
+	switch t := e.(type) {
+	case *ecdsa.PublicKey:
+		return append([]byte{0x04}, append(t.X.Bytes(), t.Y.Bytes()...)...), nil
+	default:
+		return nil, fmt.Errorf("unknown public key type: %T", t)
+	}
+}
+
+func (c *PKClient) GetPubKey() ([]byte, error) {
+	d, err := c.privKeyObj.Attribute(pkcs11.CKA_PUBLIC_KEY_INFO)
+	if err != nil {
+		return nil, err
+	}
+	if d != nil {
+		return formatPubkeyFromPublicKeyInfoAttr(d)
+	}
+	c.pubKeyObj, err = c.findDeriveKey(c.id, c.label, false)
+	if err != nil {
+		return nil, fmt.Errorf("pkcs11 module gave us a nil CKA_PUBLIC_KEY_INFO, and looking up the public key also failed: %w", err)
+	}
+	d, err = c.pubKeyObj.Attribute(pkcs11.CKA_EC_POINT)
+	if err != nil {
+		return nil, fmt.Errorf("pkcs11 module gave us a nil CKA_PUBLIC_KEY_INFO, and reading CKA_EC_POINT also failed: %w", err)
+	}
+	if d == nil {
+		return nil, fmt.Errorf("pkcs11 module gave us a nil CKA_EC_POINT")
+	}
+	switch len(d) {
+	case 65: //length of 0x04 + len(X) + len(Y)
+		return d, nil
+	case 67: //as above, DER-encoded IIRC?
+		return d[2:], nil
+	default:
+		return nil, fmt.Errorf("unknown public key length: %d", len(d))
+	}
+}
+
+func (c *PKClient) Test() error {
+	pub, err := c.GetPubKey()
+	if err != nil {
+		return fmt.Errorf("failed to get public key: %w", err)
+	}
+	out, err := c.DeriveNoise(pub) //do an ECDH with ourselves as a quick test
+	if err != nil {
+		return err
+	}
+	if len(out) != NoiseKeySize {
+		return fmt.Errorf("got a key of %d bytes, expected %d", len(out), NoiseKeySize)
+	}
+	return nil
+}

--- a/pkclient/pkclient.go
+++ b/pkclient/pkclient.go
@@ -3,26 +3,21 @@ package pkclient
 import (
 	"crypto/ecdsa"
 	"crypto/x509"
-	"errors"
 	"fmt"
-	"log"
+	"io"
 	"strconv"
 
-	"github.com/miekg/pkcs11"
-	"github.com/miekg/pkcs11/p11"
 	"github.com/stefanberger/go-pkcs11uri"
 )
 
-const NoiseKeySize = 32
-
-type PKClient struct {
-	module     p11.Module
-	session    p11.Session
-	id         []byte
-	label      []byte
-	privKeyObj p11.Object
-	pubKeyObj  p11.Object
+type Client interface {
+	io.Closer
+	GetPubKey() ([]byte, error)
+	DeriveNoise(peerPubKey []byte) ([]byte, error)
+	Test() error
 }
+
+const NoiseKeySize = 32
 
 func FromUrl(pkurl string) (*PKClient, error) {
 	uri := pkcs11uri.New()
@@ -55,160 +50,6 @@ func FromUrl(pkurl string) (*PKClient, error) {
 	return New(module, uint(slotid), pin, id, label)
 }
 
-// New tries to open a session with the HSM, select the slot and login to it
-func New(hsmPath string, slotId uint, pin string, id string, label string) (*PKClient, error) {
-	module, err := p11.OpenModule(hsmPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load module library: %s", hsmPath)
-	}
-
-	slots, err := module.Slots()
-	if err != nil {
-		module.Destroy()
-		return nil, err
-	}
-
-	// Try to open a session on the slot
-	slotIdx := 0
-	for i, slot := range slots {
-		if slot.ID() == slotId {
-			slotIdx = i
-			break
-		}
-	}
-
-	client := &PKClient{
-		module: module,
-		id:     []byte(id),
-		label:  []byte(label),
-	}
-
-	client.session, err = slots[slotIdx].OpenWriteSession()
-	if err != nil {
-		module.Destroy()
-		return nil, fmt.Errorf("failed to open session on slot %d", slotId)
-	}
-
-	if len(pin) != 0 {
-		err = client.session.Login(pin)
-		if err != nil {
-			// ignore "already logged in"
-			if !errors.Is(err, pkcs11.Error(256)) {
-				_ = client.session.Close()
-				client.module.Destroy()
-				return nil, fmt.Errorf("unable to login. error: %w", err)
-			}
-		}
-	}
-
-	// Make sure the hsm has a private key for deriving
-	client.privKeyObj, err = client.findDeriveKey(client.id, client.label, true)
-	if err != nil {
-		_ = client.Close() //log out, close session, destroy module
-		return nil, fmt.Errorf("failed to find private key for deriving: %w", err)
-	}
-
-	return client, nil
-}
-
-// Close cleans up properly and logs out
-func (c *PKClient) Close() error {
-	if err := c.session.Logout(); err != nil {
-		return err
-	}
-
-	_ = c.session.Close()
-	c.module.Destroy()
-
-	return nil
-}
-
-// DeriveNoise derives a shared secret using the input public key against the private key that was found during setup.
-// Returns a fixed 32 byte array.
-func (c *PKClient) DeriveNoise(peerPubKey []byte) ([]byte, error) {
-	// Before we call derive, we need to have an array of attributes which specify the type of
-	// key to be returned, in our case, it's the shared secret key, produced via deriving
-	// This template pulled from OpenSC pkclient-tool.c line 4038
-	attrTemplate := []*pkcs11.Attribute{
-		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, false),
-		pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_SECRET_KEY),
-		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, pkcs11.CKK_GENERIC_SECRET),
-		pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, false),
-		pkcs11.NewAttribute(pkcs11.CKA_EXTRACTABLE, true),
-		pkcs11.NewAttribute(pkcs11.CKA_ENCRYPT, true),
-		pkcs11.NewAttribute(pkcs11.CKA_DECRYPT, true),
-		pkcs11.NewAttribute(pkcs11.CKA_WRAP, true),
-		pkcs11.NewAttribute(pkcs11.CKA_UNWRAP, true),
-	}
-
-	// Set up the parameters which include the peer's public key
-	ecdhParams := pkcs11.NewECDH1DeriveParams(pkcs11.CKD_NULL, nil, peerPubKey)
-	mech := pkcs11.NewMechanism(pkcs11.CKM_ECDH1_DERIVE, ecdhParams)
-	sk := p11.PrivateKey(c.privKeyObj)
-
-	tmpKey, err := sk.Derive(*mech, attrTemplate)
-	if err != nil {
-		return nil, err
-	}
-	if tmpKey == nil || len(tmpKey) == 0 {
-		return nil, fmt.Errorf("got an empty secret key")
-	}
-	secret := make([]byte, NoiseKeySize)
-	copy(secret[:], tmpKey[:NoiseKeySize])
-	return secret, nil
-}
-
-// Try to find a suitable key on the hsm for key derivation
-// parameter GET_PUB_KEY sets the search pattern for a public or private key
-func (c *PKClient) findDeriveKey(id []byte, label []byte, private bool) (key p11.Object, err error) {
-	keyClass := pkcs11.CKO_PRIVATE_KEY
-	if !private {
-		keyClass = pkcs11.CKO_PUBLIC_KEY
-	}
-	keyAttrs := []*pkcs11.Attribute{
-		//todo, not all HSMs seem to report this, even if its true: pkcs11.NewAttribute(pkcs11.CKA_DERIVE, true),
-		pkcs11.NewAttribute(pkcs11.CKA_CLASS, keyClass),
-	}
-
-	if id != nil && len(id) != 0 {
-		keyAttrs = append(keyAttrs, pkcs11.NewAttribute(pkcs11.CKA_ID, id))
-	}
-	if label != nil && len(label) != 0 {
-		keyAttrs = append(keyAttrs, pkcs11.NewAttribute(pkcs11.CKA_LABEL, label))
-	}
-
-	return c.session.FindObject(keyAttrs)
-}
-
-func (c *PKClient) listDeriveKeys(id []byte, label []byte, private bool) {
-	keyClass := pkcs11.CKO_PRIVATE_KEY
-	if !private {
-		keyClass = pkcs11.CKO_PUBLIC_KEY
-	}
-	keyAttrs := []*pkcs11.Attribute{
-		pkcs11.NewAttribute(pkcs11.CKA_CLASS, keyClass),
-	}
-
-	if id != nil && len(id) != 0 {
-		keyAttrs = append(keyAttrs, pkcs11.NewAttribute(pkcs11.CKA_ID, id))
-	}
-	if label != nil && len(label) != 0 {
-		keyAttrs = append(keyAttrs, pkcs11.NewAttribute(pkcs11.CKA_LABEL, label))
-	}
-
-	objects, err := c.session.FindObjects(keyAttrs)
-	if err != nil {
-		return
-	}
-
-	for _, obj := range objects {
-		l, err := obj.Label()
-		log.Printf("%s, %v", l, err)
-		a, err := obj.Attribute(pkcs11.CKA_DERIVE)
-		log.Printf("DERIVE: %s %v, %v", l, a, err)
-	}
-}
-
 func formatPubkeyFromPublicKeyInfoAttr(d []byte) ([]byte, error) {
 	e, err := x509.ParsePKIXPublicKey(d)
 	if err != nil {
@@ -219,35 +60,6 @@ func formatPubkeyFromPublicKeyInfoAttr(d []byte) ([]byte, error) {
 		return append([]byte{0x04}, append(t.X.Bytes(), t.Y.Bytes()...)...), nil
 	default:
 		return nil, fmt.Errorf("unknown public key type: %T", t)
-	}
-}
-
-func (c *PKClient) GetPubKey() ([]byte, error) {
-	d, err := c.privKeyObj.Attribute(pkcs11.CKA_PUBLIC_KEY_INFO)
-	if err != nil {
-		return nil, err
-	}
-	if d != nil {
-		return formatPubkeyFromPublicKeyInfoAttr(d)
-	}
-	c.pubKeyObj, err = c.findDeriveKey(c.id, c.label, false)
-	if err != nil {
-		return nil, fmt.Errorf("pkcs11 module gave us a nil CKA_PUBLIC_KEY_INFO, and looking up the public key also failed: %w", err)
-	}
-	d, err = c.pubKeyObj.Attribute(pkcs11.CKA_EC_POINT)
-	if err != nil {
-		return nil, fmt.Errorf("pkcs11 module gave us a nil CKA_PUBLIC_KEY_INFO, and reading CKA_EC_POINT also failed: %w", err)
-	}
-	if d == nil {
-		return nil, fmt.Errorf("pkcs11 module gave us a nil CKA_EC_POINT")
-	}
-	switch len(d) {
-	case 65: //length of 0x04 + len(X) + len(Y)
-		return d, nil
-	case 67: //as above, DER-encoded IIRC?
-		return d[2:], nil
-	default:
-		return nil, fmt.Errorf("unknown public key length: %d", len(d))
 	}
 }
 

--- a/pkclient/pkclient_cgo.go
+++ b/pkclient/pkclient_cgo.go
@@ -1,0 +1,204 @@
+//go:build cgo && pkcs11
+
+package pkclient
+
+import (
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/miekg/pkcs11"
+	"github.com/miekg/pkcs11/p11"
+)
+
+type PKClient struct {
+	module     p11.Module
+	session    p11.Session
+	id         []byte
+	label      []byte
+	privKeyObj p11.Object
+	pubKeyObj  p11.Object
+}
+
+// New tries to open a session with the HSM, select the slot and login to it
+func New(hsmPath string, slotId uint, pin string, id string, label string) (*PKClient, error) {
+	module, err := p11.OpenModule(hsmPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load module library: %s", hsmPath)
+	}
+
+	slots, err := module.Slots()
+	if err != nil {
+		module.Destroy()
+		return nil, err
+	}
+
+	// Try to open a session on the slot
+	slotIdx := 0
+	for i, slot := range slots {
+		if slot.ID() == slotId {
+			slotIdx = i
+			break
+		}
+	}
+
+	client := &PKClient{
+		module: module,
+		id:     []byte(id),
+		label:  []byte(label),
+	}
+
+	client.session, err = slots[slotIdx].OpenWriteSession()
+	if err != nil {
+		module.Destroy()
+		return nil, fmt.Errorf("failed to open session on slot %d", slotId)
+	}
+
+	if len(pin) != 0 {
+		err = client.session.Login(pin)
+		if err != nil {
+			// ignore "already logged in"
+			if !errors.Is(err, pkcs11.Error(256)) {
+				_ = client.session.Close()
+				client.module.Destroy()
+				return nil, fmt.Errorf("unable to login. error: %w", err)
+			}
+		}
+	}
+
+	// Make sure the hsm has a private key for deriving
+	client.privKeyObj, err = client.findDeriveKey(client.id, client.label, true)
+	if err != nil {
+		_ = client.Close() //log out, close session, destroy module
+		return nil, fmt.Errorf("failed to find private key for deriving: %w", err)
+	}
+
+	return client, nil
+}
+
+// Close cleans up properly and logs out
+func (c *PKClient) Close() error {
+	if err := c.session.Logout(); err != nil {
+		return err
+	}
+
+	_ = c.session.Close()
+	c.module.Destroy()
+
+	return nil
+}
+
+// Try to find a suitable key on the hsm for key derivation
+// parameter GET_PUB_KEY sets the search pattern for a public or private key
+func (c *PKClient) findDeriveKey(id []byte, label []byte, private bool) (key p11.Object, err error) {
+	keyClass := pkcs11.CKO_PRIVATE_KEY
+	if !private {
+		keyClass = pkcs11.CKO_PUBLIC_KEY
+	}
+	keyAttrs := []*pkcs11.Attribute{
+		//todo, not all HSMs seem to report this, even if its true: pkcs11.NewAttribute(pkcs11.CKA_DERIVE, true),
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, keyClass),
+	}
+
+	if id != nil && len(id) != 0 {
+		keyAttrs = append(keyAttrs, pkcs11.NewAttribute(pkcs11.CKA_ID, id))
+	}
+	if label != nil && len(label) != 0 {
+		keyAttrs = append(keyAttrs, pkcs11.NewAttribute(pkcs11.CKA_LABEL, label))
+	}
+
+	return c.session.FindObject(keyAttrs)
+}
+
+func (c *PKClient) listDeriveKeys(id []byte, label []byte, private bool) {
+	keyClass := pkcs11.CKO_PRIVATE_KEY
+	if !private {
+		keyClass = pkcs11.CKO_PUBLIC_KEY
+	}
+	keyAttrs := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, keyClass),
+	}
+
+	if id != nil && len(id) != 0 {
+		keyAttrs = append(keyAttrs, pkcs11.NewAttribute(pkcs11.CKA_ID, id))
+	}
+	if label != nil && len(label) != 0 {
+		keyAttrs = append(keyAttrs, pkcs11.NewAttribute(pkcs11.CKA_LABEL, label))
+	}
+
+	objects, err := c.session.FindObjects(keyAttrs)
+	if err != nil {
+		return
+	}
+
+	for _, obj := range objects {
+		l, err := obj.Label()
+		log.Printf("%s, %v", l, err)
+		a, err := obj.Attribute(pkcs11.CKA_DERIVE)
+		log.Printf("DERIVE: %s %v, %v", l, a, err)
+	}
+}
+
+// DeriveNoise derives a shared secret using the input public key against the private key that was found during setup.
+// Returns a fixed 32 byte array.
+func (c *PKClient) DeriveNoise(peerPubKey []byte) ([]byte, error) {
+	// Before we call derive, we need to have an array of attributes which specify the type of
+	// key to be returned, in our case, it's the shared secret key, produced via deriving
+	// This template pulled from OpenSC pkclient-tool.c line 4038
+	attrTemplate := []*pkcs11.Attribute{
+		pkcs11.NewAttribute(pkcs11.CKA_TOKEN, false),
+		pkcs11.NewAttribute(pkcs11.CKA_CLASS, pkcs11.CKO_SECRET_KEY),
+		pkcs11.NewAttribute(pkcs11.CKA_KEY_TYPE, pkcs11.CKK_GENERIC_SECRET),
+		pkcs11.NewAttribute(pkcs11.CKA_SENSITIVE, false),
+		pkcs11.NewAttribute(pkcs11.CKA_EXTRACTABLE, true),
+		pkcs11.NewAttribute(pkcs11.CKA_ENCRYPT, true),
+		pkcs11.NewAttribute(pkcs11.CKA_DECRYPT, true),
+		pkcs11.NewAttribute(pkcs11.CKA_WRAP, true),
+		pkcs11.NewAttribute(pkcs11.CKA_UNWRAP, true),
+	}
+
+	// Set up the parameters which include the peer's public key
+	ecdhParams := pkcs11.NewECDH1DeriveParams(pkcs11.CKD_NULL, nil, peerPubKey)
+	mech := pkcs11.NewMechanism(pkcs11.CKM_ECDH1_DERIVE, ecdhParams)
+	sk := p11.PrivateKey(c.privKeyObj)
+
+	tmpKey, err := sk.Derive(*mech, attrTemplate)
+	if err != nil {
+		return nil, err
+	}
+	if tmpKey == nil || len(tmpKey) == 0 {
+		return nil, fmt.Errorf("got an empty secret key")
+	}
+	secret := make([]byte, NoiseKeySize)
+	copy(secret[:], tmpKey[:NoiseKeySize])
+	return secret, nil
+}
+
+func (c *PKClient) GetPubKey() ([]byte, error) {
+	d, err := c.privKeyObj.Attribute(pkcs11.CKA_PUBLIC_KEY_INFO)
+	if err != nil {
+		return nil, err
+	}
+	if d != nil {
+		return formatPubkeyFromPublicKeyInfoAttr(d)
+	}
+	c.pubKeyObj, err = c.findDeriveKey(c.id, c.label, false)
+	if err != nil {
+		return nil, fmt.Errorf("pkcs11 module gave us a nil CKA_PUBLIC_KEY_INFO, and looking up the public key also failed: %w", err)
+	}
+	d, err = c.pubKeyObj.Attribute(pkcs11.CKA_EC_POINT)
+	if err != nil {
+		return nil, fmt.Errorf("pkcs11 module gave us a nil CKA_PUBLIC_KEY_INFO, and reading CKA_EC_POINT also failed: %w", err)
+	}
+	if d == nil {
+		return nil, fmt.Errorf("pkcs11 module gave us a nil CKA_EC_POINT")
+	}
+	switch len(d) {
+	case 65: //length of 0x04 + len(X) + len(Y)
+		return d, nil
+	case 67: //as above, DER-encoded IIRC?
+		return d[2:], nil
+	default:
+		return nil, fmt.Errorf("unknown public key length: %d", len(d))
+	}
+}

--- a/pkclient/pkclient_cgo.go
+++ b/pkclient/pkclient_cgo.go
@@ -204,7 +204,7 @@ func (c *PKClient) GetPubKey() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if d != nil {
+	if d != nil && len(d) > 0 {
 		return formatPubkeyFromPublicKeyInfoAttr(d)
 	}
 	c.pubKeyObj, err = c.findDeriveKey(c.id, c.label, false)
@@ -215,8 +215,8 @@ func (c *PKClient) GetPubKey() ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("pkcs11 module gave us a nil CKA_PUBLIC_KEY_INFO, and reading CKA_EC_POINT also failed: %w", err)
 	}
-	if d == nil {
-		return nil, fmt.Errorf("pkcs11 module gave us a nil CKA_EC_POINT")
+	if d == nil || len(d) < 1 {
+		return nil, fmt.Errorf("pkcs11 module gave us a nil or empty CKA_EC_POINT")
 	}
 	switch len(d) {
 	case 65: //length of 0x04 + len(X) + len(Y)

--- a/pkclient/pkclient_stub.go
+++ b/pkclient/pkclient_stub.go
@@ -17,6 +17,10 @@ func (c *PKClient) Close() error {
 	return nil
 }
 
+func (c *PKClient) SignASN1(data []byte) ([]byte, error) {
+	return nil, notImplemented
+}
+
 func (c *PKClient) DeriveNoise(_ []byte) ([]byte, error) {
 	return nil, notImplemented
 }

--- a/pkclient/pkclient_stub.go
+++ b/pkclient/pkclient_stub.go
@@ -1,0 +1,26 @@
+//go:build !cgo || !pkcs11
+
+package pkclient
+
+import "errors"
+
+type PKClient struct {
+}
+
+var notImplemented = errors.New("not implemented")
+
+func New(hsmPath string, slotId uint, pin string, id string, label string) (*PKClient, error) {
+	return nil, notImplemented
+}
+
+func (c *PKClient) Close() error {
+	return nil
+}
+
+func (c *PKClient) DeriveNoise(_ []byte) ([]byte, error) {
+	return nil, notImplemented
+}
+
+func (c *PKClient) GetPubKey() ([]byte, error) {
+	return nil, notImplemented
+}


### PR DESCRIPTION
Adds PKCS11 support for the P256 curve. It could probably be generalized for curve 25519 as well, but this is what our HSMs support, and therefore what I could easily test.

I've tested _very thoroughly_ against the difficult-to-obtain Microchip TA100, and did a quick verification with a Yubikey 5C.

Here's some quick examples of how this change can be exercised on a TA100. I'll follow up with Yubikey instructions when time permits:

This change requires building with CGO, so here's the exact invocation we used (adjust as needed for your target architecture of course):

```
CC=aarch64-linux-gnu-gcc CGO_ENABLED=1 GOARCH=arm64 go build -buildvcs=false -ldflags="${LDFLAGS}" -o nebula.arm64.${COMMIT_HASH} ./cmd/nebula
CC=aarch64-linux-gnu-gcc CGO_ENABLED=1 GOARCH=arm64 go build -buildvcs=false -ldflags="${LDFLAGS}" -o nebula-cert.arm64.${COMMIT_HASH} ./cmd/nebula-cert
```
Unfortunately static linking with musl doesn't work, because musl doesn't implement `dlopen` for statically-linked binaries. :disappointed: 

```
./nebula-cert keygen -out-pub test.pem -pkcs11 'pkcs11:slot-id=0;object=device;token=00ABC;type=private?module-path=/tmp/libcryptoauth.so'
```

A config file's `pki` section would look like this:
```
pki:
  ca: /path/to/ca.pem
  cert: /path/to/cert.pem
  key: 'pkcs11:slot-id=0;object=device;token=00ABC;type=private?module-path=/tmp/libcryptoauth.so'
```

Please let me know what you think! I'm very open to making adjustments to make this fit in better with the existing code.