### PR TITLE
Cert V2 firewall fixes

### DIFF
--- a/firewall.go
+++ b/firewall.go
@@ -284,7 +284,7 @@ func (f *Firewall) AddRule(incoming bool, proto uint8, startPort int32, endPort 
 		fp = ft.TCP
 	case firewall.ProtoUDP:
 		fp = ft.UDP
-	case firewall.ProtoICMP:
+	case firewall.ProtoICMP, firewall.ProtoICMPv6:
 		fp = ft.ICMP
 	case firewall.ProtoAny:
 		fp = ft.AnyProto
@@ -631,7 +631,7 @@ func (ft *FirewallTable) match(p firewall.Packet, incoming bool, c *cert.CachedC
 		if ft.UDP.match(p, incoming, c, caPool) {
 			return true
 		}
-	case firewall.ProtoICMP:
+	case firewall.ProtoICMP, firewall.ProtoICMPv6:
 		if ft.ICMP.match(p, incoming, c, caPool) {
 			return true
 		}

--- a/firewall/packet.go
+++ b/firewall/packet.go
@@ -9,10 +9,11 @@ import (
 type m map[string]interface{}
 
 const (
-	ProtoAny  = 0 // When we want to handle HOPOPT (0) we can change this, if ever
-	ProtoTCP  = 6
-	ProtoUDP  = 17
-	ProtoICMP = 1
+	ProtoAny    = 0 // When we want to handle HOPOPT (0) we can change this, if ever
+	ProtoTCP    = 6
+	ProtoUDP    = 17
+	ProtoICMP   = 1
+	ProtoICMPv6 = 58
 
 	PortAny      = 0  // Special value for matching `port: any`
 	PortFragment = -1 // Special value for matching `port: fragment`

--- a/outside.go
+++ b/outside.go
@@ -335,11 +335,11 @@ func parseV6(data []byte, incoming bool, fp *firewall.Packet) error {
 			}
 			fp.Protocol = uint8(proto)
 			if incoming {
-				fp.RemotePort = binary.BigEndian.Uint16(data[offset+2 : offset+4])
-				fp.LocalPort = binary.BigEndian.Uint16(data[offset : offset+2])
-			} else {
 				fp.RemotePort = binary.BigEndian.Uint16(data[offset : offset+2])
 				fp.LocalPort = binary.BigEndian.Uint16(data[offset+2 : offset+4])
+			} else {
+				fp.LocalPort = binary.BigEndian.Uint16(data[offset : offset+2])
+				fp.RemotePort = binary.BigEndian.Uint16(data[offset+2 : offset+4])
 			}
 			fp.Fragment = false
 			return nil
@@ -350,11 +350,11 @@ func parseV6(data []byte, incoming bool, fp *firewall.Packet) error {
 			}
 			fp.Protocol = uint8(proto)
 			if incoming {
-				fp.RemotePort = binary.BigEndian.Uint16(data[offset+2 : offset+4])
-				fp.LocalPort = binary.BigEndian.Uint16(data[offset : offset+2])
-			} else {
 				fp.RemotePort = binary.BigEndian.Uint16(data[offset : offset+2])
 				fp.LocalPort = binary.BigEndian.Uint16(data[offset+2 : offset+4])
+			} else {
+				fp.LocalPort = binary.BigEndian.Uint16(data[offset : offset+2])
+				fp.RemotePort = binary.BigEndian.Uint16(data[offset+2 : offset+4])
 			}
 			fp.Fragment = false
 			return nil

--- a/outside.go
+++ b/outside.go
@@ -334,8 +334,13 @@ func parseV6(data []byte, incoming bool, fp *firewall.Packet) error {
 				return fmt.Errorf("ipv6 packet was too small")
 			}
 			fp.Protocol = uint8(proto)
-			fp.RemotePort = binary.BigEndian.Uint16(data[offset : offset+2])
-			fp.LocalPort = binary.BigEndian.Uint16(data[offset+2 : offset+4])
+			if incoming {
+				fp.RemotePort = binary.BigEndian.Uint16(data[offset+2 : offset+4])
+				fp.LocalPort = binary.BigEndian.Uint16(data[offset : offset+2])
+			} else {
+				fp.RemotePort = binary.BigEndian.Uint16(data[offset : offset+2])
+				fp.LocalPort = binary.BigEndian.Uint16(data[offset+2 : offset+4])
+			}
 			fp.Fragment = false
 			return nil
 
@@ -344,8 +349,13 @@ func parseV6(data []byte, incoming bool, fp *firewall.Packet) error {
 				return fmt.Errorf("ipv6 packet was too small")
 			}
 			fp.Protocol = uint8(proto)
-			fp.RemotePort = binary.BigEndian.Uint16(data[offset : offset+2])
-			fp.LocalPort = binary.BigEndian.Uint16(data[offset+2 : offset+4])
+			if incoming {
+				fp.RemotePort = binary.BigEndian.Uint16(data[offset+2 : offset+4])
+				fp.LocalPort = binary.BigEndian.Uint16(data[offset : offset+2])
+			} else {
+				fp.RemotePort = binary.BigEndian.Uint16(data[offset : offset+2])
+				fp.LocalPort = binary.BigEndian.Uint16(data[offset+2 : offset+4])
+			}
 			fp.Fragment = false
 			return nil
 

--- a/outside_test.go
+++ b/outside_test.go
@@ -1,11 +1,12 @@
 package nebula
 
 import (
-	"github.com/google/gopacket"
-	"github.com/google/gopacket/layers"
 	"net"
 	"net/netip"
 	"testing"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
 
 	"github.com/slackhq/nebula/firewall"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
1. Handle all ICMPv6 traffic with identical rules to ICMP
2. Correct intepretation of port numbers on UDP traffic wrt incoming vs outgoing (I'd like to add a test for this as well, but there's no .Marshal() for IPv6 headers)