### PR TITLE
netlink: ignore route updates with no destination

### DIFF
--- a/overlay/tun_linux.go
+++ b/overlay/tun_linux.go
@@ -638,6 +638,11 @@ func (t *tun) updateRoutes(r netlink.RouteUpdate) {
 		return
 	}
 
+	if r.Dst == nil {
+		t.l.WithField("route", r).Debug("Ignoring route update, no destination address")
+		return
+	}
+
 	dstAddr, ok := netip.AddrFromSlice(r.Dst.IP)
 	if !ok {
 		t.l.WithField("route", r).Debug("Ignoring route update, invalid destination address")


### PR DESCRIPTION
Currently we assume each route update must have a destination, but we should check that it is set before we try to use it.

See: #1436