### PR TITLE
make boringcrypto: add checklinkname flag for go1.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,8 @@ build/linux-mips-softfloat/%: LDFLAGS += -s -w
 # boringcrypto
 build/linux-amd64-boringcrypto/%: GOENV += GOEXPERIMENT=boringcrypto CGO_ENABLED=1
 build/linux-arm64-boringcrypto/%: GOENV += GOEXPERIMENT=boringcrypto CGO_ENABLED=1
+build/linux-amd64-boringcrypto/%: LDFLAGS += -checklinkname=0
+build/linux-arm64-boringcrypto/%: LDFLAGS += -checklinkname=0
 
 build/%/nebula: .FORCE
 	GOOS=$(firstword $(subst -, , $*)) \


### PR DESCRIPTION
Starting with go1.23, we need to set -checklinkname=0 when building for boringcrypto because we need to use go:linkname to access `newGCMTLS`.

Note that this does break builds when using a go version less than go1.23.0. We can probably assume that someone using this Makefile and manually building is using the latest release of Go though.

See:

- https://go.dev/doc/go1.23#linker