### PR TITLE
fix rare panic when local index collision happens

### DIFF
--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -488,7 +488,7 @@ func (c *HandshakeManager) CheckAndComplete(hostinfo *HostInfo, handshakePacket 
 	existingPendingIndex, found := c.indexes[hostinfo.localIndexId]
 	if found && existingPendingIndex.hostinfo != hostinfo {
 		// We have a collision, but for a different hostinfo
-		return existingIndex, ErrLocalIndexCollision
+		return existingPendingIndex.hostinfo, ErrLocalIndexCollision
 	}
 
 	existingRemoteIndex, found := c.mainHostMap.RemoteIndexes[hostinfo.remoteIndexId]


### PR DESCRIPTION
A local index collision happens when two tunnels attempt to use the same random int32 index ID. This is a rare chance, and we have code to deal with it, but we have a panic because we return the wrong thing in this case. This change should fix the panic.