### PR TITLE
Add puncuation to doc comment

### DIFF
--- a/lighthouse.go
+++ b/lighthouse.go
@@ -1151,7 +1151,7 @@ func (lhh *LightHouseHandler) handleHostPunchNotification(n *NebulaMeta, vpnIp i
 	}
 }
 
-// ipMaskContains checks if testIp is contained by ip after applying a cidr
+// ipMaskContains checks if testIp is contained by ip after applying a cidr.
 // zeros is 32 - bits from net.IPMask.Size()
 func ipMaskContains(ip iputil.VpnIp, zeros iputil.VpnIp, testIp iputil.VpnIp) bool {
 	return (testIp^ip)>>zeros == 0

--- a/noise.go
+++ b/noise.go
@@ -28,11 +28,11 @@ func NewNebulaCipherState(s *noise.CipherState) *NebulaCipherState {
 // EncryptDanger encrypts and authenticates a given payload.
 //
 // out is a destination slice to hold the output of the EncryptDanger operation.
-// - ad is additional data, which will be authenticated and appended to out, but not encrypted.
-// - plaintext is encrypted, authenticated and appended to out.
-// - n is a nonce value which must never be re-used with this key.
-// - nb is a buffer used for temporary storage in the implementation of this call, which should
-// be re-used by callers to minimize garbage collection.
+//   - ad is additional data, which will be authenticated and appended to out, but not encrypted.
+//   - plaintext is encrypted, authenticated and appended to out.
+//   - n is a nonce value which must never be re-used with this key.
+//   - nb is a buffer used for temporary storage in the implementation of this call, which should
+//     be re-used by callers to minimize garbage collection.
 func (s *NebulaCipherState) EncryptDanger(out, ad, plaintext []byte, n uint64, nb []byte) ([]byte, error) {
 	if s != nil {
 		// TODO: Is this okay now that we have made messageCounter atomic?


### PR DESCRIPTION
This change improves reading of the doc comment after it's been consumed by the Golang LSP:

Before: 

<img width="682" alt="image" src="https://github.com/slackhq/nebula/assets/10626596/f6289eff-c05d-40f7-8274-3886d698a501">

After:

<img width="729" alt="image" src="https://github.com/slackhq/nebula/assets/10626596/d777af23-dff9-42c8-8166-552977c87cba">
