### PR TITLE
Disable UDP receive error returns due to ICMP messages on Windows.

### DIFF
--- a/udp/udp_rio_windows.go
+++ b/udp/udp_rio_windows.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"syscall"
-	"time"
 	"unsafe"
 
 	"github.com/sirupsen/logrus"
@@ -96,6 +95,25 @@ func (u *RIOConn) bind(sa windows.Sockaddr) error {
 	// Enable v4 for this socket
 	syscall.SetsockoptInt(syscall.Handle(u.sock), syscall.IPPROTO_IPV6, syscall.IPV6_V6ONLY, 0)
 
+	// Disable reporting of PORT_UNREACHABLE and NET_UNREACHABLE errors from the UDP socket receive call.
+	// These errors are returned on Windows during UDP receives based on the receipt of ICMP packets. Disable
+	// the UDP receive error returns with these ioctl calls.
+	ret := uint32(0)
+	flag := uint32(0)
+	size := uint32(unsafe.Sizeof(flag))
+	err = syscall.WSAIoctl(syscall.Handle(u.sock), syscall.SIO_UDP_CONNRESET, (*byte)(unsafe.Pointer(&flag)), size, nil, 0, &ret, nil, 0)
+	if err != nil {
+		return err
+	}
+	ret = 0
+	flag = 0
+	size = uint32(unsafe.Sizeof(flag))
+	SIO_UDP_NETRESET := uint32(syscall.IOC_IN | syscall.IOC_VENDOR | 15)
+	err = syscall.WSAIoctl(syscall.Handle(u.sock), SIO_UDP_NETRESET, (*byte)(unsafe.Pointer(&flag)), size, nil, 0, &ret, nil, 0)
+	if err != nil {
+		return err
+	}
+
 	err = u.rx.Open()
 	if err != nil {
 		return err
@@ -126,7 +144,6 @@ func (u *RIOConn) ListenOut(r EncReader, lhf LightHouseHandlerFunc, cache *firew
 	fwPacket := &firewall.Packet{}
 	nb := make([]byte, 12, 12)
 
-	consecutiveErrors := 0
 	for {
 		// Just read one packet at a time
 		n, rua, err := u.receive(buffer)
@@ -135,18 +152,9 @@ func (u *RIOConn) ListenOut(r EncReader, lhf LightHouseHandlerFunc, cache *firew
 				u.l.WithError(err).Debug("udp socket is closed, exiting read loop")
 				return
 			}
-			// Try to suss out whether this is a transient error or something more permanent
-			consecutiveErrors++
-			u.l.WithError(err).WithField("consecutiveErrors", consecutiveErrors).Error("unexpected udp socket recieve error")
-			if consecutiveErrors > 15 {
-				panic("too many consecutive UDP receive errors")
-			} else if consecutiveErrors > 10 {
-				time.Sleep(100 * time.Millisecond)
-			}
+			u.l.WithError(err).Error("unexpected udp socket receive error")
 			continue
 		}
-
-		consecutiveErrors = 0
 
 		r(
 			netip.AddrPortFrom(netip.AddrFrom16(rua.Addr).Unmap(), (rua.Port>>8)|((rua.Port&0xff)<<8)),


### PR DESCRIPTION
Fix #1411 

My previous PR #1404  handled some UDP receive errors returned with a limited retry loop, with a counter to suss out whether an error condition was temporary or permanent. I wasn't sure at the time what was causing the UDP receive to return errors.

I can now reproduce errors in this path, by disabling the Windows firewall (or otherwise ensuring ICMP messages are not filtered out on the host) and by sending ICMP Destination Unreachable packets to the Windows host with the Nebula UDP socket port number.

For each ICMP received by Windows, there will be an error returned by the UDP receive call. This means that the `consecutiveErrors` counter can't really be trusted - the errors will be determined by the number of ICMP packets, not by some indeterminate cause.

To resolve this issue, I've updated the Windows path to modify this error return behavior with a pair of IOCTL calls.

I've manually tested this by generating 100 ICMP messages and firing them off at the Windows host. I have reproduced the error with the current release-1.9 code, which will panic after the 15th consecutive error. I fail to reproduce the error with this PR.