### PR TITLE
don't require a detailsVpnAddr in a HostUpdateNotification

### DIFF
--- a/lighthouse.go
+++ b/lighthouse.go
@@ -937,7 +937,6 @@ func (lh *LightHouse) SendUpdate() {
 						V4AddrPorts:   v4,
 						V6AddrPorts:   v6,
 						RelayVpnAddrs: relays,
-						VpnAddr:       netAddrToProtoAddr(lh.myVpnNetworks[0].Addr()),
 					},
 				}
 

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -1063,7 +1063,8 @@ func (lhh *LightHouseHandler) handleHostQuery(n *NebulaMeta, fromVpnAddrs []neti
 				Debugln("Dropping malformed HostQuery")
 		}
 		return
-	} else if useVersion == cert.Version1 && queryVpnAddr.Is6() {
+	}
+	if useVersion == cert.Version1 && queryVpnAddr.Is6() {
 		// this case really shouldn't be possible to represent, but reject it anyway.
 		if lhh.l.Level >= logrus.DebugLevel {
 			lhh.l.WithField("vpnAddrs", fromVpnAddrs).WithField("queryVpnAddr", queryVpnAddr).


### PR DESCRIPTION
If we don't use this information, don't put it on the wire, so we then do not have to check it. If this does indeed have a use, we can just remove the comment and close this