### PR TITLE
smoke-tests: guess the lighthouse container IP better

### DIFF
--- a/.github/workflows/smoke/build.sh
+++ b/.github/workflows/smoke/build.sh
@@ -5,6 +5,10 @@ set -e -x
 rm -rf ./build
 mkdir ./build
 
+# TODO: Assumes your docker bridge network is a /24, and the first container that launches will be .1
+# - We could make this better by launching the lighthouse first and then fetching what IP it is.
+NET="$(docker network inspect bridge -f '{{ range .IPAM.Config }}{{ .Subnet }}{{ end }}' | cut -d. -f1-3)"
+
 (
     cd build
 
@@ -21,16 +25,16 @@ mkdir ./build
         ../genconfig.sh >lighthouse1.yml
 
     HOST="host2" \
-        LIGHTHOUSES="192.168.100.1 172.17.0.2:4242" \
+        LIGHTHOUSES="192.168.100.1 $NET.2:4242" \
         ../genconfig.sh >host2.yml
 
     HOST="host3" \
-        LIGHTHOUSES="192.168.100.1 172.17.0.2:4242" \
+        LIGHTHOUSES="192.168.100.1 $NET.2:4242" \
         INBOUND='[{"port": "any", "proto": "icmp", "group": "lighthouse"}]' \
         ../genconfig.sh >host3.yml
 
     HOST="host4" \
-        LIGHTHOUSES="192.168.100.1 172.17.0.2:4242" \
+        LIGHTHOUSES="192.168.100.1 $NET.2:4242" \
         OUTBOUND='[{"port": "any", "proto": "icmp", "group": "lighthouse"}]' \
         ../genconfig.sh >host4.yml
 


### PR DESCRIPTION
Currently we just assume you are using the default Docker bridge network config of `172.17.0.0/24`. This change works to try to detect if you are using a different config, but still only works if you are using a `/24` and aren't running any other containers.

A future PR could make this better by launching the lighthouse container first and then fetching what the IP address is before continuing with the configuration.