### PR TITLE
cert-v2 relay stuff

### DIFF
--- a/hostmap.go
+++ b/hostmap.go
@@ -456,18 +456,19 @@ func (hm *HostMap) QueryVpnAddrsRelayFor(targetIps []netip.Addr, relayHostIp net
 	hm.RLock()
 	defer hm.RUnlock()
 
-	for _, targetIp := range targetIps {
-		h, ok := hm.Hosts[relayHostIp]
-		if !ok {
-			return nil, nil, errors.New("unable to find host")
-		}
-		for h != nil {
+	h, ok := hm.Hosts[relayHostIp]
+	if !ok {
+		return nil, nil, errors.New("unable to find host")
+	}
+
+	for h != nil {
+		for _, targetIp := range targetIps {
 			r, ok := h.relayState.QueryRelayForByIp(targetIp)
 			if ok && r.State == Established {
 				return h, r, nil
 			}
-			h = h.next
 		}
+		h = h.next
 	}
 
 	return nil, nil, errors.New("unable to find host with relay")

--- a/inside.go
+++ b/inside.go
@@ -330,14 +330,7 @@ func (f *Interface) sendNoMetrics(t header.MessageType, st header.MessageSubType
 	} else {
 		// Try to send via a relay
 		for _, relayIP := range hostinfo.relayState.CopyRelayIps() {
-			var relayHostInfo *HostInfo
-			var relay *Relay
-			for _, vpnAddr := range hostinfo.vpnAddrs {
-				relayHostInfo, relay, err = f.hostMap.QueryVpnAddrRelayFor(vpnAddr, relayIP)
-				if err == nil {
-					break
-				}
-			}
+			relayHostInfo, relay, err := f.hostMap.QueryVpnAddrsRelayFor(hostinfo.vpnAddrs, relayIP)
 			if err != nil {
 				hostinfo.relayState.DeleteRelay(relayIP)
 				hostinfo.logger(f.l).WithField("relay", relayIP).WithError(err).Info("sendNoMetrics failed to find HostInfo")

--- a/inside.go
+++ b/inside.go
@@ -330,7 +330,14 @@ func (f *Interface) sendNoMetrics(t header.MessageType, st header.MessageSubType
 	} else {
 		// Try to send via a relay
 		for _, relayIP := range hostinfo.relayState.CopyRelayIps() {
-			relayHostInfo, relay, err := f.hostMap.QueryVpnAddrRelayFor(hostinfo.vpnAddrs[0], relayIP)
+			var relayHostInfo *HostInfo
+			var relay *Relay
+			for _, vpnAddr := range hostinfo.vpnAddrs {
+				relayHostInfo, relay, err = f.hostMap.QueryVpnAddrRelayFor(vpnAddr, relayIP)
+				if err == nil {
+					break
+				}
+			}
 			if err != nil {
 				hostinfo.relayState.DeleteRelay(relayIP)
 				hostinfo.logger(f.l).WithField("relay", relayIP).WithError(err).Info("sendNoMetrics failed to find HostInfo")

--- a/outside.go
+++ b/outside.go
@@ -104,9 +104,16 @@ func (f *Interface) readOutsidePackets(ip netip.AddrPort, via *ViaSender, out []
 				return
 			case ForwardingType:
 				// Find the target HostInfo relay object
-				targetHI, targetRelay, err := f.hostMap.QueryVpnAddrRelayFor(hostinfo.vpnAddrs[0], relay.PeerAddr)
+				var targetHI *HostInfo
+				var targetRelay *Relay
+				for _, vpnAddr := range hostinfo.vpnAddrs {
+					targetHI, targetRelay, err = f.hostMap.QueryVpnAddrRelayFor(vpnAddr, relay.PeerAddr)
+					if err == nil {
+						break
+					}
+				}
 				if err != nil {
-					hostinfo.logger(f.l).WithField("relayTo", relay.PeerAddr).WithError(err).Info("Failed to find target host info by ip")
+					hostinfo.logger(f.l).WithField("relayTo", relay.PeerAddr).WithError(err).WithField("hostinfo.vpnAddrs", hostinfo.vpnAddrs).Info("Failed to find target host info by ip")
 					return
 				}
 

--- a/outside.go
+++ b/outside.go
@@ -104,14 +104,7 @@ func (f *Interface) readOutsidePackets(ip netip.AddrPort, via *ViaSender, out []
 				return
 			case ForwardingType:
 				// Find the target HostInfo relay object
-				var targetHI *HostInfo
-				var targetRelay *Relay
-				for _, vpnAddr := range hostinfo.vpnAddrs {
-					targetHI, targetRelay, err = f.hostMap.QueryVpnAddrRelayFor(vpnAddr, relay.PeerAddr)
-					if err == nil {
-						break
-					}
-				}
+				targetHI, targetRelay, err := f.hostMap.QueryVpnAddrsRelayFor(hostinfo.vpnAddrs, relay.PeerAddr)
 				if err != nil {
 					hostinfo.logger(f.l).WithField("relayTo", relay.PeerAddr).WithError(err).WithField("hostinfo.vpnAddrs", hostinfo.vpnAddrs).Info("Failed to find target host info by ip")
 					return

--- a/relay_manager.go
+++ b/relay_manager.go
@@ -280,7 +280,8 @@ func (rm *relayManager) handleCreateRelayRequest(v cert.Version, h *HostInfo, f 
 
 		msg, err := resp.Marshal()
 		if err != nil {
-			logMsg.WithError(err).Error("relayManager Failed to marshal Control CreateRelayResponse message to create relay")
+			logMsg.
+				WithError(err).Error("relayManager Failed to marshal Control CreateRelayResponse message to create relay")
 		} else {
 			f.SendMessageToHostInfo(header.Control, 0, h, msg, make([]byte, 12), make([]byte, mtu))
 			rm.l.WithFields(logrus.Fields{
@@ -334,27 +335,29 @@ func (rm *relayManager) handleCreateRelayRequest(v cert.Version, h *HostInfo, f 
 			}
 
 			if v == cert.Version1 {
-				if !from.Is4() {
+				if !h.vpnAddrs[0].Is4() {
 					//TODO: log it
 					return
 				}
-				b := from.As4()
+
+				b := h.vpnAddrs[0].As4()
 				req.OldRelayFromAddr = binary.BigEndian.Uint32(b[:])
 				b = target.As4()
 				req.OldRelayToAddr = binary.BigEndian.Uint32(b[:])
 			} else {
-				req.RelayFromAddr = netAddrToProtoAddr(from)
+				req.RelayFromAddr = netAddrToProtoAddr(h.vpnAddrs[0])
 				req.RelayToAddr = netAddrToProtoAddr(target)
 			}
 
 			msg, err := req.Marshal()
 			if err != nil {
-				logMsg.WithError(err).Error("relayManager Failed to marshal Control message to create relay")
+				logMsg.
+					WithError(err).Error("relayManager Failed to marshal Control message to create relay")
 			} else {
 				f.SendMessageToHostInfo(header.Control, 0, peer, msg, make([]byte, 12), make([]byte, mtu))
 				rm.l.WithFields(logrus.Fields{
 					//TODO: IPV6-WORK another lazy used to use the req object
-					"relayFrom":           from,
+					"relayFrom":           h.vpnAddrs[0],
 					"relayTo":             target,
 					"initiatorRelayIndex": req.InitiatorRelayIndex,
 					"responderRelayIndex": req.ResponderRelayIndex,
@@ -372,7 +375,8 @@ func (rm *relayManager) handleCreateRelayRequest(v cert.Version, h *HostInfo, f 
 			}
 			_, err := AddRelay(rm.l, h, f.hostMap, target, &m.InitiatorRelayIndex, ForwardingType, state)
 			if err != nil {
-				logMsg.WithError(err).Error("relayManager Failed to allocate a local index for relay")
+				logMsg.
+					WithError(err).Error("relayManager Failed to allocate a local index for relay")
 				return
 			}
 		} else {
@@ -393,28 +397,29 @@ func (rm *relayManager) handleCreateRelayRequest(v cert.Version, h *HostInfo, f 
 				}
 
 				if v == cert.Version1 {
-					if !from.Is4() {
+					if !h.vpnAddrs[0].Is4() {
 						//TODO: log it
 						return
 					}
 
-					b := from.As4()
+					b := h.vpnAddrs[0].As4()
 					resp.OldRelayFromAddr = binary.BigEndian.Uint32(b[:])
 					b = target.As4()
 					resp.OldRelayToAddr = binary.BigEndian.Uint32(b[:])
 				} else {
-					resp.RelayFromAddr = netAddrToProtoAddr(from)
+					resp.RelayFromAddr = netAddrToProtoAddr(h.vpnAddrs[0])
 					resp.RelayToAddr = netAddrToProtoAddr(target)
 				}
 
 				msg, err := resp.Marshal()
 				if err != nil {
-					rm.l.WithError(err).Error("relayManager Failed to marshal Control CreateRelayResponse message to create relay")
+					rm.l.
+						WithError(err).Error("relayManager Failed to marshal Control CreateRelayResponse message to create relay")
 				} else {
 					f.SendMessageToHostInfo(header.Control, 0, h, msg, make([]byte, 12), make([]byte, mtu))
 					rm.l.WithFields(logrus.Fields{
 						//TODO: IPV6-WORK more lazy, used to use resp object
-						"relayFrom":           from,
+						"relayFrom":           h.vpnAddrs[0],
 						"relayTo":             target,
 						"initiatorRelayIndex": resp.InitiatorRelayIndex,
 						"responderRelayIndex": resp.ResponderRelayIndex,

--- a/relay_manager.go
+++ b/relay_manager.go
@@ -280,8 +280,7 @@ func (rm *relayManager) handleCreateRelayRequest(v cert.Version, h *HostInfo, f 
 
 		msg, err := resp.Marshal()
 		if err != nil {
-			logMsg.
-				WithError(err).Error("relayManager Failed to marshal Control CreateRelayResponse message to create relay")
+			logMsg.WithError(err).Error("relayManager Failed to marshal Control CreateRelayResponse message to create relay")
 		} else {
 			f.SendMessageToHostInfo(header.Control, 0, h, msg, make([]byte, 12), make([]byte, mtu))
 			rm.l.WithFields(logrus.Fields{
@@ -335,29 +334,27 @@ func (rm *relayManager) handleCreateRelayRequest(v cert.Version, h *HostInfo, f 
 			}
 
 			if v == cert.Version1 {
-				if !h.vpnAddrs[0].Is4() {
+				if !from.Is4() {
 					//TODO: log it
 					return
 				}
-
-				b := h.vpnAddrs[0].As4()
+				b := from.As4()
 				req.OldRelayFromAddr = binary.BigEndian.Uint32(b[:])
 				b = target.As4()
 				req.OldRelayToAddr = binary.BigEndian.Uint32(b[:])
 			} else {
-				req.RelayFromAddr = netAddrToProtoAddr(h.vpnAddrs[0])
+				req.RelayFromAddr = netAddrToProtoAddr(from)
 				req.RelayToAddr = netAddrToProtoAddr(target)
 			}
 
 			msg, err := req.Marshal()
 			if err != nil {
-				logMsg.
-					WithError(err).Error("relayManager Failed to marshal Control message to create relay")
+				logMsg.WithError(err).Error("relayManager Failed to marshal Control message to create relay")
 			} else {
 				f.SendMessageToHostInfo(header.Control, 0, peer, msg, make([]byte, 12), make([]byte, mtu))
 				rm.l.WithFields(logrus.Fields{
 					//TODO: IPV6-WORK another lazy used to use the req object
-					"relayFrom":           h.vpnAddrs[0],
+					"relayFrom":           from,
 					"relayTo":             target,
 					"initiatorRelayIndex": req.InitiatorRelayIndex,
 					"responderRelayIndex": req.ResponderRelayIndex,
@@ -375,8 +372,7 @@ func (rm *relayManager) handleCreateRelayRequest(v cert.Version, h *HostInfo, f 
 			}
 			_, err := AddRelay(rm.l, h, f.hostMap, target, &m.InitiatorRelayIndex, ForwardingType, state)
 			if err != nil {
-				logMsg.
-					WithError(err).Error("relayManager Failed to allocate a local index for relay")
+				logMsg.WithError(err).Error("relayManager Failed to allocate a local index for relay")
 				return
 			}
 		} else {
@@ -397,29 +393,28 @@ func (rm *relayManager) handleCreateRelayRequest(v cert.Version, h *HostInfo, f 
 				}
 
 				if v == cert.Version1 {
-					if !h.vpnAddrs[0].Is4() {
+					if !from.Is4() {
 						//TODO: log it
 						return
 					}
 
-					b := h.vpnAddrs[0].As4()
+					b := from.As4()
 					resp.OldRelayFromAddr = binary.BigEndian.Uint32(b[:])
 					b = target.As4()
 					resp.OldRelayToAddr = binary.BigEndian.Uint32(b[:])
 				} else {
-					resp.RelayFromAddr = netAddrToProtoAddr(h.vpnAddrs[0])
+					resp.RelayFromAddr = netAddrToProtoAddr(from)
 					resp.RelayToAddr = netAddrToProtoAddr(target)
 				}
 
 				msg, err := resp.Marshal()
 				if err != nil {
-					rm.l.
-						WithError(err).Error("relayManager Failed to marshal Control CreateRelayResponse message to create relay")
+					rm.l.WithError(err).Error("relayManager Failed to marshal Control CreateRelayResponse message to create relay")
 				} else {
 					f.SendMessageToHostInfo(header.Control, 0, h, msg, make([]byte, 12), make([]byte, mtu))
 					rm.l.WithFields(logrus.Fields{
 						//TODO: IPV6-WORK more lazy, used to use resp object
-						"relayFrom":           h.vpnAddrs[0],
+						"relayFrom":           from,
 						"relayTo":             target,
 						"initiatorRelayIndex": resp.InitiatorRelayIndex,
 						"responderRelayIndex": resp.ResponderRelayIndex,


### PR DESCRIPTION
Because hosts can have more than one IP now, we need to query the whole list of relay-fors to handle this flow:

1. Host A -> `CreateRelayRequest(HostA, (HostB's non-primary IP))` -> Relay
2. _things happen to set the relay up_
3. Host B -> replies to Host A's handshake via Relay
4. Relay has the following relay-tionships:
    - (Host A Primary) -> (Host B secondary)
    - (Host B Primary) -> (Host A Primary)
5. in order for this reply to make it back to Host A, we need to look at all the relays on Relay, not just the ones that exactly match the primary address
    - Said another way, if you only need to relay to node's primary IPs, this isn't a problem. 
    - But, if you only "know" a non-primary IP, you have no way to discover the primary IP without a handshake, which you may need a functional relay to get.
  