### PR TITLE
DNS server fixes and improvements

### DIFF
--- a/dns_server.go
+++ b/dns_server.go
@@ -105,14 +105,14 @@ func (d *dnsRecords) Add(crt cert.Certificate) {
 }
 
 func (d *dnsRecords) parseQuery(m *dns.Msg) {
+	d.RLock()
+	defer d.RUnlock()
 	for _, q := range m.Question {
 		switch q.Qtype {
 		case dns.TypeA, dns.TypeAAAA, dns.TypePTR, dns.TypeTXT:
-			d.RLock()
 			if rr, ok := d.dnsMap[q]; ok {
 				m.Answer = append(m.Answer, rr...)
 			}
-			d.RUnlock()
 		}
 	}
 

--- a/dns_server.go
+++ b/dns_server.go
@@ -47,7 +47,7 @@ func (d *dnsRecords) addA(name string, crt cert.Certificate) {
 			}
 		}
 	}
-} 
+}
 
 func (d *dnsRecords) addAAAA(name string, crt cert.Certificate) {
 	q := dns.Question{Name: name, Qclass: dns.ClassINET, Qtype: dns.TypeAAAA}
@@ -63,7 +63,7 @@ func (d *dnsRecords) addAAAA(name string, crt cert.Certificate) {
 			}
 		}
 	}
-} 
+}
 
 func (d *dnsRecords) addPTR(name string, crt cert.Certificate) {
 	for _, n := range crt.Networks() {
@@ -78,23 +78,23 @@ func (d *dnsRecords) addPTR(name string, crt cert.Certificate) {
 			}
 		}
 	}
-} 
+}
 
 func (d *dnsRecords) addTXT(name string, crt cert.Certificate) {
 	q := dns.Question{Name: name, Qclass: dns.ClassINET, Qtype: dns.TypeTXT}
 	d.dnsMap[q] = nil
 
 	qType := dns.TypeToString[q.Qtype]
-	rr, err := dns.NewRR(fmt.Sprintf("%s %s \"Name: %v\" \"Networks: %v\" \"Groups: %v\" \"UnsafeNetworks: %v\"", name, qType, crt.Name(), crt.Networks(), crt.Groups(), crt.UnsafeNetworks()))
+	rr, err := dns.NewRR(fmt.Sprintf("%s %s \"Name: %v\" \"Networks: %v\" \"Groups: %v\" \"UnsafeNetworks: %v\" \"NotBefore: %v\" \"NotAfter: %v\" \"PublicKey: %x\" \"Issuer: %v\"", name, qType, crt.Name(), crt.Networks(), crt.Groups(), crt.UnsafeNetworks(), crt.NotBefore(), crt.NotAfter(), crt.PublicKey(), crt.Issuer()))
 	if err == nil {
 		d.dnsMap[q] = []dns.RR{rr}
 		d.l.Debugf("DNS record added %s", rr.String())
 	}
-} 
+}
 
 func (d *dnsRecords) Add(crt cert.Certificate) {
 	host := dns.Fqdn(strings.ToLower(crt.Name() + dnsSuffix))
-	
+
 	d.Lock()
 	defer d.Unlock()
 

--- a/dns_server.go
+++ b/dns_server.go
@@ -34,9 +34,7 @@ func newDnsRecords(l *logrus.Logger) *dnsRecords {
 	}
 }
 
-func (d *dnsRecords) AddA(name string, addresses []netip.Addr) {
-	d.Lock()
-	defer d.Unlock()
+func (d *dnsRecords) addA(name string, addresses []netip.Addr) {
 	q := dns.Question{Name: name, Qclass: dns.ClassINET, Qtype: dns.TypeA}
 	d.dnsMap[q] = nil
 
@@ -50,11 +48,9 @@ func (d *dnsRecords) AddA(name string, addresses []netip.Addr) {
 			}
 		}
 	}
-}
+} 
 
-func (d *dnsRecords) AddAAAA(name string, addresses []netip.Addr) {
-	d.Lock()
-	defer d.Unlock()
+func (d *dnsRecords) addAAAA(name string, addresses []netip.Addr) {
 	q := dns.Question{Name: name, Qclass: dns.ClassINET, Qtype: dns.TypeAAAA}
 	d.dnsMap[q] = nil
 
@@ -68,12 +64,9 @@ func (d *dnsRecords) AddAAAA(name string, addresses []netip.Addr) {
 			}
 		}
 	}
-}
+} 
 
