### PR TITLE
update CHANGELOG.md, point readers to release-1.9 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.7] - 2025-10-10
+
+The master branch has been heavily updated for some major changes, and in the meantime,
+maintenance has been occurring on the release-1.9 branch. Please refer to the release-1.9
+branch changelog for releases 1.9.5-1.9.7:
+
+<https://github.com/slackhq/nebula/blob/release-1.9/CHANGELOG.md>
+
 ### Changed
 
 - `default_local_cidr_any` now defaults to false, meaning that any firewall rule


### PR DESCRIPTION
It seems development for the last few versions is happening on the https://github.com/slackhq/nebula/tree/release-1.9 branch - this amends the CHANGELOG.md in the master branch, so it's clearer to readers where the changes for those versions are documented (as per #1542).

(It's also possible to get the CHANGELOG entries by going from a particular release on the Releases page, to the corresponding repo tag, and then going to the CHANGELOG at that point in the repo - but it might be helpful to note this on the master branch.)

