### PR TITLE
deduplicate relays

### DIFF
--- a/control_tester.go
+++ b/control_tester.go
@@ -70,7 +70,7 @@ func (c *Control) InjectRelays(vpnIp netip.Addr, relayVpnIps []netip.Addr) {
 	defer remoteList.Unlock()
 	c.f.lightHouse.Unlock()
 
-	remoteList.unlockedSetRelay(vpnIp, vpnIp, relayVpnIps)
+	remoteList.unlockedSetRelay(vpnIp, relayVpnIps)
 }
 
 // GetFromTun will pull a packet off the tun side of nebula

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -1222,7 +1222,7 @@ func (lhh *LightHouseHandler) handleHostQueryReply(n *NebulaMeta, fromVpnAddrs [
 		}
 	}
 
-	am.unlockedSetRelay(fromVpnAddrs[0], certVpnAddr, relays)
+	am.unlockedSetRelay(fromVpnAddrs[0], relays)
 	am.Unlock()
 
 	// Non-blocking attempt to trigger, skip if it would block
@@ -1286,7 +1286,7 @@ func (lhh *LightHouseHandler) handleHostUpdateNotification(n *NebulaMeta, fromVp
 		}
 	}
 
-	am.unlockedSetRelay(fromVpnAddrs[0], detailsVpnAddr, relays)
+	am.unlockedSetRelay(fromVpnAddrs[0], relays)
 	am.Unlock()
 
 	n = lhh.resetMeta()


### PR DESCRIPTION
Deduplicates relays, should they arise.

Some users have reported duplicated relay IPs appearing in logs during handshakes. These duplicate relays cause extra CreateRelayRequest traffic unnecessarily. This should clean that up.