-func (d *dnsRecords) AddPTR(name string, addresses []netip.Addr) {
-	d.Lock()
-	defer d.Unlock()
-
+func (d *dnsRecords) addPTR(name string, addresses []netip.Addr) {
 	for _, addr := range addresses {
 		arpa, err := dns.ReverseAddr(addr.String())
 		if err == nil {
@@ -86,11 +79,9 @@ func (d *dnsRecords) AddPTR(name string, addresses []netip.Addr) {
 			}
 		}
 	}
-}
+} 
 
-func (d *dnsRecords) AddTXT(name string, crt cert.Certificate) {
-	d.Lock()
-	defer d.Unlock()
+func (d *dnsRecords) addTXT(name string, crt cert.Certificate) {
 	q := dns.Question{Name: name, Qclass: dns.ClassINET, Qtype: dns.TypeTXT}
 	d.dnsMap[q] = nil
 
@@ -100,14 +91,18 @@ func (d *dnsRecords) AddTXT(name string, crt cert.Certificate) {
 		d.dnsMap[q] = []dns.RR{rr}
 		d.l.Debugf("DNS record added %s", rr.String())
 	}
-}
+} 
 
 func (d *dnsRecords) Add(crt cert.Certificate, addresses []netip.Addr) {
 	host := dns.Fqdn(strings.ToLower(crt.Name() + dnsSuffix))
-	d.AddA(host, addresses)
-	d.AddAAAA(host, addresses)
-	d.AddPTR(host, addresses)
-	d.AddTXT(host, crt)
+	
+	d.Lock()
+	defer d.Unlock()
+
+	d.addA(host, addresses)
+	d.addAAAA(host, addresses)
+	d.addPTR(host, addresses)
+	d.addTXT(host, crt)
 }
 
 func (d *dnsRecords) parseQuery(m *dns.Msg) {

--- a/dns_server.go
+++ b/dns_server.go
@@ -102,7 +102,6 @@ func (d *dnsRecords) AddTXT(name string, crt cert.Certificate) {
 	}
 }
 
