### PR TITLE
Fix bounds checking in IPv6 packet parser

### DIFF
--- a/outside.go
+++ b/outside.go
@@ -312,12 +312,11 @@ func parseV6(data []byte, incoming bool, fp *firewall.Packet) error {
 	offset := ipv6.HeaderLen // Start at the end of the ipv6 header
 	next := 0
 	for {
-		if dataLen < offset {
+		if protoAt >= dataLen {
 			break
 		}
-
 		proto := layers.IPProtocol(data[protoAt])
-		//fmt.Println(proto, protoAt)
+
 		switch proto {
 		case layers.IPProtocolICMPv6, layers.IPProtocolESP, layers.IPProtocolNoNextHeader:
 			fp.Protocol = uint8(proto)
@@ -365,7 +364,7 @@ func parseV6(data []byte, incoming bool, fp *firewall.Packet) error {
 
 		case layers.IPProtocolAH:
 			// Auth headers, used by IPSec, have a different meaning for header length
-			if dataLen < offset+1 {
+			if dataLen <= offset+1 {
 				break
 			}
 
@@ -373,7 +372,7 @@ func parseV6(data []byte, incoming bool, fp *firewall.Packet) error {
 
 		default:
 			// Normal ipv6 header length processing
-			if dataLen < offset+1 {
+			if dataLen <= offset+1 {
 				break
 			}
 


### PR DESCRIPTION
Fix bounds checks in IPv6 parsing.

Bounds checks with slices were OK, because slice ends are exclusive. The code paths that directly index the length field were off by one because the direct indexes used were inclusive.

I also modified the initial check to directly match the variables used in the indexing, but I don't see a code path to ever trigger an issue here, because other checks prevent bad input from ever reaching this point.
- In the initial for loop, the buffer is already checked to be at least 40 bytes, and the proto is at byte 6.
- In subsequent iterations, protoAt is at offset, but the length field is already consumed, and is beyond the proto field.

Tests included to exercise the modified code paths.
