### PR TITLE
Fix a bug with udp ipv4 only on darwin

### DIFF
--- a/udp/udp_darwin.go
+++ b/udp/udp_darwin.go
@@ -98,9 +98,9 @@ func (u *StdConn) WriteTo(b []byte, ap netip.AddrPort) error {
 			return ErrInvalidIPv6RemoteForSocket
 		}
 
-		var rsa unix.RawSockaddrInet6
-		rsa.Family = unix.AF_INET6
-		rsa.Addr = ap.Addr().As16()
+		var rsa unix.RawSockaddrInet4
+		rsa.Family = unix.AF_INET
+		rsa.Addr = ap.Addr().As4()
 		binary.BigEndian.PutUint16((*[2]byte)(unsafe.Pointer(&rsa.Port))[:], ap.Port())
 		sa = unsafe.Pointer(&rsa)
 		addrLen = syscall.SizeofSockaddrInet4


### PR DESCRIPTION
Noticed that the ipv4 only packet handling in the udp socket looked suspect. I was able to confirm there is a bug by listening on a specific ipv4 address, which forced the socket into ipv4 only mode.

Dual stack is used when listening on `0.0.0.0` even with ipv6 disabled on the one actual interface my computer is using for networking via `sudo networksetup -setv6off "Wi-Fi"`, likely because there are other interfaces present with ipv6 addresses. We also don't expose a way to set the `network` argument for `net.ListenPacket` to `udp4`. Basically, it looks like the only real world way anyone gets into this situation is by listening on a specific ipv4 address.
