### PR TITLE
add so_mark sockopt support

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -138,6 +138,11 @@ listen:
   # valid values: always, never, private
   # This setting is reloadable.
   #send_recv_error: always
+  # The so_sock option is a Linux-specific feature that allows all outgoing Nebula packets to be tagged with a specific identifier.
+  # This tagging enables IP rule-based filtering. For example, it supports 0.0.0.0/0 unsafe_routes,
+  # allowing for more precise routing decisions based on the packet tags. Default is 0 meaning no mark is set.
+  # This setting is reloadable.
+  #so_mark: 0
 
 # Routines is the number of thread pairs to run that consume from the tun and UDP queues.
 # Currently, this defaults to 1 which means we have 1 tun queue reader and 1

--- a/udp/udp_linux.go
+++ b/udp/udp_linux.go
@@ -94,12 +94,20 @@ func (u *StdConn) SetSendBuffer(n int) error {
 	return unix.SetsockoptInt(u.sysFd, unix.SOL_SOCKET, unix.SO_SNDBUFFORCE, n)
 }
 
+func (u *StdConn) SetSoMark(mark int) error {
+	return unix.SetsockoptInt(u.sysFd, unix.SOL_SOCKET, unix.SO_MARK, mark)
+}
+
 func (u *StdConn) GetRecvBuffer() (int, error) {
 	return unix.GetsockoptInt(int(u.sysFd), unix.SOL_SOCKET, unix.SO_RCVBUF)
 }
 
 func (u *StdConn) GetSendBuffer() (int, error) {
 	return unix.GetsockoptInt(int(u.sysFd), unix.SOL_SOCKET, unix.SO_SNDBUF)
+}
+
+func (u *StdConn) GetSoMark() (int, error) {
+	return unix.GetsockoptInt(int(u.sysFd), unix.SOL_SOCKET, unix.SO_MARK)
 }
 
 func (u *StdConn) LocalAddr() (netip.AddrPort, error) {
@@ -300,6 +308,22 @@ func (u *StdConn) ReloadConfig(c *config.C) {
 			}
 		} else {
 			u.l.WithError(err).Error("Failed to set listen.write_buffer")
+		}
+	}
+
+	b = c.GetInt("listen.so_mark", 0)
+	s, err := u.GetSoMark()
+	if b > 0 || (err == nil && s != 0) {
+		err := u.SetSoMark(b)
+		if err == nil {
+			s, err := u.GetSoMark()
+			if err == nil {
+				u.l.WithField("mark", s).Info("listen.so_mark was set")
+			} else {
+				u.l.WithError(err).Warn("Failed to get listen.so_mark")
+			}
+		} else {
+			u.l.WithError(err).Error("Failed to set listen.so_mark")
 		}
 	}
 }


### PR DESCRIPTION
This PR adds the ability to mark the traffic on the nebula interface for linux based systems. This allows the user to handle the nebula generated taffic via ip rules and using generic routing tables. For example, this allows the use of default routes via nebula for clients that already have a default gw set due to their network setup.

Current state:

0.0.0.0/0 routing is already possible in nebula using network namespaces (see https://www.wireguard.com/netns/) however I noticed in my own testing that moving network interfaces between namespaces can often introduce different new problems. E.g. you loose ip assignements on interfaces, `ip a` does not show your physical nic anymore resulting in problems with network managers on desktop style clients.

Related issues / existing pull requests:
- fixes #973 : directly addresses this
- fixes #280 and addresses #145, #307 : this feature enables the scenarios described in this issue (full subnet routing, 0.0.0.0/0, etc). 
- alternative solution to #1324 : while 1324 offers to add the unsafe routes directly to alternative routing tables it currently requires parsing files at distro specific locations. Additionally the PR currently does not support the upcoming ipv6 nebula networks. I belive my pr adds a more generic approach to this problem that is already implemented this way in leading vpn projects (wireguard / openVPN). 
- implements #351 in a more generic way and touching as less code as possible.

To enable 0.0.0.0/0 routing one would have to start nebula using `listen.so_mark` set to e.g. 4242 and then set the following ip rules / ip routes (taken from https://ro-che.info/articles/2021-02-27-linux-routing and the wg-quick project):
```
> ip rule add not from all fwmark 4242 lookup 4242
> ip rule add from all lookup main suppress_prefixlength 0
> ip route add default dev nebula1 via <nebula_unsafe_route_gw> table 4242
```

This PR leaves the "final routing descision" to the user by adding only the abbitity to actually do it to nebula.  This even enables setups with multiple 0.0.0.0/0 unsafe routes in the nebula config. Meaning one could add multiple 0.0.0.0/0 unsafe route endpoints and change which endpoint to actually use on the fly. You could also do something like source based routing to different gws at the same time.
