### PR TITLE
warn user if they configure a firewall rule that will allow way more traffic than you might expect

### DIFF
--- a/firewall_test.go
+++ b/firewall_test.go
@@ -1024,7 +1024,7 @@ func TestFirewall_convertRule(t *testing.T) {
 	r, err := convertRule(l, c, "test", 1)
 	assert.Contains(t, ob.String(), "test rule #1; group was an array with a single value, converting to simple value")
 	require.NoError(t, err)
-	assert.Equal(t, "group1", r.Group)
+	assert.Equal(t, []string{"group1"}, r.Groups)
 
 	// Ensure group array of > 1 is errord
 	ob.Reset()
@@ -1044,7 +1044,7 @@ func TestFirewall_convertRule(t *testing.T) {
 
 	r, err = convertRule(l, c, "test", 1)
 	require.NoError(t, err)
-	assert.Equal(t, "group1", r.Group)
+	assert.Equal(t, []string{"group1"}, r.Groups)
 }
 
 func TestFirewall_convertRuleSanity(t *testing.T) {
@@ -1081,6 +1081,23 @@ func TestFirewall_convertRuleSanity(t *testing.T) {
 		c["host"] = "any"
 		r, err := convertRule(l, c, "test", 1)
 		require.NoError(t, err)
+		err = r.sanity()
+		require.Error(t, err, "I wanted a warning: %+v", c)
+	}
+	//reset the list
+	yesWarningPlease = []map[string]any{
+		{"group": "group1"},
+		{"groups": []any{"group2"}},
+		{"cidr": "1.1.1.1/1"},
+		{"groups": []any{"group2"}, "host": "bob"},
+		{"cidr": "1.1.1.1/1", "host": "bob"},
+		{"groups": []any{"group2"}, "cidr": "1.1.1.1/1"},
+		{"groups": []any{"group2"}, "cidr": "1.1.1.1/1", "host": "bob"},
+	}
+	for _, c := range yesWarningPlease {
+		r, err := convertRule(l, c, "test", 1)
+		require.NoError(t, err)
+		r.Groups = append(r.Groups, "any")
 		err = r.sanity()
 		require.Error(t, err, "I wanted a warning: %+v", c)
 	}


### PR DESCRIPTION
Example firewall:
```
firewall:
  outbound:
    - port: any
      proto: any
      host: any

  inbound:
    - port: any
      proto: icmp
      group: any
    - proto: any
      port: any
      host: any
      group: "beep"
```

Example output:
```
INFO[0000] Firewall rule added                           firewallRule="map[caName: caSha: direction:outgoing endPort:0 groups:[] host:any ip: localIp: proto:0 startPort:0]"
INFO[0000] Firewall rule added                           firewallRule="map[caName: caSha: direction:incoming endPort:0 groups:[any] host: ip: localIp: proto:1 startPort:0]"
WARN[0000] firewall.inbound rule #1; groups specified as beep, but host=any will match any host, regardless of groups
INFO[0000] Firewall rule added                           firewallRule="map[caName: caSha: direction:incoming endPort:0 groups:[beep] host:any ip: localIp: proto:0 startPort:0]"
INFO[0000] Firewall started                              firewallHashes="SHA:9e9a8f4cea040574412197ccd7e105ee81130384d909a0f4f98040ae1c4ff451,FNV:3029762174"
INFO[0000] Main HostMap created                          preferredRanges="[]"
INFO[0000] punchy enabled
```

right now this will only fire on `host=any` with a configured `cidr`/`group`/`groups`, but since that's the most common footgun I figured it'd be a good place to start.

I'm not sure the language on the `WARN` line is helpful/urgent enough, I'm gonna think on that for a bit

continuous improvement from #1511 