### PR TITLE
Fix relay migration panic by covering every possible relay state

### DIFF
--- a/connection_manager.go
+++ b/connection_manager.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"fmt"
 	"net/netip"
 	"sync"
 	"time"
@@ -227,21 +228,25 @@ func (n *connectionManager) migrateRelayUsed(oldhostinfo, newhostinfo *HostInfo)
 		var relayFrom netip.Addr
 		var relayTo netip.Addr
 		switch {
-		case ok && existing.State == Established:
-			// This relay already exists in newhostinfo, then do nothing.
-			continue
-		case ok && existing.State == Requested:
-			// The relay exists in a Requested state; re-send the request
-			index = existing.LocalIndex
-			switch r.Type {
-			case TerminalType:
-				relayFrom = n.intf.myVpnNet.Addr()
-				relayTo = existing.PeerIp
-			case ForwardingType:
-				relayFrom = existing.PeerIp
-				relayTo = newhostinfo.vpnIp
-			default:
-				// should never happen
+		case ok:
+			switch existing.State {
+			case Established, PeerRequested, Disestablished:
+				// This relay already exists in newhostinfo, then do nothing.
+				continue
+			case Requested:
+				// The relayed connection exists in a Requested state; re-send the request
+				index = existing.LocalIndex
+				switch r.Type {
+				case TerminalType:
+					relayFrom = n.intf.myVpnNet.Addr()
+					relayTo = existing.PeerIp
+				case ForwardingType:
+					relayFrom = existing.PeerIp
+					relayTo = newhostinfo.vpnIp
+				default:
+					// should never happen
+					panic(fmt.Sprintf("Migrating unknown relay type: %v", r.Type))
+				}
 			}
 		case !ok:
 			n.relayUsedLock.RLock()
@@ -267,6 +272,7 @@ func (n *connectionManager) migrateRelayUsed(oldhostinfo, newhostinfo *HostInfo)
 				relayTo = newhostinfo.vpnIp
 			default:
 				// should never happen
+				panic(fmt.Sprintf("Migrating unknown relay type: %v", r.Type))
 			}
 		}
 


### PR DESCRIPTION
With the move to ipnet.Addr types, there will be a panic if an uninitialized netip.Addr type has `As4()` called on it.

We received a stack trace from a user showing this was happening on line 274 of connection_manager. Based on code inspection, this PR ensures that every State case is covered to avoid an uninitialized Addr panicking on line 274.

I tried for a bit, but couldn't come up with a nice automated test for this case.