### PR TITLE
Update slack invitation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Further documentation can be found [here](https://nebula.defined.net/docs/).
 
 You can read more about Nebula [here](https://medium.com/p/884110a5579).
 
-You can also join the NebulaOSS Slack group [here](https://join.slack.com/t/nebulaoss/shared_invite/enQtOTA5MDI4NDg3MTg4LTkwY2EwNTI4NzQyMzc0M2ZlODBjNWI3NTY1MzhiOThiMmZlZjVkMTI0NGY4YTMyNjUwMWEyNzNkZTJmYzQxOGU).
+You can also join the NebulaOSS Slack group [here](https://join.slack.com/t/nebulaoss/shared_invite/zt-2xqe6e7vn-k_KGi8s13nsr7cvHVvHvuQ).
 
 ## Supported Platforms
 


### PR DESCRIPTION
Closes #1306.

Creates a link that will be valid for 10 years/400 people.

<img width="552" alt="Slack 2025-01-13 09 10 16" src="https://github.com/user-attachments/assets/630124f7-9e06-4994-9c0e-19899d620853" />.