### PR TITLE
populate default Build version if missing

### DIFF
--- a/cmd/nebula-cert/main.go
+++ b/cmd/nebula-cert/main.go
@@ -5,9 +5,27 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime/debug"
+	"strings"
 )
 
+// A version string that can be set with
+//
+//	-ldflags "-X main.Build=SOMEVERSION"
+//
+// at compile-time.
 var Build string
+
+func init() {
+	if Build == "" {
+		info, ok := debug.ReadBuildInfo()
+		if !ok {
+			return
+		}
+
+		Build = strings.TrimPrefix(info.Main.Version, "v")
+	}
+}
 
 type helpError struct {
 	s string

--- a/cmd/nebula-service/main.go
+++ b/cmd/nebula-service/main.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime/debug"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/slackhq/nebula"
@@ -17,6 +19,17 @@ import (
 //
 // at compile-time.
 var Build string
+
+func init() {
+	if Build == "" {
+		info, ok := debug.ReadBuildInfo()
+		if !ok {
+			return
+		}
+
+		Build = strings.TrimPrefix(info.Main.Version, "v")
+	}
+}
 
 func main() {
 	serviceFlag := flag.String("service", "", "Control the system service.")

--- a/cmd/nebula/main.go
+++ b/cmd/nebula/main.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime/debug"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/slackhq/nebula"
@@ -17,6 +19,17 @@ import (
 //
 // at compile-time.
 var Build string
+
+func init() {
+	if Build == "" {
+		info, ok := debug.ReadBuildInfo()
+		if !ok {
+			return
+		}
+
+		Build = strings.TrimPrefix(info.Main.Version, "v")
+	}
+}
 
 func main() {
 	configPath := flag.String("config", "", "Path to either a file or directory to load configuration from")


### PR DESCRIPTION
Use the Go module information built into the binary if the Build var wasn't set during the build.

This means if you install via a specific tag, you get:

    go install github.com/slackhq/nebula/cmd/nebula@v1.9.5

    $ nebula -version
    Version: 1.9.5

And if you install master, you get:

    go install github.com/slackhq/nebula/cmd/nebula@master

    $ nebula -version
    Version: 1.9.5-0.20250408154034-18279ed17b10