### PR TITLE
Use x/net/route to manage routes directly

### DIFF
--- a/overlay/tun.go
+++ b/overlay/tun.go
@@ -1,6 +1,7 @@
 package overlay
 
 import (
+	"net"
 	"net/netip"
 
 	"github.com/sirupsen/logrus"
@@ -69,4 +70,14 @@ func findRemovedRoutes(newRoutes, oldRoutes []Route) []Route {
 	}
 
 	return removed
+}
+
+func prefixToMask(prefix netip.Prefix) netip.Addr {
+	pLen := 128
+	if prefix.Addr().Is4() {
+		pLen = 32
+	}
+
+	addr, _ := netip.AddrFromSlice(net.CIDRMask(prefix.Bits(), pLen))
+	return addr
 }

--- a/overlay/tun_darwin.go
+++ b/overlay/tun_darwin.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/netip"
 	"os"
 	"sync/atomic"
@@ -553,14 +552,4 @@ func (t *tun) Name() string {
 
 func (t *tun) NewMultiQueueReader() (io.ReadWriteCloser, error) {
 	return nil, fmt.Errorf("TODO: multiqueue not implemented for darwin")
-}
-
-func prefixToMask(prefix netip.Prefix) netip.Addr {
-	pLen := 128
-	if prefix.Addr().Is4() {
-		pLen = 32
-	}
-
-	addr, _ := netip.AddrFromSlice(net.CIDRMask(prefix.Bits(), pLen))
-	return addr
 }


### PR DESCRIPTION
This is a continuation of #1399 to finish off the last of the `exec.Command`s in freebsd which is needed for ipv6 unsafe route support