### PR TITLE
Don't overwrite old DNS results with empty list

### DIFF
--- a/lighthouse.go
+++ b/lighthouse.go
@@ -545,7 +545,7 @@ func (lh *LightHouse) addStaticRemotes(i int, d time.Duration, network string, t
 	ctx := lh.ctx
 	lh.Unlock()
 
-	hr, err := NewHostnameResults(ctx, lh.l, d, network, timeout, toAddrs, func() {
+	hr, err := NewHostnamesResults(ctx, lh.l, d, vpnIp, network, timeout, toAddrs, func() {
 		// This callback runs whenever the DNS hostname resolver finds a different set of IP's
 		// in its resolution for hostnames.
 		am.Lock()


### PR DESCRIPTION
This should improve DNS static_host_map entries for some users, such as the scenario described in this comment: https://github.com/slackhq/nebula/issues/909#issuecomment-1823451020

The `hostnamesResults.ips` variable is used to build the list of available underlay IPs for a given VPN IP. All hostnames are queried on `static_map.cadence` and `hr.ips` is updated when the new list of resolved IPs is different from the old list. A more detailed explanation can be [found here](https://github.com/slackhq/nebula/wiki/LightHouse-addrMap).

This could cause slow reconnects after connectivity loss:

1. Have a `static_host_map` entry for a Lighthouse that points at a DNS name only
2. Form a connection to the Lighthouse based on the result of the DNS query
3. Lose internet connection
4. DNS lookup fails, overwriting the IPs for the Lighthouse with an empty list
5. Internet connectivity is restored
6. No underlay route to Lighthouse until `static_map.cadence`

In addition to the above fix, I renamed `NewHostnameResults` to `NewHostnamesResults` which matches the struct's name and included `vpnIp` in logs related to the DNS resolution.

Some notes:

- If a static IP address is defined in `static_host_map` in addition to a DNS name, prior DNS resolutions will still be overwritten
- If a `static_host_map` entries defines multiple DNS names, and one resolves while another fails, any prior results for the failed DNS name will still be overwritten
- A cleaner solution would involve tracking the results by hostname. This would allow us to avoid the previous two pitfalls. One could imagine these living in `RemoteList.dnsCache`, using the hostname as map key, similar to `RemoteList.cache` which uses the Lighthouse/self vpnIp as map key: https://github.com/slackhq/nebula/blob/3e6c75573fd55d4bcdb6ad19f8c362d59bb1d9f0/remote_list.go#L198-L201

---

Example logs:

```
-- Demonstrating the new behavior
ERRO[0870] DNS resolution failed for static_map host     error="lookup foobar.johnmaguire.me: no such host" hostname=foobar.johnmaguire.me network=ip4 vpnIp=100.100.0.3
ERRO[1140] DNS resolution failed for static_map host     error="lookup home.johnmaguire.me: no such host" hostname=home.johnmaguire.me network=ip4 vpnIp=100.100.0.3
INFO[1140] No IPs resolved for hostnames, refusing to overwrite existing IPs  hostnames="[{home.johnmaguire.me 4242} {foobar.johnmaguire.me 4242}]" vpnIp=100.100.0.3

-- Demonstrating a known issue above (static IP in static_host_map)
ERRO[1140] DNS resolution failed for static_map host     error="lookup home.johnmaguire.me: no such host" hostname=home.johnmaguire.me network=ip4 vpnIp=100.100.0.4
INFO[1140] DNS results changed for host list             newSet="map[127.0.0.1:2424:{}]" origSet="&map[127.0.0.1:2424:{} 162.194.213.135:4242:{}]" vpnIp=100.100.0.4
```

Using config:

```
static_host_map:
  "100.100.0.3": ["home.johnmaguire.me:4242", "foobar.johnmaguire.me:4242"]
  "100.100.0.4": ["127.0.0.1:2424", "home.johnmaguire.me:4242"]

lighthouse:
  hosts:
    - "100.100.0.4"
    - "100.100.0.5"
```

Where `foobar.johnmaguire.me` was never resolvable but `home.johnmaguire.me` was resolvable at startup and then became unresolvable.