### PR TITLE
initialize routesFromSystem

### DIFF
--- a/overlay/tun_linux.go
+++ b/overlay/tun_linux.go
@@ -137,6 +137,7 @@ func newTunGeneric(c *config.C, l *logrus.Logger, file *os.File, vpnNetworks []n
 		TXQueueLen:                c.GetInt("tun.tx_queue", 500),
 		useSystemRoutes:           c.GetBool("tun.use_system_route_table", false),
 		useSystemRoutesBufferSize: c.GetInt("tun.use_system_route_table_buffer_size", 0),
+		routesFromSystem:          map[netip.Prefix]routing.Gateways{},
 		l:                         l,
 	}
 


### PR DESCRIPTION
This is a regression introduced by #1573. We need to initialize this map.

Fixes: #1579