### PR TITLE
Improve logging when handshaking with an invalid cert

### DIFF
--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -257,7 +257,7 @@ func (hm *HandshakeManager) handleOutbound(vpnIp netip.Addr, lighthouseTriggered
 			WithField("initiatorIndex", hostinfo.localIndexId).
 			WithField("handshake", m{"stage": 1, "style": "ix_psk0"}).
 			Info("Handshake message sent")
-	} else if hm.l.IsLevelEnabled(logrus.DebugLevel) {
+	} else if hm.l.Level >= logrus.DebugLevel {
 		hostinfo.logger(hm.l).WithField("udpAddrs", sentTo).
 			WithField("initiatorIndex", hostinfo.localIndexId).
 			WithField("handshake", m{"stage": 1, "style": "ix_psk0"}).


### PR DESCRIPTION
Fixes a bug where the cert was not printed in debug log level when an invalid cert is encountered.

Adds some information about an invalid cert when in info log level is set. This is to help locate the offending host/certificate.

Logs the cert in some cases after we have determined it is trusted but still invalid for some reason.



