### PR TITLE
feat: support via gateway for v6 multihop for v4 routes

### DIFF
--- a/overlay/tun_linux.go
+++ b/overlay/tun_linux.go
@@ -608,7 +608,7 @@ func (t *tun) getGatewaysFromRoute(r *netlink.Route) routing.Gateways {
 	for _, p := range r.MultiPath {
 		// If this route is relevant to our interface and there is a gateway then add it
 		if p.LinkIndex == link.Attrs().Index {
-			gwAddr, ok := getGatewayAddr(r.Gw, r.Via)
+			gwAddr, ok := getGatewayAddr(p.Gw, p.Via)
 			if ok {
 				if t.isGatewayInVpnNetworks(gwAddr) {
 					gateways = append(gateways, routing.NewGateway(gwAddr, p.Hops+1))


### PR DESCRIPTION
<!--
Thank you for taking the time to submit a pull request!

Please be sure to provide a clear description of what you're trying to achieve with the change.

- If you're submitting a new feature, please explain how to use it and document any new config options in the example config.
- If you're submitting a bugfix, please link the related issue or describe the circumstances surrounding the issue.
- If you're changing a default, explain why you believe the new default is appropriate for most users.

P.S. If you're only updating the README or other docs, please file a pull request here instead: https://github.com/DefinedNet/nebula-docs
-->
When using use_system_route_table, IPv4 routes with an IPv6 nexthop are not added to the internal routing map. As a result, connectivity does not work. This fixes that by adding the via addresses in the route as a gateway, since it appears that Gw is not present on these kinds of routes.

I'm not too well-versed with the Linux kernel, so I'm not sure what the distinction between Gw and Via is. I tried to preserve existing behavior as much as possible (use Gw first, before checking Via). There may need to be more testing done around potential routes that could exist.