### PR TITLE
don't block startup on failure to configure SSH

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,7 +75,8 @@ func Main(c *config.C, configTest bool, buildVersion string, logger *logrus.Logg
 	if c.GetBool("sshd.enabled", false) {
 		sshStart, err = configSSH(l, ssh, c)
 		if err != nil {
-			return nil, util.ContextualizeIfNeeded("Error while configuring the sshd", err)
+			l.WithError(err).Warn("Failed to configure sshd, ssh debugging will not be available")
+			sshStart = nil
 		}
 	}
 


### PR DESCRIPTION
Imagine having a problem you need ssh-debugging to triage, adding, the config stanza, but, oh no! You couldn't read the host key file or something! Now nebula refuses to start. Unfortunate.

This fixes that
