### PR TITLE
Allow defining a route table id where routes will be installed

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -280,6 +280,11 @@ tun:
   # SO_RCVBUFFORCE is used to avoid having to raise the system wide max
   #use_system_route_table_buffer_size: 0
 
+  # On linux only, set the routing table id where nebula installs routes. 
+  # This includes the assigned IPs in the certificate and the unsafe_routes.
+  # Defaults to using the 'main' table (id 254).
+  #route_table_id: 254
+
 # Configure logging level
 logging:
   # panic, fatal, error, warning, info, or debug. Default is info and is reloadable.

--- a/overlay/tun_linux.go
+++ b/overlay/tun_linux.go
@@ -39,6 +39,7 @@ type tun struct {
 	routeChan                 chan struct{}
 	useSystemRoutes           bool
 	useSystemRoutesBufferSize int
+	routeTableId              int
 
 	l *logrus.Logger
 }
@@ -131,6 +132,7 @@ func newTunGeneric(c *config.C, l *logrus.Logger, file *os.File, vpnNetworks []n
 		TXQueueLen:                c.GetInt("tun.tx_queue", 500),
 		useSystemRoutes:           c.GetBool("tun.use_system_route_table", false),
 		useSystemRoutesBufferSize: c.GetInt("tun.use_system_route_table_buffer_size", 0),
+		routeTableId:              c.GetInt("tun.route_table_id", unix.RT_TABLE_MAIN),
 		l:                         l,
 	}
 
@@ -288,6 +290,10 @@ func (t *tun) addIPs(link netlink.Link) error {
 				Mask: net.CIDRMask(t.vpnNetworks[i].Bits(), t.vpnNetworks[i].Addr().BitLen()),
 			},
 			Label: t.vpnNetworks[i].Addr().Zone(),
+			// Do not create a route when assigning the IP, routes are instead managed with setDefaultRoute
+			// This way we make sure that routes have the correct MTU during creation and
+			// they can be created directly in a routing table of our choice
+			Flags: unix.IFA_F_NOPREFIXROUTE,
 		}
 	}
 
@@ -419,12 +425,13 @@ func (t *tun) setDefaultRoute(cidr netip.Prefix) error {
 		Scope:     unix.RT_SCOPE_LINK,
 		Src:       net.IP(cidr.Addr().AsSlice()),
 		Protocol:  unix.RTPROT_KERNEL,
-		Table:     unix.RT_TABLE_MAIN,
+		Table:     t.routeTableId,
 		Type:      unix.RTN_UNICAST,
 	}
 	err := netlink.RouteReplace(&nr)
 	if err != nil {
-		t.l.WithError(err).WithField("cidr", cidr).Warn("Failed to set default route MTU, retrying")
+		t.l.WithError(err).WithField("cidr", cidr).WithField("mtu", t.DefaultMTU).WithField("table", t.routeTableId).
+			Warn("Failed to add default route, retrying")
 		//retry twice more -- on some systems there appears to be a race condition where if we set routes too soon, netlink says `invalid argument`
 		for i := 0; i < 2; i++ {
 			time.Sleep(100 * time.Millisecond)
@@ -432,13 +439,16 @@ func (t *tun) setDefaultRoute(cidr netip.Prefix) error {
 			if err == nil {
 				break
 			} else {
-				t.l.WithError(err).WithField("cidr", cidr).WithField("mtu", t.DefaultMTU).Warn("Failed to set default route MTU, retrying")
+				t.l.WithError(err).WithField("cidr", cidr).WithField("mtu", t.DefaultMTU).WithField("table", t.routeTableId).
+					Warn("Failed to add default route, retrying")
 			}
 		}
 		if err != nil {
-			return fmt.Errorf("failed to set mtu %v on the default route %v; %v", t.DefaultMTU, dr, err)
+			return fmt.Errorf("failed to create default route %v; %v", dr, err)
 		}
 	}
+
+	t.l.WithField("cidr", cidr).WithField("mtu", t.DefaultMTU).WithField("table", t.routeTableId).Info("Added default route")
 
 	return nil
 }
@@ -462,6 +472,7 @@ func (t *tun) addRoutes(logErrors bool) error {
 			MTU:       r.MTU,
 			AdvMSS:    t.advMSS(r),
 			Scope:     unix.RT_SCOPE_LINK,
+			Table:     t.routeTableId,
 		}
 
 		if r.Metric > 0 {
@@ -477,7 +488,7 @@ func (t *tun) addRoutes(logErrors bool) error {
 				return retErr
 			}
 		} else {
-			t.l.WithField("route", r).Info("Added route")
+			t.l.WithField("route", r).WithField("table", t.routeTableId).Info("Added route")
 		}
 	}
 
@@ -501,6 +512,7 @@ func (t *tun) removeRoutes(routes []Route) {
 			MTU:       r.MTU,
 			AdvMSS:    t.advMSS(r),
 			Scope:     unix.RT_SCOPE_LINK,
+			Table:     t.routeTableId,
 		}
 
 		if r.Metric > 0 {
@@ -509,9 +521,9 @@ func (t *tun) removeRoutes(routes []Route) {
 
 		err := netlink.RouteDel(&nr)
 		if err != nil {
-			t.l.WithError(err).WithField("route", r).Error("Failed to remove route")
+			t.l.WithError(err).WithField("route", r).WithField("table", t.routeTableId).Error("Failed to remove route")
 		} else {
-			t.l.WithField("route", r).Info("Removed route")
+			t.l.WithField("route", r).WithField("table", t.routeTableId).Info("Removed route")
 		}
 	}
 }


### PR DESCRIPTION
This feature allows defining the route table id where Nebula will install routes to unlock the full potential of policy routing.

Additionally this also makes it so that the 'default routes' are always installed with the correct MTU, previously there was a tiny window where the MTU was not set.

This uses the IFA_F_NOPREFIXROUTE flag when setting the IP of the interface to avoid adding a route by default.
This flag was added in Linux kernel 4.4, if support for older kernel versions is required then more changes are going to be required.
