### PR TITLE
Darwin udp fix

### DIFF
--- a/udp/errors.go
+++ b/udp/errors.go
@@ -1,0 +1,5 @@
+package udp
+
+import "errors"
+
+var ErrInvalidIPv6RemoteForSocket = errors.New("listener is IPv4, but writing to IPv6 remote")

--- a/udp/udp_generic.go
+++ b/udp/udp_generic.go
@@ -1,6 +1,7 @@
-//go:build (!linux || android) && !e2e_testing
+//go:build (!linux || android) && !e2e_testing && !darwin
 // +build !linux android
 // +build !e2e_testing
+// +build !darwin
 
 // udp_generic implements the nebula UDP interface in pure Go stdlib. This
 // means it can be used on platforms like Darwin and Windows.

--- a/udp/udp_linux.go
+++ b/udp/udp_linux.go
@@ -243,7 +243,7 @@ func (u *StdConn) writeTo6(b []byte, ip netip.AddrPort) error {
 
 func (u *StdConn) writeTo4(b []byte, ip netip.AddrPort) error {
 	if !ip.Addr().Is4() {
-		return fmt.Errorf("Listener is IPv4, but writing to IPv6 remote")
+		return ErrInvalidIPv6RemoteForSocket
 	}
 
 	var rsa unix.RawSockaddrInet4


### PR DESCRIPTION
Golang stdlib has a situation in darwin where a UDP write can return `EAGAIN` but never sees a writeable event bubble up from `kevent` which causes the write to deadlock, [bug report](https://github.com/golang/go/issues/73919). 

This PR attempts to avoid the deadlock by making our own `sendto` syscall and returning an error when `EAGAIN` is encountered.

The reason I am lifting `sendto` out of the `x/sys` package is because Apple doesn't like folks calling the kernel directly and instead wants them to go through `libSystem` and I would rather not re-implement the trampoline through assembly in our codebase. Doing a direct syscall might also block future releases of mobile nebula.
- https://github.com/golang/go/issues/17490
- https://github.com/golang/go/issues/28984

Side note: Rebind support was added for ipv4 only sockets as well as a matter of completion. 

Co-authored-by: @brad-defined