### PR TITLE
Add TBSCertificate.SignWith to abstract out sources-of-signatures

### DIFF
--- a/cert/sign.go
+++ b/cert/sign.go
@@ -11,8 +11,6 @@ import (
 	"net/netip"
 	"slices"
 	"time"
-
-	"github.com/slackhq/nebula/pkclient"
 )
 
 // TBSCertificate represents a certificate intended to be signed.
@@ -71,21 +69,6 @@ func (t *TBSCertificate) Sign(signer Certificate, curve Curve, key []byte) (Cert
 			return ecdsa.SignASN1(rand.Reader, pk, hashed[:])
 		}
 		return t.SignWith(signer, curve, sp)
-	default:
-		return nil, fmt.Errorf("invalid curve: %s", t.Curve)
-	}
-}
-
-func (t *TBSCertificate) SignPkcs11(signer Certificate, curve Curve, client *pkclient.PKClient) (Certificate, error) {
-	if client == nil {
-		return nil, fmt.Errorf("pkclient must be non-nil")
-	}
-	switch t.Curve {
-	case Curve_CURVE25519:
-		return nil, fmt.Errorf("only P256 is supported by PKCS#11")
-	case Curve_P256:
-		//todo: verify that pkcs11 hashes for you
-		return t.SignWith(signer, curve, client.SignASN1)
 	default:
 		return nil, fmt.Errorf("invalid curve: %s", t.Curve)
 	}

--- a/cert/sign.go
+++ b/cert/sign.go
@@ -42,7 +42,9 @@ type beingSignedCertificate interface {
 
 type SignerLambda func(certBytes []byte) ([]byte, error)
 
-// Sign calls SignWith with an appropriate function to sign with the value of key.
+// Sign will create a sealed certificate using details provided by the TBSCertificate as long as those
+// details do not violate constraints of the signing certificate.
+// If the TBSCertificate is a CA then signer must be nil.
 func (t *TBSCertificate) Sign(signer Certificate, curve Curve, key []byte) (Certificate, error) {
 	switch t.Curve {
 	case Curve_CURVE25519:
@@ -74,10 +76,8 @@ func (t *TBSCertificate) Sign(signer Certificate, curve Curve, key []byte) (Cert
 	}
 }
 
-// SignWith will create a sealed certificate using details provided by the TBSCertificate as long as those
-// details do not violate constraints of the signing certificate.
-// If the TBSCertificate is a CA then signer must be nil.
-// sp is used to calculate the signature
+// SignWith does the same thing as sign, but uses the function in `sp` to calculate the signature.
+// You should only use SignWith if you do not have direct access to your private key.
 func (t *TBSCertificate) SignWith(signer Certificate, curve Curve, sp SignerLambda) (Certificate, error) {
 	if curve != t.Curve {
 		return nil, fmt.Errorf("curve in cert and private key supplied don't match")

--- a/cmd/nebula-cert/ca.go
+++ b/cmd/nebula-cert/ca.go
@@ -272,7 +272,7 @@ func ca(args []string, out io.Writer, errOut io.Writer, pr PasswordReader) error
 	var b []byte
 
 	if isP11 {
-		c, err = t.SignPkcs11(nil, curve, p11Client)
+		c, err = t.SignWith(nil, curve, p11Client.SignASN1)
 		if err != nil {
 			return fmt.Errorf("error while signing with PKCS#11: %w", err)
 		}

--- a/cmd/nebula-cert/sign.go
+++ b/cmd/nebula-cert/sign.go
@@ -316,7 +316,7 @@ func signCert(args []string, out io.Writer, errOut io.Writer, pr PasswordReader)
 				return fmt.Errorf("error while signing: %w", err)
 			}
 		} else {
-			nc, err = t.SignPkcs11(caCert, curve, p11Client)
+			nc, err = t.SignWith(caCert, curve, p11Client.SignASN1)
 			if err != nil {
 				return fmt.Errorf("error while signing with PKCS#11: %w", err)
 			}
@@ -346,7 +346,7 @@ func signCert(args []string, out io.Writer, errOut io.Writer, pr PasswordReader)
 				return fmt.Errorf("error while signing: %w", err)
 			}
 		} else {
-			nc, err = t.SignPkcs11(caCert, curve, p11Client)
+			nc, err = t.SignWith(caCert, curve, p11Client.SignASN1)
 			if err != nil {
 				return fmt.Errorf("error while signing with PKCS#11: %w", err)
 			}


### PR DESCRIPTION
This can probably also be rebased onto cert-interface, but I haven't tried yet