### PR TITLE
Alternative route table and 0.0.0.0 routing

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -243,6 +243,9 @@ tun:
   # On linux only, set to true to manage unsafe routes directly on the system route table with gateway routes instead of
   # in nebula configuration files. Default false, not reloadable.
   #use_system_route_table: false
+  # Specify the alternative routing table for created routes.
+  # If unset, defaults to main routing table.
+  #alternative_routing_table: "my_alt_table"
 
 # TODO
 # Configure logging level


### PR DESCRIPTION
Added preliminary support for the creation of routes in alternative route tables on Linux, and using default routes via Nebula.
Nebula would crash anytime a default route was added or modified, regardless of the default route being added on to a separate table.

Requires new config param: 
  # Specify the alternative routing table for created routes.
  # If unset, defaults to main routing table.
  #alternative_routing_table: "my_alt_table"