### PR TITLE
Store relay states in a slice for consistent ordering

### DIFF
--- a/control_test.go
+++ b/control_test.go
@@ -66,7 +66,7 @@ func TestControl_GetHostInfoByVpnIp(t *testing.T) {
 		localIndexId:  201,
 		vpnIp:         vpnIp,
 		relayState: RelayState{
-			relays:        map[netip.Addr]struct{}{},
+			relays:        nil,
 			relayForByIp:  map[netip.Addr]*Relay{},
 			relayForByIdx: map[uint32]*Relay{},
 		},
@@ -85,7 +85,7 @@ func TestControl_GetHostInfoByVpnIp(t *testing.T) {
 		localIndexId:  201,
 		vpnIp:         vpnIp2,
 		relayState: RelayState{
-			relays:        map[netip.Addr]struct{}{},
+			relays:        nil,
 			relayForByIp:  map[netip.Addr]*Relay{},
 			relayForByIdx: map[uint32]*Relay{},
 		},

--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -151,7 +151,7 @@ func ixHandshakeStage1(f *Interface, addr netip.AddrPort, via *ViaSender, packet
 		HandshakePacket:   make(map[uint8][]byte, 0),
 		lastHandshakeTime: hs.Details.Time,
 		relayState: RelayState{
-			relays:        map[netip.Addr]struct{}{},
+			relays:        nil,
 			relayForByIp:  map[netip.Addr]*Relay{},
 			relayForByIdx: map[uint32]*Relay{},
 		},

--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -403,7 +403,7 @@ func (hm *HandshakeManager) StartHandshake(vpnIp netip.Addr, cacheCb func(*Hands
 		vpnIp:           vpnIp,
 		HandshakePacket: make(map[uint8][]byte, 0),
 		relayState: RelayState{
-			relays:        map[netip.Addr]struct{}{},
+			relays:        nil,
 			relayForByIp:  map[netip.Addr]*Relay{},
 			relayForByIdx: map[uint32]*Relay{},
 		},

--- a/hostmap_test.go
+++ b/hostmap_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/slackhq/nebula/config"
 	"github.com/slackhq/nebula/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHostMap_MakePrimary(t *testing.T) {
@@ -224,4 +225,32 @@ func TestHostMap_reload(t *testing.T) {
 
 	c.ReloadConfigString("preferred_ranges: [1.1.1.1/32]")
 	assert.EqualValues(t, []string{"1.1.1.1/32"}, toS(hm.GetPreferredRanges()))
+}
+
+func TestHostMap_RelayState(t *testing.T) {
+	h1 := &HostInfo{vpnIp: netip.MustParseAddr("0.0.0.1"), localIndexId: 1}
+	a1 := netip.MustParseAddr("::1")
+	a2 := netip.MustParseAddr("2001::1")
+
+	h1.relayState.InsertRelayTo(a1)
+	assert.Equal(t, h1.relayState.relays, []netip.Addr{a1})
+	h1.relayState.InsertRelayTo(a2)
+	assert.Equal(t, h1.relayState.relays, []netip.Addr{a1, a2})
+	// Ensure that the first relay added is the first one returned in the copy
+	currentRelays := h1.relayState.CopyRelayIps()
+	require.Len(t, currentRelays, 2)
+	assert.Equal(t, currentRelays[0], a1)
+
+	// Deleting the last one in the list works ok
+	h1.relayState.DeleteRelay(a2)
+	assert.Equal(t, h1.relayState.relays, []netip.Addr{a1})
+
+	// Deleting an element not in the list works ok
+	h1.relayState.DeleteRelay(a2)
+	assert.Equal(t, h1.relayState.relays, []netip.Addr{a1})
+
+	// Deleting the only element in the list works ok
+	h1.relayState.DeleteRelay(a1)
+	assert.Equal(t, h1.relayState.relays, []netip.Addr{})
+
 }


### PR DESCRIPTION
Store relays in a slice for consistent ordering. The first IP placed in the slice will always be the first one returned in the copy.

This will ensure that the first relay established during handshaking is always the relay used to send traffic (unlike the map, which will order the relay ip's arbitrarily, should additional relays be established after the initial setup is complete.) Additionally, golang returns map orderings somewhat randomly. Changing this to an ordered slice ensures that the same relay is always used in a connection.
