### PR TITLE
cert-v2: backwards compatibility trickery for ipv6

### DIFF
--- a/cert/cert.go
+++ b/cert/cert.go
@@ -109,6 +109,10 @@ type CachedCertificate struct {
 	signerFingerprint string
 }
 
+func (cc *CachedCertificate) String() string {
+	return cc.Certificate.String()
+}
+
 // UnmarshalCertificate will attempt to unmarshal a wire protocol level certificate.
 func UnmarshalCertificate(b []byte) (Certificate, error) {
 	//TODO: you left off here, no one uses this function but it might be beneficial to export _something_ that someone can use, maybe the Versioned unmarshallsers?

--- a/connection_state.go
+++ b/connection_state.go
@@ -26,8 +26,9 @@ type ConnectionState struct {
 	writeLock      sync.Mutex
 }
 
-func NewConnectionState(l *logrus.Logger, cs *CertState, initiator bool, pattern noise.HandshakePattern) *ConnectionState {
-	crt := cs.GetDefaultCertificate()
+func NewConnectionState(l *logrus.Logger, cs *CertState, version cert.Version, initiator bool, pattern noise.HandshakePattern) *ConnectionState {
+	//todo I don't like passing version as an arg here but it's the sanest way to force v2 at stage0 but only sometimes
+	crt := cs.getCertificate(version)
 	var dhFunc noise.DHFunc
 	switch crt.Curve() {
 	case cert.Curve_CURVE25519:

--- a/control.go
+++ b/control.go
@@ -134,6 +134,7 @@ func (c *Control) GetCertByVpnIp(vpnIp netip.Addr) cert.Certificate {
 	_, found := c.f.myVpnAddrsTable.Lookup(vpnIp)
 	if found {
 		//TODO: we might have 2 certs....
+		//TODO: this should return our latest version cert
 		return c.f.pki.getDefaultCertificate().Copy()
 	}
 	hi := c.f.hostMap.QueryVpnAddr(vpnIp)

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package nebula
 import (
 	"context"
 	"fmt"
+	"github.com/slackhq/nebula/cert"
 	"net"
 	"net/netip"
 	"time"
@@ -61,6 +62,10 @@ func Main(c *config.C, configTest bool, buildVersion string, logger *logrus.Logg
 	}
 
 	certificate := pki.getDefaultCertificate()
+	v2Cert := pki.getCertificate(cert.Version2)
+	if v2Cert != nil {
+		certificate = v2Cert
+	}
 	fw, err := NewFirewallFromConfig(l, certificate, c)
 	if err != nil {
 		return nil, util.ContextualizeIfNeeded("Error while loading firewall rules", err)

--- a/main.go
+++ b/main.go
@@ -62,10 +62,14 @@ func Main(c *config.C, configTest bool, buildVersion string, logger *logrus.Logg
 		return nil, util.ContextualizeIfNeeded("Failed to load PKI from config", err)
 	}
 
-	certificate := pki.getDefaultCertificate()
-	v2Cert := pki.getCertificate(cert.Version2)
-	if v2Cert != nil {
-		certificate = v2Cert
+	cs := pki.getCertState()
+	certificate := cs.getCertificate(cert.Version2)
+	if certificate == nil {
+		certificate = cs.getCertificate(cert.Version1)
+	}
+
+	if certificate == nil {
+		panic("No certificates available to configure the firewall")
 	}
 	fw, err := NewFirewallFromConfig(l, certificate, c)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -3,10 +3,11 @@ package nebula
 import (
 	"context"
 	"fmt"
-	"github.com/slackhq/nebula/cert"
 	"net"
 	"net/netip"
 	"time"
+
+	"github.com/slackhq/nebula/cert"
 
 	"github.com/sirupsen/logrus"
 	"github.com/slackhq/nebula/config"

--- a/pki.go
+++ b/pki.go
@@ -70,10 +70,12 @@ func (p *PKI) getCertState() *CertState {
 	return p.cs.Load()
 }
 
+// TODO: We should remove this
 func (p *PKI) getDefaultCertificate() cert.Certificate {
 	return p.cs.Load().GetDefaultCertificate()
 }
 
+// TODO: We should remove this
 func (p *PKI) getCertificate(v cert.Version) cert.Certificate {
 	return p.cs.Load().getCertificate(v)
 }
@@ -209,10 +211,6 @@ func (cs *CertState) GetDefaultCertificate() cert.Certificate {
 	return c
 }
 
-func (cs *CertState) getDefaultHandshakeBytes() []byte {
-	return cs.getHandshakeBytes(cs.defaultVersion)
-}
-
 func (cs *CertState) getCertificate(v cert.Version) cert.Certificate {
 	switch v {
 	case cert.Version1:
@@ -224,15 +222,17 @@ func (cs *CertState) getCertificate(v cert.Version) cert.Certificate {
 	return nil
 }
 
+// getHandshakeBytes returns the cached bytes to be used in a handshake message for the requested version.
+// Callers must check if the return []byte is nil.
 func (cs *CertState) getHandshakeBytes(v cert.Version) []byte {
 	switch v {
 	case cert.Version1:
 		return cs.v1HandshakeBytes
 	case cert.Version2:
 		return cs.v2HandshakeBytes
+	default:
+		return nil
 	}
-
-	panic("No handshake bytes found")
 }
 
 func (cs *CertState) String() string {
@@ -369,6 +369,8 @@ func newCertState(dv cert.Version, v1, v2 cert.Certificate, pkcs11backed bool, p
 		if v1.Curve() != v2.Curve() {
 			return nil, util.NewContextualError("v1 and v2 curve are not the same, ignoring", nil, nil)
 		}
+
+		//TODO: make sure v2 has v1s address
 
 		cs.defaultVersion = dv
 	}

--- a/ssh.go
+++ b/ssh.go
@@ -785,6 +785,7 @@ func sshPrintCert(ifce *Interface, fs interface{}, a []string, w sshd.StringWrit
 		return nil
 	}
 
+	//TODO: This should return both certs
 	cert := ifce.pki.getDefaultCertificate()
 	if len(a) > 0 {
 		vpnIp, err := netip.ParseAddr(a[0])


### PR DESCRIPTION
Here's a collection of hacks I've made to get IPv6 connectivity working on networks with:

1. v2-compatible lighthouses with v1 and v2 certs
2. some hosts with just v1 certs, some with both, some with just v2
3. pki.default_version unset on all hosts

Not all of it is good imo, but it does seem to work fairly well.