### PR TITLE
Rename pki.default_version to pki.initiating_version

### DIFF
--- a/connection_manager.go
+++ b/connection_manager.go
@@ -498,7 +498,7 @@ func (n *connectionManager) tryRehandshake(hostinfo *HostInfo) {
 	cs := n.intf.pki.getCertState()
 	curCrt := hostinfo.ConnectionState.myCert
 	myCrt := cs.getCertificate(curCrt.Version())
-	if curCrt.Version() >= cs.defaultVersion && bytes.Equal(curCrt.Signature(), myCrt.Signature()) == true {
+	if curCrt.Version() >= cs.outgoingVersion && bytes.Equal(curCrt.Signature(), myCrt.Signature()) == true {
 		// The current tunnel is using the latest certificate and version, no need to rehandshake.
 		return
 	}

--- a/connection_manager_test.go
+++ b/connection_manager_test.go
@@ -44,7 +44,7 @@ func Test_NewConnectionManagerTest(t *testing.T) {
 	hostMap.preferredRanges.Store(&preferredRanges)
 
 	cs := &CertState{
-		defaultVersion:   cert.Version1,
+		outgoingVersion:  cert.Version1,
 		privateKey:       []byte{},
 		v1Cert:           &dummyCert{version: cert.Version1},
 		v1HandshakeBytes: []byte{},
@@ -126,7 +126,7 @@ func Test_NewConnectionManagerTest2(t *testing.T) {
 	hostMap.preferredRanges.Store(&preferredRanges)
 
 	cs := &CertState{
-		defaultVersion:   cert.Version1,
+		outgoingVersion:  cert.Version1,
 		privateKey:       []byte{},
 		v1Cert:           &dummyCert{version: cert.Version1},
 		v1HandshakeBytes: []byte{},

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -13,11 +13,11 @@ pki:
   # disconnect_invalid is a toggle to force a client to be disconnected if the certificate is expired or invalid.
   #disconnect_invalid: true
 
-  # default_version controls which certificate version is used in handshakes.
+  # outgoing_version controls which certificate version is used when initiating handshakes.
   # This setting only applies if both a v1 and a v2 certificate are configured, in which case it will default to `1`.
   # Once all hosts in the mesh are configured with both a v1 and v2 certificate then this should be changed to `2`.
   # After all hosts in the mesh are using a v2 certificate then v1 certificates are no longer needed.
-  # default_version: 1
+  # outgoing_version: 1
 
 # The static host map defines a set of hosts with fixed IP addresses on the internet (or any network).
 # A host can have multiple fixed IP addresses defined here, and nebula will try each when establishing a tunnel.

--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -25,7 +25,7 @@ func ixHandshakeStage0(f *Interface, hh *HandshakeHostInfo) bool {
 
 	// If we're connecting to a v6 address we must use a v2 cert
 	cs := f.pki.getCertState()
-	v := cs.defaultVersion
+	v := cs.outgoingVersion
 	for _, a := range hh.hostinfo.vpnAddrs {
 		if a.Is6() {
 			v = cert.Version2
@@ -101,7 +101,7 @@ func ixHandshakeStage1(f *Interface, addr netip.AddrPort, via *ViaSender, packet
 	if crt == nil {
 		f.l.WithField("udpAddr", addr).
 			WithField("handshake", m{"stage": 0, "style": "ix_psk0"}).
-			WithField("certVersion", cs.defaultVersion).
+			WithField("certVersion", cs.outgoingVersion).
 			Error("Unable to handshake with host because no certificate is available")
 	}
 

--- a/handshake_manager_test.go
+++ b/handshake_manager_test.go
@@ -24,7 +24,7 @@ func Test_NewHandshakeManagerVpnIp(t *testing.T) {
 	lh := newTestLighthouse()
 
 	cs := &CertState{
-		defaultVersion:   cert.Version1,
+		outgoingVersion:  cert.Version1,
 		privateKey:       []byte{},
 		v1Cert:           &dummyCert{version: cert.Version1},
 		v1HandshakeBytes: []byte{},
@@ -98,5 +98,5 @@ func (mw *mockEncWriter) GetHostInfo(_ netip.Addr) *HostInfo {
 }
 
 func (mw *mockEncWriter) GetCertState() *CertState {
-	return &CertState{defaultVersion: cert.Version2}
+	return &CertState{outgoingVersion: cert.Version2}
 }

--- a/interface.go
+++ b/interface.go
@@ -410,7 +410,7 @@ func (f *Interface) emitStats(ctx context.Context, i time.Duration) {
 	udpStats := udp.NewUDPStatsEmitter(f.writers)
 
 	certExpirationGauge := metrics.GetOrRegisterGauge("certificate.ttl_seconds", nil)
-	certDefaultVersion := metrics.GetOrRegisterGauge("certificate.default_version", nil)
+	certOutgoingVersion := metrics.GetOrRegisterGauge("certificate.outgoing_version", nil)
 	certMaxVersion := metrics.GetOrRegisterGauge("certificate.max_version", nil)
 
 	for {
@@ -425,7 +425,7 @@ func (f *Interface) emitStats(ctx context.Context, i time.Duration) {
 			certState := f.pki.getCertState()
 			defaultCrt := certState.GetDefaultCertificate()
 			certExpirationGauge.Update(int64(defaultCrt.NotAfter().Sub(time.Now()) / time.Second))
-			certDefaultVersion.Update(int64(defaultCrt.Version()))
+			certOutgoingVersion.Update(int64(defaultCrt.Version()))
 
 			// Report the max certificate version we are capable of using
 			if certState.v2Cert != nil {

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -763,7 +763,7 @@ func (lh *LightHouse) innerQueryServer(addr netip.Addr, nb, out []byte) {
 		if hi != nil {
 			v = hi.ConnectionState.myCert.Version()
 		} else {
-			v = lh.ifce.GetCertState().defaultVersion
+			v = lh.ifce.GetCertState().outgoingVersion
 		}
 
 		if v == cert.Version1 {
@@ -883,7 +883,7 @@ func (lh *LightHouse) SendUpdate() {
 		if hi != nil {
 			v = hi.ConnectionState.myCert.Version()
 		} else {
-			v = lh.ifce.GetCertState().defaultVersion
+			v = lh.ifce.GetCertState().outgoingVersion
 		}
 		if v == cert.Version1 {
 			if v1Update == nil {
@@ -1114,7 +1114,7 @@ func (lhh *LightHouseHandler) sendHostPunchNotification(n *NebulaMeta, fromVpnAd
 		targetHI := lhh.lh.ifce.GetHostInfo(punchNotifDest)
 		var useVersion cert.Version
 		if targetHI == nil {
-			useVersion = lhh.lh.ifce.GetCertState().defaultVersion
+			useVersion = lhh.lh.ifce.GetCertState().outgoingVersion
 		} else {
 			crt := targetHI.GetCert().Certificate
 			useVersion = crt.Version()

--- a/lighthouse_test.go
+++ b/lighthouse_test.go
@@ -417,7 +417,7 @@ func (tw *testEncWriter) GetHostInfo(vpnIp netip.Addr) *HostInfo {
 }
 
 func (tw *testEncWriter) GetCertState() *CertState {
-	return &CertState{defaultVersion: tw.protocolVersion}
+	return &CertState{outgoingVersion: tw.protocolVersion}
 }
 
 // assertIp4InArray asserts every address in want is at the same position in have and that the lengths match

--- a/pki.go
+++ b/pki.go
@@ -33,10 +33,10 @@ type CertState struct {
 	v2Cert           cert.Certificate
 	v2HandshakeBytes []byte
 
-	defaultVersion cert.Version
-	privateKey     []byte
-	pkcs11Backed   bool
-	cipher         string
+	outgoingVersion cert.Version
+	privateKey      []byte
+	pkcs11Backed    bool
+	cipher          string
 
 	myVpnNetworks            []netip.Prefix
 	myVpnNetworksTable       *bart.Table[struct{}]
@@ -194,7 +194,7 @@ func (p *PKI) reloadCAPool(c *config.C) *util.ContextualError {
 }
 
 func (cs *CertState) GetDefaultCertificate() cert.Certificate {
-	c := cs.getCertificate(cs.defaultVersion)
+	c := cs.getCertificate(cs.outgoingVersion)
 	if c == nil {
 		panic("No default certificate found")
 	}
@@ -317,28 +317,28 @@ func newCertStateFromConfig(c *config.C) (*CertState, error) {
 		return nil, errors.New("no certificates found in pki.cert")
 	}
 
-	useDefaultVersion := uint32(1)
+	useOutgoingVersion := uint32(1)
 	if v1 == nil {
 		// The only condition that requires v2 as the default is if only a v2 certificate is present
 		// We do this to avoid having to configure it specifically in the config file
-		useDefaultVersion = 2
+		useOutgoingVersion = 2
 	}
 
-	rawDefaultVersion := c.GetUint32("pki.default_version", useDefaultVersion)
-	var defaultVersion cert.Version
-	switch rawDefaultVersion {
+	rawOutgoingVersion := c.GetUint32("pki.outgoing_version", useOutgoingVersion)
+	var outgoingVersion cert.Version
+	switch rawOutgoingVersion {
 	case 1:
 		if v1 == nil {
-			return nil, fmt.Errorf("can not use pki.default_version 1 without a v1 certificate in pki.cert")
+			return nil, fmt.Errorf("can not use pki.outgoing_version 1 without a v1 certificate in pki.cert")
 		}
-		defaultVersion = cert.Version1
+		outgoingVersion = cert.Version1
 	case 2:
-		defaultVersion = cert.Version2
+		outgoingVersion = cert.Version2
 	default:
-		return nil, fmt.Errorf("unknown pki.default_version: %v", rawDefaultVersion)
+		return nil, fmt.Errorf("unknown pki.outgoing_version: %v", rawOutgoingVersion)
 	}
 
-	return newCertState(defaultVersion, v1, v2, isPkcs11, curve, rawKey)
+	return newCertState(outgoingVersion, v1, v2, isPkcs11, curve, rawKey)
 }
 
 func newCertState(dv cert.Version, v1, v2 cert.Certificate, pkcs11backed bool, privateKeyCurve cert.Curve, privateKey []byte) (*CertState, error) {
@@ -361,7 +361,7 @@ func newCertState(dv cert.Version, v1, v2 cert.Certificate, pkcs11backed bool, p
 
 		//TODO: CERT-V2 make sure v2 has v1s address
 
-		cs.defaultVersion = dv
+		cs.outgoingVersion = dv
 	}
 
 	if v1 != nil {
@@ -380,8 +380,8 @@ func newCertState(dv cert.Version, v1, v2 cert.Certificate, pkcs11backed bool, p
 		cs.v1Cert = v1
 		cs.v1HandshakeBytes = v1hs
 
-		if cs.defaultVersion == 0 {
-			cs.defaultVersion = cert.Version1
+		if cs.outgoingVersion == 0 {
+			cs.outgoingVersion = cert.Version1
 		}
 	}
 
@@ -401,8 +401,8 @@ func newCertState(dv cert.Version, v1, v2 cert.Certificate, pkcs11backed bool, p
 		cs.v2Cert = v2
 		cs.v2HandshakeBytes = v2hs
 
-		if cs.defaultVersion == 0 {
-			cs.defaultVersion = cert.Version2
+		if cs.outgoingVersion == 0 {
+			cs.outgoingVersion = cert.Version2
 		}
 	}
 


### PR DESCRIPTION
Default may imply that we will fallback to v1 in the event that v2 does not work. This is not true - this config value specifies the exact certificate version that should be used when initiating a tunnel.