### PR TITLE
cert-v2 group based query protection

### DIFF
--- a/lighthouse.go
+++ b/lighthouse.go
@@ -1490,6 +1490,11 @@ func newQueryProtectionTableFromConfig(c *config.C) *QueryProtectionTable {
 }
 
 func (l *QueryProtectionTable) check(invertedGroups map[string]struct{}, queryAddr netip.Addr, logger *logrus.Logger) bool {
+
+	if len(l.rules) == 0 {
+		return true
+	}
+
 	for group := range invertedGroups {
 		if prefixes, ok := l.rules[group]; ok {
 			for _, p := range prefixes {

--- a/outside.go
+++ b/outside.go
@@ -139,7 +139,7 @@ func (f *Interface) readOutsidePackets(ip netip.AddrPort, via *ViaSender, out []
 			return
 		}
 
-		lhf.HandleRequest(ip, hostinfo.vpnAddrs, d, f)
+		lhf.HandleRequest(ip, hostinfo, d, f)
 
 		// Fallthrough to the bottom to record incoming traffic
 


### PR DESCRIPTION
This MR introduces an interface for filtering incoming host queries based on groups in the querying host's cert and groups in the queried host's cert.  

This will improve the privacy of the network for its users by preventing users from querying hosts that they are not supposed to have access to as defined by the lighthouse configuration. 

<details>
<summary> Required config file additions </summary>

```yaml
lighthouse:
  query_protection:
    test-protection:
      - allowed-group
```
</details>

<details>
<summary> Example positive interaction </summary>

![mermaid-diagram-2025-02-14-140947](https://github.com/user-attachments/assets/f92a34d3-486d-42d3-bd9c-638e584e3b38)

</details>

<details>
<summary> Example negative interaction </summary>

![mermaid-diagram-2025-02-14-140746](https://github.com/user-attachments/assets/1e329d94-4ba6-43c9-bf6c-c8aa831af7a5)

</details>