-// Add adds the first IPv4 and IPv6 address that appears in `addresses` as the record for `host`
 func (d *dnsRecords) Add(crt cert.Certificate, addresses []netip.Addr) {
 	host := dns.Fqdn(strings.ToLower(crt.Name() + dnsSuffix))
 	d.AddA(host, addresses)

--- a/dns_server_test.go
+++ b/dns_server_test.go
@@ -20,7 +20,10 @@ func TestParsequery(t *testing.T) {
 		netip.MustParseAddr("fd01::25"),
 	}
 	dnsSuffix = ".com"
-	ds.Add("test.com", addrs)
+	crt := &dummyCert{
+		name: "test.com",
+	}
+	ds.Add(crt, addrs)
 
 	m := &dns.Msg{}
 	m.SetQuestion("test.com.com.", dns.TypeA)

--- a/dns_server_test.go
+++ b/dns_server_test.go
@@ -13,17 +13,18 @@ import (
 func TestParsequery(t *testing.T) {
 	l := logrus.New()
 	ds := newDnsRecords(l)
-	addrs := []netip.Addr{
-		netip.MustParseAddr("1.2.3.4"),
-		netip.MustParseAddr("1.2.3.5"),
-		netip.MustParseAddr("fd01::24"),
-		netip.MustParseAddr("fd01::25"),
+	networks := []netip.Prefix{
+		netip.MustParsePrefix("1.2.3.4/24"),
+		netip.MustParsePrefix("1.2.3.5/32"),
+		netip.MustParsePrefix("fd01::24/64"),
+		netip.MustParsePrefix("fd01::25/128"),
 	}
 	dnsSuffix = ".com"
 	crt := &dummyCert{
 		name: "test.com",
+		networks: networks,
 	}
-	ds.Add(crt, addrs)
+	ds.Add(crt)
 
 	m := &dns.Msg{}
 	m.SetQuestion("test.com.com.", dns.TypeA)

--- a/dns_server_test.go
+++ b/dns_server_test.go
@@ -30,12 +30,14 @@ func TestParsequery(t *testing.T) {
 	ds.parseQuery(m)
 	assert.NotNil(t, m.Answer)
 	assert.Equal(t, "1.2.3.4", m.Answer[0].(*dns.A).A.String())
+	assert.Equal(t, "1.2.3.5", m.Answer[1].(*dns.A).A.String())
 
 	m = &dns.Msg{}
 	m.SetQuestion("test.com.com.", dns.TypeAAAA)
 	ds.parseQuery(m)
 	assert.NotNil(t, m.Answer)
 	assert.Equal(t, "fd01::24", m.Answer[0].(*dns.AAAA).AAAA.String())
+	assert.Equal(t, "fd01::25", m.Answer[1].(*dns.AAAA).AAAA.String())
 
 	m = &dns.Msg{}
 	m.SetQuestion("4.3.2.1.in-addr.arpa.", dns.TypePTR)

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -52,6 +52,7 @@ lighthouse:
     # The DNS host defines the IP to bind the dns listener to. This also allows binding to the nebula node IP.
     #host: 0.0.0.0
     #port: 53
+    #suffix: ".nebula"
   # interval is the number of seconds between updates from this node to a lighthouse.
   # during updates, a node sends information about its current IP addresses to each node.
   interval: 60

--- a/hostmap.go
+++ b/hostmap.go
@@ -565,7 +565,7 @@ func (hm *HostMap) queryVpnAddr(vpnIp netip.Addr, promoteIfce *Interface) *HostI
 func (hm *HostMap) unlockedAddHostInfo(hostinfo *HostInfo, f *Interface) {
 	if f.serveDns {
 		remoteCert := hostinfo.ConnectionState.peerCert
-		dnsR.Add(remoteCert.Certificate, hostinfo.vpnAddrs)
+		dnsR.Add(remoteCert.Certificate)
 	}
 	for _, addr := range hostinfo.vpnAddrs {
 		hm.unlockedInnerAddHostInfo(addr, hostinfo, f)

--- a/hostmap.go
+++ b/hostmap.go
@@ -565,7 +565,7 @@ func (hm *HostMap) queryVpnAddr(vpnIp netip.Addr, promoteIfce *Interface) *HostI
 func (hm *HostMap) unlockedAddHostInfo(hostinfo *HostInfo, f *Interface) {
 	if f.serveDns {
 		remoteCert := hostinfo.ConnectionState.peerCert
-		dnsR.Add(remoteCert.Certificate.Name(), hostinfo.vpnAddrs)
+		dnsR.Add(remoteCert.Certificate, hostinfo.vpnAddrs)
 	}
 	for _, addr := range hostinfo.vpnAddrs {
 		hm.unlockedInnerAddHostInfo(addr, hostinfo, f)

--- a/hostmap.go
+++ b/hostmap.go
@@ -565,7 +565,7 @@ func (hm *HostMap) queryVpnAddr(vpnIp netip.Addr, promoteIfce *Interface) *HostI
 func (hm *HostMap) unlockedAddHostInfo(hostinfo *HostInfo, f *Interface) {
 	if f.serveDns {
 		remoteCert := hostinfo.ConnectionState.peerCert
-		dnsR.Add(remoteCert.Certificate.Name()+".", hostinfo.vpnAddrs)
+		dnsR.Add(remoteCert.Certificate.Name(), hostinfo.vpnAddrs)
 	}
 	for _, addr := range hostinfo.vpnAddrs {
 		hm.unlockedInnerAddHostInfo(addr, hostinfo, f)

--- a/main.go
+++ b/main.go
@@ -284,7 +284,7 @@ func Main(c *config.C, configTest bool, buildVersion string, logger *logrus.Logg
 	var dnsStart func()
 	if lightHouse.amLighthouse && serveDns {
 		l.Debugln("Starting dns server")
-		dnsStart = dnsMain(l, pki.getCertState(), hostMap, c)
+		dnsStart = dnsMain(l, pki.getCertState(), c)
 	}
 
 	return &Control{


### PR DESCRIPTION
This PR adds a number of fixes and improvements to the DNS server, including:

- Adding configurable DNS suffix. This can be used to add an optional DNS suffix for example `.nebula` to all DNS records.  This is useful for adding a common namespace for all nebula hosts, and ensuring that all host have a fully qualified domain name.
- Adding PTR records for all IP addresses. This makes it possible to do reverse DNS lookup and finding the host name from an IP address.
- Fixing broken TXT records. There seems to be a bug in the current implementation stopping the DNS server form sending out TXT records. This PR fixes this issue, and reduces the information in the TXT record to only include Name, Networks/Ips, Groups, and UnsafeNetworks
- Adding support for multiple IP addresses by providing one A/AAAA record for each IPv4/IPv6 address of the host.
- Adds DNS record for the host runng the DNS server.