### PR TITLE
Update example config to listen on `::` by default

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -126,8 +126,8 @@ lighthouse:
 # Port Nebula will be listening on. The default here is 4242. For a lighthouse node, the port should be defined,
 # however using port 0 will dynamically assign a port and is recommended for roaming nodes.
 listen:
-  # To listen on both any ipv4 and ipv6 use "::"
-  host: 0.0.0.0
+  # To listen on only ipv4, use "0.0.0.0"
+  host: "::"
   port: 4242
   # Sets the max number of packets to pull from the kernel for each syscall (under systems that support recvmmsg)
   # default is 64, does not support reload


### PR DESCRIPTION
The current example config defaults to listening only on IPv4. I think the default config makes sense to be listening on all paths, including IPv6 paths, so I've updated this example config, as well as inverting the comment that explains how to adjust it.

