### PR TITLE
Fix logging in `cachePacket`

### DIFF
--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -96,7 +96,7 @@ func (hh *HandshakeHostInfo) cachePacket(l *logrus.Logger, t header.MessageType,
 			hh.hostinfo.logger(l).
 				WithField("length", len(hh.packetStore)).
 				WithField("stored", false).
-				Debugf("Packet store")
+				Debugf("Packet drop")
 		}
 	}
 }


### PR DESCRIPTION
We were previously logging "Packet store" when the packet is dropped, the counter and logging should agree.
