### PR TITLE
Minor fixes to Readme shell snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ For each host, copy the nebula binary to the host, along with `config.yml` from 
 **DO NOT COPY `ca.key` TO INDIVIDUAL NODES.**
 
 #### 7. Run nebula on each host
+
 ```sh
 ./nebula -config /path/to/config.yml
 ```
@@ -147,6 +148,7 @@ See the [Makefile](Makefile) for more details on build targets
 The default curve used for cryptographic handshakes and signatures is Curve25519. This is the recommended setting for most users. If your deployment has certain compliance requirements, you have the option of creating your CA using `nebula-cert ca -curve P256` to use NIST Curve P256. The CA will then sign certificates using ECDSA P256, and any hosts using these certificates will use P256 for ECDH handshakes.
 
 In addition, Nebula can be built using the [BoringCrypto GOEXPERIMENT](https://github.com/golang/go/blob/go1.20/src/crypto/internal/boring/README.md) by running either of the following make targets:
+
 ```sh
 make bin-boringcrypto
 make release-boringcrypto

--- a/README.md
+++ b/README.md
@@ -127,14 +127,10 @@ For each host, copy the nebula binary to the host, along with `config.yml` from 
 Make sure you have [go](https://go.dev/doc/install) installed and clone this repo. Change to the nebula directory.
 
 To build nebula for all platforms:
-```sh
-make all
-```
+`make all`
 
 To build nebula for a specific platform (ex, Windows):
-```sh
-make bin-windows
-```
+`make bin-windows`
 
 See the [Makefile](Makefile) for more details on build targets
 

--- a/README.md
+++ b/README.md
@@ -28,33 +28,33 @@ Check the [releases](https://github.com/slackhq/nebula/releases/latest) page for
 #### Distribution Packages
 
 - [Arch Linux](https://archlinux.org/packages/extra/x86_64/nebula/)
-    ```
-    $ sudo pacman -S nebula
+    ```sh
+    sudo pacman -S nebula
     ```
 
 - [Fedora Linux](https://src.fedoraproject.org/rpms/nebula)
-    ```
-    $ sudo dnf install nebula
+    ```sh
+    sudo dnf install nebula
     ```
 
 - [Debian Linux](https://packages.debian.org/source/stable/nebula)
-    ```
-    $ sudo apt install nebula
+    ```sh
+    sudo apt install nebula
     ```
 
 - [Alpine Linux](https://pkgs.alpinelinux.org/packages?name=nebula)
-    ```
-    $ sudo apk add nebula
+    ```sh
+    sudo apk add nebula
     ```
 
 - [macOS Homebrew](https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/n/nebula.rb)
-    ```
-    $ brew install nebula
+    ```sh
+    brew install nebula
     ```
 
 - [Docker](https://hub.docker.com/r/nebulaoss/nebula)
-    ```
-    $ docker pull nebulaoss/nebula
+    ```sh
+    docker pull nebulaoss/nebula
     ```
 
 #### Mobile
@@ -89,14 +89,14 @@ Nebula lighthouses allow nodes to find each other, anywhere in the world. A ligh
 
 #### 3. A Nebula certificate authority, which will be the root of trust for a particular Nebula network.
 
-  ```
-  ./nebula-cert ca -name "Myorganization, Inc"
-  ```
+```sh
+./nebula-cert ca -name "Myorganization, Inc"
+```
   This will create files named `ca.key` and `ca.cert` in the current directory. The `ca.key` file is the most sensitive file you'll create, because it is the key used to sign the certificates for individual nebula nodes/hosts. Please store this file somewhere safe, preferably with strong encryption.
 
 #### 4. Nebula host keys and certificates generated from that certificate authority
 This assumes you have four nodes, named lighthouse1, laptop, server1, host3. You can name the nodes any way you'd like, including FQDN. You'll also need to choose IP addresses and the associated subnet. In this example, we are creating a nebula network that will use 192.168.100.x/24 as its network range. This example also demonstrates nebula groups, which can later be used to define traffic rules in a nebula network.
-```
+```sh
 ./nebula-cert sign -name "lighthouse1" -ip "192.168.100.1/24"
 ./nebula-cert sign -name "laptop" -ip "192.168.100.2/24" -groups "laptop,home,ssh"
 ./nebula-cert sign -name "server1" -ip "192.168.100.9/24" -groups "servers"
@@ -118,7 +118,7 @@ For each host, copy the nebula binary to the host, along with `config.yml` from 
 **DO NOT COPY `ca.key` TO INDIVIDUAL NODES.**
 
 #### 7. Run nebula on each host
-```
+```sh
 ./nebula -config /path/to/config.yml
 ```
 
@@ -127,10 +127,14 @@ For each host, copy the nebula binary to the host, along with `config.yml` from 
 Make sure you have [go](https://go.dev/doc/install) installed and clone this repo. Change to the nebula directory.
 
 To build nebula for all platforms:
-`make all`
+```sh
+make all
+```
 
 To build nebula for a specific platform (ex, Windows):
-`make bin-windows`
+```sh
+make bin-windows
+```
 
 See the [Makefile](Makefile) for more details on build targets
 
@@ -139,9 +143,10 @@ See the [Makefile](Makefile) for more details on build targets
 The default curve used for cryptographic handshakes and signatures is Curve25519. This is the recommended setting for most users. If your deployment has certain compliance requirements, you have the option of creating your CA using `nebula-cert ca -curve P256` to use NIST Curve P256. The CA will then sign certificates using ECDSA P256, and any hosts using these certificates will use P256 for ECDH handshakes.
 
 In addition, Nebula can be built using the [BoringCrypto GOEXPERIMENT](https://github.com/golang/go/blob/go1.20/src/crypto/internal/boring/README.md) by running either of the following make targets:
-
-    make bin-boringcrypto
-    make release-boringcrypto
+```sh
+make bin-boringcrypto
+make release-boringcrypto
+```
 
 This is not the recommended default deployment, but may be useful based on your compliance requirements.
 


### PR DESCRIPTION
Closes #1388 

This removes the shell prompt from the install snippets, allowing those blocks to be copied and directly pasted into a terminal.

This also adds the `sh` block syntax coloring to all shell snippets.