### PR TITLE
Update changelog for v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.10.0] - 2025-12-04
 
+See the [v1.10.0](https://github.com/slackhq/nebula/milestone/16?closed=1) milestone for a complete list of changes.
+
 ### Added
 
 - Support for ipv6 and multiple ipv4/6 addresses in the overlay.
   A new v2 ASN.1 based certificate format.
   Certificates now have a unified interface for external implementations.
   (#1212, #1216, #1345, #1359, #1381, #1419, #1464, #1466, #1451, #1476, #1467, #1481, #1399, #1488, #1492, #1495, #1468, #1521, #1535, #1538)
-  **TODO: External documentation link!**
 - Add the ability to mark packets on linux to better target nebula packets in iptables/nftables. (#1331)
 - Add ECMP support for `unsafe_routes`. (#1332)
 - PKCS11 support for P256 keys when built with `pkcs11` tag (#1153, #1482)
 
 ### Changed
 
+- **NOTE**: `default_local_cidr_any` now defaults to false, meaning that any firewall rule
+  intended to target an `unsafe_routes` entry must explicitly declare it via the
+  `local_cidr` field. This is almost always the intended behavior. This flag is
+  deprecated and will be removed in a future release. (#1373)
 - Improve logging when a relay is in use on an inbound packet. (#1533)
 - Avoid fatal errors if `rountines` is > 1 on systems that don't support more than 1 routine. (#1531)
 - Log a warning if a firewall rule contains an `any` that negates a more restrictive filter. (#1513)
@@ -30,10 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Log only the count of blocklisted certificate fingerprints instead of the entire list. (#1525)
 - Don't fatal when the ssh server is unable to be configured successfully. (#1520)
 - Update to build against go v1.25. (#1483)
-- `default_local_cidr_any` now defaults to false, meaning that any firewall rule
-  intended to target an `unsafe_routes` entry must explicitly declare it via the
-  `local_cidr` field. This is almost always the intended behavior. This flag is
-  deprecated and will be removed in a future release. (#1373)
 - Allow projects using `nebula` as a library with userspace networking to configure the `logger` and build version. (#1239) 
 - Upgrade to `yaml.v3`. (#1148, #1371, #1438, #1478)
 


### PR DESCRIPTION
v1.10 specific changes
- [x] 56067af (origin/master, origin/HEAD, master) Stab at better logging when a relay is being used (#1533)
- [x] 64f202f Make 0.0.0.0/0 and ::/0 not mean any address family, add any for that (#1538)
- [x] 6d7cf61 improve nebula-cert sign version auto-select (#1535)
- [x] 83ae807 No need to clear counter 0 (#1537)
- [x] 12cf348 (bits-counter-9) feat: support via gateway for v6 multihop for v4 routes (#1521)
- [x] 7aff313 Relax the restriction on routines from the config (#1531)
- [x] 297767b warn user if they configure a firewall rule that will allow way more traffic than you might expect (#1513)
- [x] 99faab5 Fix a potential bug with udp ipv4 only on darwin (#1532)
- [x] 27ea667 add more tests around bits counters (#1441)
- [x] 4df8bcb nebula-cert: support reading CA passphrase from env (#1421)
- [x] a89f951 Firewall types and cross-stack subnet stuff (#1509)
- [x] 52f1908 Don't log every blocklisted fingerprint (#1525)
- [x] 48f1ae9 switch to go.yaml.in/yaml (#1478)
- [x] 97b3972 honor remote_allow_list in hole punch response (#1186)
- [x] 0f305d5 don't block startup on failure to configure SSH (#1520)
- [x] 01909f4 try to make certificate addition/removal reloadable in some cases (#1468)
- [x] 45c1d3e Support for multi proto tun device on OpenBSD (#1495)
- [x] eb89839 Support for multi proto tun device on NetBSD (#1492)
- [x] fb7f0c3 Use x/net/route to manage routes directly (#1488)
- [x] b1f53d8 Support IPv6 tunneling in FreeBSD (#1399)
- [x] 8824eea helper functions to more correctly marshal curve 25519 public keys (#1481)
- [x] 1ea5f77 update to go 1.25, use the cool new ECDSA key marshalling functions (#1483)
- [x] 4cdeb28 Set CKA_VALUE_LEN attribute in DeriveNoise (#1482)
- [x] 5cccd39 update RemoteList.vpnAddrs when we complete a handshake (#1467)
- [x] 65cc253 prevent linux from assigning ipv6 link-local addresses (#1476)
- [x] 73cfa7b add firewall tests for ipv6 (#1451)
- [x] 768325c cert-v2 chores (#1466)
- [x] 932e329 Don't delete static host mappings for non-primary IPs (#1464)
- [x] 5cff83b netlink: ignore route updates with no destination (#1437)
- [x] 7da7968 fix lighthouse.calculated_remotes parsing (#1438)
- [x] 442a528 Fix off by one error in IPv6 packet parser (#1419)
- [x] 8536c57 Allow configuration of logger and build version in gvisor service library (#1239)
- [x] e5ce896 add netlink options  (#1326)
- [x] 2dc30fc Support 32-bit machines in crypto test (#1394)
- [x] d4a7df3 Rename pki.default_version to pki.initiating_version (#1381)
- [x] e83a1c6 Update config.go (#1353)
- [x] e136d1d Update example config with default_local_cidr_any changes (#1373)
- [x] 36bc9dd fix parseUnsafeRoutes for yaml.v3 (#1371)
- [x] 879852c upgrade to yaml.v3  (#1148)
- [x] 4444ed1 Add `certVersion` field to logs when logging the cert name in handshakes (#1359)
- [x] f86953c Implement ECMP for unsafe_routes (#1332)
- [x] 1d3c853 add so_mark sockopt support (#1331)
- [x] 94e89a1 smoke-tests: guess the lighthouse container IP better (#1347)
- [x] f8734ff Improve logging when handshaking with an invalid cert (#1345)
- [x] d97ed57 V2 certificate format (#1216)
- [x] 3e6c755 Fix static host map wrong responder situations, correct logging (#1259)
- [x] 08ac653 Cert interface (#1212)
- [x] 35603d1 add PKCS11 support (#1153)

Changes on `release-1.9` that should be present in `master` but we need to confirm

- [x] 7c3f533 (tag: v1.9.7, origin/release-1.9, release-1.9) Better words (#1497)
- [x] 824cd3f (origin/changelog-v1.9.7, changelog-v1.9.7) Update CHANGELOG for Nebula v1.9.7
- [x] 9f69217 HostInfo.remoteCidr should only be populated with the entire vpn ip address issued in the certificate (#1494) - in #1493
- [x] 22af56f Fix `recv_error` receipt limit allowance for v1.9.x (#1459) - in #1463
- [x] 1d73e46 Quietly log error on UDP_NETRESET ioctl on Windows. (#1453)
- [x] 105e0ec (tag: v1.9.6) v1.9.6 (#1434)
- [x] 4870bb6 Darwin udp fix (#1426) - in #1428
- [x] a1498ca Store relay states in a slice for consistent ordering (#1422) - #1423
- [x] 9877648 Drop inactive tunnels (#1413) - in #1427
- [x] 8e0a7bc Disable UDP receive error returns due to ICMP messages on Windows. (#1412) - in #1415
- [x] 8c29b15 (watchdog) fix relay migration panic (#1403) - in #1414
- [x] 04d7a8c Retry UDP receive on Windows in some receive error cases (#1404) - in #1415
- [x] b55b901 (tag: v1.9.5) v1.9.5 (#1285)
- [x] 2e85d13 [v1.9.x] do not panic when loading a V2 CA certificate (#1282) - The point of v1.10
- [x] 9bfdfba Backport reestablish relays from cert-v2 to release-1.9 (#1277) - in #1270

PRs I chose not to document in the changelog:
- #1472
- #1473
- #1536
- #1530
- #1386
- #1508
- #1502
- #1526
- #1450
- #1516
- #1515
- #1523
- #1510
- #1444
- #1433
- #1409
- #1470
- #1471
- #1469
- #1435
- #1408
- #1407
- #1400
- #1406
- #1389
- #1378
- #1376
- #1395
- #1393
- #1392
- #1391
- #1384
- #1382
- #1372
- #1363
- #1364
- #1365
- #1369
- #1361
- #1370
- #1338
- #1198
- #1351
- #1219
- #1350
- #1321
- #1320
- #1346
- #1340
- #1343
- #1344
- #1339
- #1341
- #1342
- #1303
- #1311
- #1308
- #1250
- #1228
- #1231
- #1201
- #1211
- #1237
- #1200