### PR TITLE
Fix: Incorrect conversion between integer types

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -243,7 +243,7 @@ func (c *C) GetInt(k string, d int) int {
 // GetUint32 will get the uint32 for k or return the default d if not found or invalid
 func (c *C) GetUint32(k string, d uint32) uint32 {
 	r := c.GetInt(k, int(d))
-	if uint64(r) > uint64(math.MaxUint32) {
+	if r < 0 || uint64(r) > uint64(math.MaxUint32) {
 		return d
 	}
 	return uint32(r)


### PR DESCRIPTION
## Ticket 🎟️ #1352
---
To fix the problem, we need to ensure that the value being converted to `uint32` is within the valid range for `uint32`, which is from 0 to `math.MaxUint32`. This involves adding a lower bound check to ensure the value is not negative. 

The best way to fix this is to modify the `GetUint32` function to include a check for negative values before performing the conversion. This can be done by adding a condition to check if the value is less than 0 and returning the default value `d` if it is.