### PR TITLE
Fix `recv_error` receipt limit allowance for v1.9.x

### DIFF
--- a/hostmap.go
+++ b/hostmap.go
@@ -22,7 +22,6 @@ const defaultPromoteEvery = 1000       // Count of packets sent before we try mo
 const defaultReQueryEvery = 5000       // Count of packets sent before re-querying a hostinfo to the lighthouse
 const defaultReQueryWait = time.Minute // Minimum amount of seconds to wait before re-querying a hostinfo the lighthouse. Evaluated every ReQueryEvery
 const MaxRemotes = 10
-const maxRecvError = 4
 
 // MaxHostInfosPerVpnIp is the max number of hostinfos we will track for a given vpn ip
 // 5 allows for an initial handshake and each host pair re-handshaking twice
@@ -220,7 +219,6 @@ type HostInfo struct {
 	remoteIndexId   uint32
 	localIndexId    uint32
 	vpnIp           netip.Addr
-	recvError       atomic.Uint32
 	remoteCidr      *bart.Table[struct{}]
 	relayState      RelayState
 
@@ -703,10 +701,6 @@ func (i *HostInfo) SetRemoteIfPreferred(hm *HostMap, newRemote netip.AddrPort) b
 	}
 
 	return false
-}
-
-func (i *HostInfo) RecvErrorExceeded() bool {
-	return i.recvError.Add(1) >= maxRecvError
 }
 
 func (i *HostInfo) CreateRemoteCIDR(c *cert.NebulaCertificate) {

--- a/hostmap.go
+++ b/hostmap.go
@@ -706,10 +706,7 @@ func (i *HostInfo) SetRemoteIfPreferred(hm *HostMap, newRemote netip.AddrPort) b
 }
 
 func (i *HostInfo) RecvErrorExceeded() bool {
-	if i.recvError.Add(1) >= maxRecvError {
-		return true
-	}
-	return true
+	return i.recvError.Add(1) >= maxRecvError
 }
 
 func (i *HostInfo) CreateRemoteCIDR(c *cert.NebulaCertificate) {

--- a/outside.go
+++ b/outside.go
@@ -286,16 +286,18 @@ func (f *Interface) handleHostRoaming(hostinfo *HostInfo, ip netip.AddrPort) {
 
 }
 
+// handleEncrypted returns true if a packet should be processed, false otherwise
 func (f *Interface) handleEncrypted(ci *ConnectionState, addr netip.AddrPort, h *header.H) bool {
-	// If connectionstate exists and the replay protector allows, process packet
-	// Else, send recv errors for 300 seconds after a restart to allow fast reconnection.
-	if ci == nil || !ci.window.Check(f.l, h.MessageCounter) {
+	// If connectionstate does not exist, send a recv error, if possible, to encourage a fast reconnect
+	if ci == nil {
 		if addr.IsValid() {
 			f.maybeSendRecvError(addr, h.RemoteIndex)
-			return false
-		} else {
-			return false
 		}
+		return false
+	}
+	// If the window check fails, refuse to process the packet, but don't send a recv error
+	if !ci.window.Check(f.l, h.MessageCounter) {
+		return false
 	}
 
 	return true
@@ -455,10 +457,6 @@ func (f *Interface) handleRecvError(addr netip.AddrPort, h *header.H) {
 	hostinfo := f.hostMap.QueryReverseIndex(h.RemoteIndex)
 	if hostinfo == nil {
 		f.l.WithField("remoteIndex", h.RemoteIndex).Debugln("Did not find remote index in main hostmap")
-		return
-	}
-
-	if !hostinfo.RecvErrorExceeded() {
 		return
 	}
 


### PR DESCRIPTION
Since #955 (v1.8.0) we have changed from dropping a tunnel on the 4th `recv_error` receipt to dropping a tunnel on the 1st `recv_error` receipt. This change reverts to the pre-v1.8.0 behavior.

Ultimately, I think it would be best to remove `recv_error` messages entirely and rely on `tunnels.drop_inactive` (which landed in v1.9.6 and `test` packets to sort out tunnel issues). I am submitting this change to v1.9.x in case we do not want to take on that deprecation at this point but would argue that, at worst, we should in v1.10.