### PR TITLE
Don't delete static host mappings for non-primary IPs

### DIFF
--- a/connection_manager.go
+++ b/connection_manager.go
@@ -356,7 +356,7 @@ func (cm *connectionManager) makeTrafficDecision(localIndex uint32, now time.Tim
 			decision = tryRehandshake
 
 		} else {
-			if cm.shouldSwapPrimary(hostinfo, primary) {
+			if cm.shouldSwapPrimary(hostinfo) {
 				decision = swapPrimary
 			} else {
 				// migrate the relays to the primary, if in use.
@@ -447,7 +447,7 @@ func (cm *connectionManager) isInactive(hostinfo *HostInfo, now time.Time) (time
 	return inactiveDuration, true
 }
 
-func (cm *connectionManager) shouldSwapPrimary(current, primary *HostInfo) bool {
+func (cm *connectionManager) shouldSwapPrimary(current *HostInfo) bool {
 	// The primary tunnel is the most recent handshake to complete locally and should work entirely fine.
 	// If we are here then we have multiple tunnels for a host pair and neither side believes the same tunnel is primary.
 	// Let's sort this out.

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -631,13 +631,19 @@ func (lh *LightHouse) addCalculatedRemotes(vpnAddr netip.Addr) bool {
 	return len(calculatedV4) > 0 || len(calculatedV6) > 0
 }
 
-// unlockedGetRemoteList
-// assumes you have the lh lock
+// unlockedGetRemoteList assumes you have the lh lock
 func (lh *LightHouse) unlockedGetRemoteList(allAddrs []netip.Addr) *RemoteList {
 	// before we go and make a new remotelist, we need to make sure we don't have one for any of this set of vpnaddrs yet
-	for _, addr := range allAddrs {
+	for i, addr := range allAddrs {
 		am, ok := lh.addrMap[addr]
 		if ok {
+			if i != 0 {
+				//if we had a record in the cache for a non-primary IPI
+				for _, x := range allAddrs {
+					lh.addrMap[x] = am
+				}
+				lh.addrMap[addr] = am
+			}
 			return am
 		}
 	}

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -634,21 +634,17 @@ func (lh *LightHouse) addCalculatedRemotes(vpnAddr netip.Addr) bool {
 // unlockedGetRemoteList
 // assumes you have the lh lock
 func (lh *LightHouse) unlockedGetRemoteList(allAddrs []netip.Addr) *RemoteList {
-	var am *RemoteList
-	ok := false
 	// before we go and make a new remotelist, we need to make sure we don't have one for any of this set of vpnaddrs yet
 	for _, addr := range allAddrs {
-		am, ok = lh.addrMap[addr]
+		am, ok := lh.addrMap[addr]
 		if ok {
-			break
+			return am
 		}
 	}
 
-	if !ok {
-		am = NewRemoteList(allAddrs, func(a netip.Addr) bool { return lh.shouldAdd(allAddrs[0], a) })
-		for _, addr := range allAddrs {
-			lh.addrMap[addr] = am
-		}
+	am := NewRemoteList(allAddrs, func(a netip.Addr) bool { return lh.shouldAdd(allAddrs[0], a) })
+	for _, addr := range allAddrs {
+		lh.addrMap[addr] = am
 	}
 	return am
 }

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -638,11 +638,7 @@ func (lh *LightHouse) unlockedGetRemoteList(allAddrs []netip.Addr) *RemoteList {
 		am, ok := lh.addrMap[addr]
 		if ok {
 			if i != 0 {
-				//if we had a record in the cache for a non-primary IPI
-				for _, x := range allAddrs {
-					lh.addrMap[x] = am
-				}
-				lh.addrMap[addr] = am
+				lh.addrMap[allAddrs[0]] = am
 			}
 			return am
 		}

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -636,7 +636,8 @@ func (lh *LightHouse) addCalculatedRemotes(vpnAddr netip.Addr) bool {
 func (lh *LightHouse) unlockedGetRemoteList(allAddrs []netip.Addr) *RemoteList {
 	var am *RemoteList
 	ok := false
-	for _, addr := range allAddrs { // before we go and make a new remotelist, we need to make sure we don't have one for any of this set of vpnaddrs yet
+	// before we go and make a new remotelist, we need to make sure we don't have one for any of this set of vpnaddrs yet
+	for _, addr := range allAddrs {
 		am, ok = lh.addrMap[addr]
 		if ok {
 			break

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -644,6 +644,7 @@ func (lh *LightHouse) unlockedGetRemoteList(allAddrs []netip.Addr) *RemoteList {
 		}
 	}
 
+	//TODO lighthouse.remote_allow_ranges is almost certainly broken in a multiple-address-per-cert scenario
 	am := NewRemoteList(allAddrs, func(a netip.Addr) bool { return lh.shouldAdd(allAddrs[0], a) })
 	for _, addr := range allAddrs {
 		lh.addrMap[addr] = am

--- a/lighthouse_test.go
+++ b/lighthouse_test.go
@@ -529,10 +529,10 @@ func TestLighthouse_Dont_Delete_Static_Hosts(t *testing.T) {
 
 	//test that we actually have the static entry:
 	out := lh.Query(testStaticHost)
-	assert.NotEqual(t, out, nil)
+	assert.NotNil(t, out)
 	assert.Equal(t, out.vpnAddrs[0], testStaticHost)
 	out.Rebuild([]netip.Prefix{}) //why tho
-	assert.True(t, out.addrs[0] == myUdpAddr2)
+	assert.Equal(t, out.addrs[0], myUdpAddr2)
 
 	//bolt on a lower numbered primary IP
 	am := lh.unlockedGetRemoteList([]netip.Addr{testStaticHost})
@@ -542,27 +542,26 @@ func TestLighthouse_Dont_Delete_Static_Hosts(t *testing.T) {
 
 	//test that we actually have the static entry:
 	out = lh.Query(testStaticHost)
-	assert.NotEqual(t, out, nil)
+	assert.NotNil(t, out)
 	assert.Equal(t, out.vpnAddrs[0], testSameHostNotStatic)
 	assert.Equal(t, out.vpnAddrs[1], testStaticHost)
 	assert.Equal(t, out.addrs[0], myUdpAddr2)
 
 	//test that we actually have the static entry for BOTH:
 	out2 := lh.Query(testSameHostNotStatic)
-	assert.True(t, out2 == out)
+	assert.Same(t, out2, out)
 
 	//now do the delete
 	lh.DeleteVpnAddrs([]netip.Addr{testSameHostNotStatic, testStaticHost})
 	//verify
 	out = lh.Query(testSameHostNotStatic)
-	assert.NotEqual(t, out, nil)
+	assert.NotNil(t, out)
 	if out == nil {
 		t.Fatal("expected non-nil query for the static host")
 	}
 	assert.Equal(t, out.vpnAddrs[0], testSameHostNotStatic)
 	assert.Equal(t, out.vpnAddrs[1], testStaticHost)
 	assert.Equal(t, out.addrs[0], myUdpAddr2)
-
 }
 
 func TestLighthouse_DeletesWork(t *testing.T) {
@@ -603,7 +602,7 @@ func TestLighthouse_DeletesWork(t *testing.T) {
 
 	//test that we actually have the entry:
 	out := lh.Query(testHost)
-	assert.NotEqual(t, out, nil)
+	assert.NotNil(t, out)
 	assert.Equal(t, out.vpnAddrs[0], testHost)
 	out.Rebuild([]netip.Prefix{}) //why tho
 	assert.Equal(t, out.addrs[0], myUdpAddr2)
@@ -612,5 +611,5 @@ func TestLighthouse_DeletesWork(t *testing.T) {
 	lh.DeleteVpnAddrs([]netip.Addr{testHost})
 	//verify
 	out = lh.Query(testHost)
-	assert.Equal(t, out, nil)
+	assert.Nil(t, out)
 }


### PR DESCRIPTION
Fixes #1447 

- [x] The config of Nebula included a static host mapping for one IP of the host. The host's certificate includes multiple IPs. Spelunking through the code, the function DeleteVpnAddrs is updated in master to support a host with multiple IPs. However, that function will only skip address deletion if the first IP in the certificate is recorded as having a static host mapping entry. We believe that in the user's reported case, the first IP in the host cert was not the IP listed in the config's static host mapping.

- [x] Reading through the code to investigate this issue, I noticed that unlockedGetRemoteList may also overwrite a static mapping if it receives a list of IP's and if the first IP in the slice is not in the addrMap but any subsequent IP is in the map. In that case, the subsequent IP entries will be overwritten by the newly created entry.
 
- [x] To close this issue, investigate the lighthouse addrMap to cover the scenario in which a given host's secondary IP appears in the static host map.

- [x] Add tests to prove this is fixed!