### PR TITLE
smoke-extra: support Ubuntu 24.04

### DIFF
--- a/.github/workflows/smoke-extra.yml
+++ b/.github/workflows/smoke-extra.yml
@@ -27,6 +27,9 @@ jobs:
         go-version-file: 'go.mod'
         check-latest: true
 
+    - name: add hashicorp source
+      run: wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg && echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+
     - name: install vagrant
       run: sudo apt-get update && sudo apt-get install -y vagrant virtualbox
 


### PR DESCRIPTION
Ubuntu 24.04 doesn't include vagrant anymore, so add the hashicorp source