### PR TITLE
Feature: Expose Nebula API as a socket

### DIFF
--- a/control.go
+++ b/control.go
@@ -35,6 +35,7 @@ type Control struct {
 	dnsStart               func()
 	lighthouseStart        func()
 	connectionManagerStart func(context.Context)
+	infoStart       func()
 }
 
 type ControlHostInfo struct {
@@ -69,6 +70,9 @@ func (c *Control) Start() {
 	}
 	if c.lighthouseStart != nil {
 		c.lighthouseStart()
+	}
+	if c.infoStart != nil {
+		go c.infoStart()
 	}
 
 	// Start reading packets.

--- a/info.go
+++ b/info.go
@@ -1,0 +1,109 @@
+package nebula
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/netip"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/slackhq/nebula/config"
+)
+
+func handleHostmapList(l *logrus.Logger, hm *HostMap, w http.ResponseWriter, r *http.Request) {
+	type HostListItem struct {
+		VpnAddrs []netip.Addr `json:"vpnAddrs"`
+		//Remote            netip.AddrPort `json:"remote"`
+		Relayed           bool      `json:"relayed,omitempty"`
+		LastHandshakeTime time.Time `json:"lastHandshakeTime"`
+		Groups            []string  `json:"groups"`
+	}
+
+	out := map[string]HostListItem{}
+	hm.ForEachVpnAddr(func(hi *HostInfo) {
+		cert := hi.GetCert().Certificate
+		out[cert.Name()] = HostListItem{
+			VpnAddrs: hi.vpnAddrs,
+			//Remote:            hi.remote,
+			Relayed:           !hi.remote.IsValid(),
+			LastHandshakeTime: time.Unix(0, int64(hi.lastHandshakeTime)),
+			Groups:            cert.Groups(),
+		}
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+	js := json.NewEncoder(w)
+	err := js.Encode(out)
+	if err != nil {
+		http.Error(w, "json error: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func handleHostCertLookup(l *logrus.Logger, hm *HostMap, w http.ResponseWriter, r *http.Request) {
+	ipStr := r.PathValue("ipStr")
+	if ipStr == "" {
+		http.Error(w, "you must provide an IP address", http.StatusNotFound)
+		return
+	}
+
+	addr, err := netip.ParseAddr(ipStr)
+	if err != nil {
+		//todo filter non-Nebula IPs?
+		http.Error(w, fmt.Sprintf("Invalid IP address: %s", ipStr), http.StatusBadRequest)
+		return
+	}
+	hi := hm.QueryVpnAddr(addr)
+	if hi == nil {
+		http.Error(w, "IP address not found", http.StatusNotFound)
+		return
+	} else if hi.ConnectionState == nil {
+		http.Error(w, "Host not connected", http.StatusNotFound)
+		return
+	}
+	out, err := hi.ConnectionState.peerCert.Certificate.MarshalJSON()
+	if err != nil {
+		l.WithError(err).Error("failed to marshal peer certificate")
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(out)
+}
+
+func setupInfoServer(l *logrus.Logger, hm *HostMap) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /hostmap", func(w http.ResponseWriter, r *http.Request) { handleHostmapList(l, hm, w, r) })
+	mux.HandleFunc("GET /host/{ipStr}", func(w http.ResponseWriter, r *http.Request) { handleHostCertLookup(l, hm, w, r) })
+	return mux
+}
+
+// startInfo stands up a REST API that serves information about what Nebula is doing to other services
+// Right now, this is just hostmap info,
+func startInfo(l *logrus.Logger, c *config.C, configTest bool, hm *HostMap) (func(), error) {
+	listen := c.GetString("info.listen", "") //todo this should probably refuse non-localhost, right?
+	if listen == "" {
+		return nil, nil
+	}
+
+	var startFn func()
+	if configTest {
+		return startFn, nil
+	}
+
+	startFn = func() {
+		mux := setupInfoServer(l, hm)
+		l.WithField("bind", listen).Info("Info listener starting")
+		err := http.ListenAndServe(listen, mux)
+		if errors.Is(err, http.ErrServerClosed) {
+			return
+		}
+		if err != nil {
+			l.Fatal(err)
+		}
+	}
+
+	return startFn, nil
+}

--- a/main.go
+++ b/main.go
@@ -268,6 +268,11 @@ func Main(c *config.C, configTest bool, buildVersion string, logger *logrus.Logg
 		return nil, util.ContextualizeIfNeeded("Failed to start stats emitter", err)
 	}
 
+	infoStart, err := startInfo(l, c, configTest, hostMap)
+	if err != nil {
+		return nil, util.ContextualizeIfNeeded("Failed to start info socket", err)
+	}
+
 	if configTest {
 		return nil, nil
 	}
@@ -293,5 +298,6 @@ func Main(c *config.C, configTest bool, buildVersion string, logger *logrus.Logg
 		dnsStart,
 		lightHouse.StartUpdateWorker,
 		connManager.Start,
+		infoStart,
 	}, nil
 }


### PR DESCRIPTION
This MR introduces an info server socket to serve information about the Hostmap. This is in reference to #1398. 

<details>
<summary> Required config file additions </summary>

```yaml
info:
  listen: 127.0.0.2:5555
```
</details>

<details>
<summary> Example curls</summary

```
curl http://127.0.0.2:5555/host/100.100.100.100
{"curve":"P256","details":{"groups":["group1","group2"],"isCa":false,"issuer":"6a20d559ef58a72a2c8e599284fc11bfb95a61b21cd55ec51c0bdd59b4582537","name":"demo","networks":["100.100.100.100/11"],"notAfter":"2026-11-29T11:22:32-06:00","notBefore":"2025-1-03T12:00:11-05:00","unsafeNetworks":["0.0.0.0/0"]},"fingerprint":"c175687fec1ace05821b77b39f4b7520d1839e948fb7140570c0c4ffb99ac67f","publicKey":"77de6cf8a3541e527b6517532d36c0b3e01cdfcf54fe5270b7538881d5886e1885bbaa05b919a17b1d2b7dd49b5bfb103725ef1cf25c6a6212e00943caf9d8191e","signature":"9ec4e33140a71ee6e3c5ccb305f8920c3445d868b24b58f5217f84928e4dca2b8a408c32d108c5b99af0bf1f395a4468b4d21690d1fad1591a216e48d0da5a8c7726f2b34f54","version":2}% 

curl http://127.0.0.2:5553/hostmap
{"demo":{"vpnAddrs":["100.100.100.100"],"lastHandshakeTime":"2025-08-26T09:07:13.609073708-05:00","groups":["demo1","demo2"]},{"demo2":{"vpnAddrs":["100.100.100.101"],"lastHandshakeTime":"2025-08-26T09:07:13.609073708-05:00","groups":["demo3","demo4"]}}
```
</details>
