### PR TITLE
Add prometheus/graphite stats e2e smoke tests

### DIFF
--- a/e2e/stats_test.go
+++ b/e2e/stats_test.go
@@ -36,8 +36,12 @@ func TestPrometheusStats(t *testing.T) {
 	myControl.Start()
 	defer myControl.Stop()
 
-	// Fetch metrics from the Prometheus endpoint
-	resp, err := http.Get("http://127.0.0.1:9090/metrics")
+	// Fetch metrics from the Prometheus endpoint with context
+	ctx := t.Context()
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://127.0.0.1:9090/metrics", nil)
+	require.NoError(t, err, "Failed to create request")
+
+	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err, "Failed to fetch metrics endpoint")
 	defer resp.Body.Close()
 

--- a/e2e/stats_test.go
+++ b/e2e/stats_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
@@ -133,23 +132,10 @@ func TestGraphiteStats(t *testing.T) {
 	// Wait for stats to be sent
 	select {
 	case statsData := <-statsChan:
-		// Verify the data is in Graphite plaintext format: "metric.path value timestamp\n"
-		assert.NotEmpty(t, statsData, "Should receive stats data")
-
 		// Check for expected metrics with the configured prefix
 		assert.Contains(t, statsData, "nebula.test.", "Should contain configured prefix")
 		assert.Contains(t, statsData, "runtime.NumGoroutine", "Should contain runtime metrics")
 		assert.Contains(t, statsData, "runtime.MemStats.Alloc", "Should contain memory stats")
-
-		// Verify format: each line should have metric, value, and timestamp
-		lines := strings.Split(strings.TrimSpace(statsData), "\n")
-		assert.Greater(t, len(lines), 0, "Should have at least one metric line")
-
-		// Check first line format
-		if len(lines) > 0 {
-			parts := strings.Fields(lines[0])
-			assert.Equal(t, 3, len(parts), "Each metric line should have 3 parts: metric value timestamp")
-		}
 
 	case <-time.After(3 * time.Second):
 		t.Fatal("Timeout waiting for stats to be sent to Graphite endpoint")

--- a/e2e/stats_test.go
+++ b/e2e/stats_test.go
@@ -1,0 +1,130 @@
+//go:build e2e_testing
+// +build e2e_testing
+
+package e2e
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/slackhq/nebula/cert"
+	"github.com/slackhq/nebula/cert_test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrometheusStats(t *testing.T) {
+	ca, _, caKey, _ := cert_test.NewTestCaCert(cert.Version1, cert.Curve_CURVE25519, time.Now(), time.Now().Add(10*time.Minute), nil, nil, []string{})
+
+	// Create a server with Prometheus stats enabled
+	myControl, _, _, _ := newSimpleServer(cert.Version1, ca, caKey, "me", "10.128.0.1/24", m{
+		"stats": m{
+			"type":      "prometheus",
+			"listen":    "127.0.0.1:9090",
+			"path":      "/metrics",
+			"interval":  "1s",
+			"namespace": "nebula",
+			"subsystem": "e2e",
+		},
+	})
+
+	// Start the server
+	myControl.Start()
+	defer myControl.Stop()
+
+	// Fetch metrics from the Prometheus endpoint
+	resp, err := http.Get("http://127.0.0.1:9090/metrics")
+	require.NoError(t, err, "Failed to fetch metrics endpoint")
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "Metrics endpoint should return 200 OK")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err, "Failed to read metrics response")
+
+	metricsOutput := string(body)
+
+	// Verify that some expected metrics are present
+	assert.Contains(t, metricsOutput, "nebula_e2e_info", "Should contain version info metric")
+	assert.Contains(t, metricsOutput, "nebula_e2e_handshake_manager", "Should contain handshake manager metrics")
+	assert.Contains(t, metricsOutput, "nebula_e2e_firewall", "Should contain firewall metrics")
+
+}
+
+func TestGraphiteStats(t *testing.T) {
+	ca, _, caKey, _ := cert_test.NewTestCaCert(cert.Version1, cert.Curve_CURVE25519, time.Now(), time.Now().Add(10*time.Minute), nil, nil, []string{})
+
+	// Create a mock Graphite server
+	listener, err := net.Listen("tcp", "127.0.0.1:2003")
+	require.NoError(t, err, "Failed to create mock Graphite listener")
+	defer listener.Close()
+
+	// Channel to receive stats data
+	statsChan := make(chan string, 1)
+
+	// Start accepting connections
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			t.Logf("Accept error: %v", err)
+			return
+		}
+		defer conn.Close()
+
+		// Set a read timeout
+		conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+
+		// Read all data sent by the stats system
+		data, err := io.ReadAll(conn)
+		if err != nil {
+			t.Logf("Read error: %v", err)
+			return
+		}
+
+		statsChan <- string(data)
+	}()
+
+	// Create a server with Graphite stats configured
+	myControl, _, _, _ := newSimpleServer(cert.Version1, ca, caKey, "me", "10.128.0.1/24", m{
+		"stats": m{
+			"type":     "graphite",
+			"protocol": "tcp",
+			"host":     "127.0.0.1:2003",
+			"interval": "1s",
+			"prefix":   "nebula.test",
+		},
+	})
+
+	// Start the server
+	myControl.Start()
+	defer myControl.Stop()
+
+	// Wait for stats to be sent
+	select {
+	case statsData := <-statsChan:
+		// Verify the data is in Graphite plaintext format: "metric.path value timestamp\n"
+		assert.NotEmpty(t, statsData, "Should receive stats data")
+
+		// Check for expected metrics with the configured prefix
+		assert.Contains(t, statsData, "nebula.test.", "Should contain configured prefix")
+		assert.Contains(t, statsData, "runtime.NumGoroutine", "Should contain runtime metrics")
+		assert.Contains(t, statsData, "runtime.MemStats.Alloc", "Should contain memory stats")
+
+		// Verify format: each line should have metric, value, and timestamp
+		lines := strings.Split(strings.TrimSpace(statsData), "\n")
+		assert.Greater(t, len(lines), 0, "Should have at least one metric line")
+
+		// Check first line format
+		if len(lines) > 0 {
+			parts := strings.Fields(lines[0])
+			assert.Equal(t, 3, len(parts), "Each metric line should have 3 parts: metric value timestamp")
+		}
+
+	case <-time.After(3 * time.Second):
+		t.Fatal("Timeout waiting for stats to be sent to Graphite endpoint")
+	}
+}

--- a/e2e/stats_test.go
+++ b/e2e/stats_test.go
@@ -45,6 +45,7 @@ func TestPrometheusStats(t *testing.T) {
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
+out:
 	for {
 		select {
 		case <-ctx.Done():
@@ -66,15 +67,13 @@ func TestPrometheusStats(t *testing.T) {
 				body, err = io.ReadAll(resp.Body)
 				resp.Body.Close()
 				if err == nil {
-					goto success
+					break out
 				}
 			} else {
 				resp.Body.Close()
 			}
 		}
 	}
-
-success:
 
 	metricsOutput := string(body)
 

--- a/e2e/stats_test.go
+++ b/e2e/stats_test.go
@@ -4,9 +4,11 @@
 package e2e
 
 import (
+	"bufio"
 	"io"
 	"net"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -89,6 +91,13 @@ func TestGraphiteStats(t *testing.T) {
 
 	ctx := t.Context()
 
+	// expected metrics
+	checks := map[string]string{
+		"nebula.test.":           "Should contain configured prefix",
+		"runtime.NumGoroutine":   "Should contain runtime metrics",
+		"runtime.MemStats.Alloc": "Should contain memory stats",
+	}
+
 	// Create a mock Graphite server
 	listener, err := net.Listen("tcp", "127.0.0.1:2003")
 	require.NoError(t, err, "Failed to create mock Graphite listener")
@@ -120,18 +129,24 @@ func TestGraphiteStats(t *testing.T) {
 		}
 		defer conn.Close()
 
-		// Read all data sent by the stats system
-		data, err := io.ReadAll(conn)
-		if err != nil {
-			if ctx.Err() != nil {
-				// Context was cancelled
-				return
-			}
-			t.Logf("Read error: %v", err)
-			return
-		}
+		scanner := bufio.NewScanner(conn)
+		seen := make(map[string]bool)
+		var sb strings.Builder
 
-		statsChan <- string(data)
+		for scanner.Scan() {
+			line := scanner.Text()
+			sb.WriteString(line + "\n")
+			for needle := range checks {
+				if strings.Contains(line, needle) {
+					seen[needle] = true
+				}
+			}
+			// scan until we see all checks
+			if len(seen) == len(checks) {
+				break
+			}
+		}
+		statsChan <- sb.String()
 	}()
 
 	// Ensure goroutine completes before test exits
@@ -158,11 +173,10 @@ func TestGraphiteStats(t *testing.T) {
 	// Wait for stats to be sent
 	select {
 	case statsData := <-statsChan:
-		// Check for expected metrics with the configured prefix
-		assert.Contains(t, statsData, "nebula.test.", "Should contain configured prefix")
-		assert.Contains(t, statsData, "runtime.NumGoroutine", "Should contain runtime metrics")
-		assert.Contains(t, statsData, "runtime.MemStats.Alloc", "Should contain memory stats")
-
+		for needle, msg := range checks {
+			// Check for expected metrics with the configured prefix
+			assert.Contains(t, statsData, needle, msg)
+		}
 	case <-time.After(3 * time.Second):
 		t.Fatal("Timeout waiting for stats to be sent to Graphite endpoint")
 	}


### PR DESCRIPTION
<!--
Thank you for taking the time to submit a pull request!

Please be sure to provide a clear description of what you're trying to achieve with the change.

- If you're submitting a new feature, please explain how to use it and document any new config options in the example config.
- If you're submitting a bugfix, please link the related issue or describe the circumstances surrounding the issue.
- If you're changing a default, explain why you believe the new default is appropriate for most users.

P.S. If you're only updating the README or other docs, please file a pull request here instead: https://github.com/DefinedNet/nebula-docs
-->

Adds a smoke test for the graphite and prometheus config, testing that you can get a few basic metrics from each setup.

I'm intending to use this to adjust the stats code to accept graceful shutdowns / taking a look at things w/ https://github.com/uber-go/goleak

<details>
<summary>example output of prometheus test w/ <code>defer goleak.VerifyNone(t)</code> added</summary>

Definitely seeing the udp/tun stuff that is being worked on in #1375 in the leak detection

```console
❯ go test ./e2e -run TestPrometheusStats -tags=e2e_testing -v
=== RUN   TestPrometheusStats
    stats_test.go:61: found unexpected goroutines:
        [Goroutine 37 in state chan receive, with github.com/nbrownus/go-metrics-prometheus.(*PrometheusConfig).UpdatePrometheusMetrics on top of the stack:
        github.com/nbrownus/go-metrics-prometheus.(*PrometheusConfig).UpdatePrometheusMetrics(0x14000110960)
        	/Users/calebjasik/go/pkg/mod/github.com/nbrownus/go-metrics-prometheus@v0.0.0-20210712211119-974a6260965f/prometheusmetrics.go:157 +0xcc
        created by github.com/slackhq/nebula.startPrometheusStats in goroutine 34
        	/Users/calebjasik/Git/defined.net/nebula/stats.go:99 +0x268
         Goroutine 39 in state chan receive, with github.com/rcrowley/go-metrics.(*meterArbiter).tick on top of the stack:
        github.com/rcrowley/go-metrics.(*meterArbiter).tick(...)
        	/Users/calebjasik/go/pkg/mod/github.com/rcrowley/go-metrics@v0.0.0-20201227073835-cf1acfcdf475/meter.go:239
        created by github.com/rcrowley/go-metrics.NewMeter in goroutine 34
        	/Users/calebjasik/go/pkg/mod/github.com/rcrowley/go-metrics@v0.0.0-20201227073835-cf1acfcdf475/meter.go:46 +0xc0
         Goroutine 56 in state IO wait, with internal/poll.runtime_pollWait on top of the stack:
        internal/poll.runtime_pollWait(0x14ebda600, 0x72)
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/runtime/netpoll.go:351 +0xa0
        internal/poll.(*pollDesc).wait(0x14000274100?, 0x14000276000?, 0x0)
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/internal/poll/fd_poll_runtime.go:84 +0x28
        internal/poll.(*pollDesc).waitRead(...)
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/internal/poll/fd_poll_runtime.go:89
        internal/poll.(*FD).Read(0x14000274100, {0x14000276000, 0x1000, 0x1000})
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/internal/poll/fd_unix.go:165 +0x1e0
        net.(*netFD).Read(0x14000274100, {0x14000276000?, 0x1400027daa8?, 0x1025b82ec?})
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/net/fd_posix.go:68 +0x28
        net.(*conn).Read(0x1400007e360, {0x14000276000?, 0x72?, 0x0?})
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/net/net.go:196 +0x34
        net/http.(*connReader).Read(0x140000b1440, {0x14000276000, 0x1000, 0x1000})
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/net/http/server.go:812 +0x230
        bufio.(*Reader).fill(0x140000351a0)
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/bufio/bufio.go:113 +0xe0
        bufio.(*Reader).Peek(0x140000351a0, 0x4)
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/bufio/bufio.go:152 +0x58
        net/http.(*conn).serve(0x140001802d0, {0x102a1a9f8, 0x14000284390})
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/net/http/server.go:2145 +0x654
        created by net/http.(*Server).Serve in goroutine 43
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/net/http/server.go:3493 +0x384
         Goroutine 40 in state chan receive, with github.com/rcrowley/go-metrics.CaptureDebugGCStats on top of the stack:
        github.com/rcrowley/go-metrics.CaptureDebugGCStats({0x102a21210, 0x102f017c0}, 0x0?)
        	/Users/calebjasik/go/pkg/mod/github.com/rcrowley/go-metrics@v0.0.0-20201227073835-cf1acfcdf475/debug.go:27 +0x7c
        created by github.com/slackhq/nebula.startStats in goroutine 34
        	/Users/calebjasik/Git/defined.net/nebula/stats.go:56 +0x1e8
         Goroutine 41 in state chan receive, with github.com/rcrowley/go-metrics.CaptureRuntimeMemStats on top of the stack:
        github.com/rcrowley/go-metrics.CaptureRuntimeMemStats({0x102a21210, 0x102f017c0}, 0x0?)
        	/Users/calebjasik/go/pkg/mod/github.com/rcrowley/go-metrics@v0.0.0-20201227073835-cf1acfcdf475/runtime.go:60 +0x7c
        created by github.com/slackhq/nebula.startStats in goroutine 34
        	/Users/calebjasik/Git/defined.net/nebula/stats.go:57 +0x248
         Goroutine 43 in state IO wait, with internal/poll.runtime_pollWait on top of the stack:
        internal/poll.runtime_pollWait(0x14ebdaa00, 0x72)
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/runtime/netpoll.go:351 +0xa0
        internal/poll.(*pollDesc).wait(0x140002e2000?, 0x1021a415c?, 0x0)
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/internal/poll/fd_poll_runtime.go:84 +0x28
        internal/poll.(*pollDesc).waitRead(...)
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/internal/poll/fd_poll_runtime.go:89
        internal/poll.(*FD).Accept(0x140002e2000)
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/internal/poll/fd_unix.go:613 +0x21c
        net.(*netFD).accept(0x140002e2000)
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/net/fd_unix.go:161 +0x28
        net.(*TCPListener).accept(0x140002ae100)
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/net/tcpsock_posix.go:159 +0x24
        net.(*TCPListener).Accept(0x140002ae100)
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/net/tcpsock.go:380 +0x2c
        net/http.(*Server).Serve(0x140002e0000, {0x102a198d0, 0x140002ae100})
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/net/http/server.go:3463 +0x24c
        net/http.(*Server).ListenAndServe(0x140002e0000)
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/net/http/server.go:3389 +0x80
        net/http.ListenAndServe(...)
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/net/http/server.go:3704
        github.com/slackhq/nebula.startPrometheusStats.func1()
        	/Users/calebjasik/Git/defined.net/nebula/stats.go:122 +0x188
        created by github.com/slackhq/nebula.(*Control).Start in goroutine 34
        	/Users/calebjasik/Git/defined.net/nebula/control.go:62 +0x44
         Goroutine 66 in state IO wait, with internal/poll.runtime_pollWait on top of the stack:
        internal/poll.runtime_pollWait(0x14ebda800, 0x72)
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/runtime/netpoll.go:351 +0xa0
        internal/poll.(*pollDesc).wait(0x14000144d00?, 0x14000376000?, 0x0)
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/internal/poll/fd_poll_runtime.go:84 +0x28
        internal/poll.(*pollDesc).waitRead(...)
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/internal/poll/fd_poll_runtime.go:89
        internal/poll.(*FD).Read(0x14000144d00, {0x14000376000, 0x1000, 0x1000})
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/internal/poll/fd_unix.go:165 +0x1e0
        net.(*netFD).Read(0x14000144d00, {0x14000376000?, 0x80?, 0x8?})
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/net/fd_posix.go:68 +0x28
        net.(*conn).Read(0x14000116170, {0x14000376000?, 0x0?, 0x140002d7d28?})
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/net/net.go:196 +0x34
        net/http.(*persistConn).Read(0x1400033cea0, {0x14000376000?, 0x102a13eb8?, 0x102ee5a30?})
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/net/http/transport.go:2125 +0x48
        bufio.(*Reader).fill(0x14000110de0)
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/bufio/bufio.go:113 +0xe0
        bufio.(*Reader).Peek(0x14000110de0, 0x1)
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/bufio/bufio.go:152 +0x58
        net/http.(*persistConn).readLoop(0x1400033cea0)
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/net/http/transport.go:2278 +0x110
        created by net/http.(*Transport).dialConn in goroutine 48
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/net/http/transport.go:1947 +0x111c
         Goroutine 67 in state select, with net/http.(*persistConn).writeLoop on top of the stack:
        net/http.(*persistConn).writeLoop(0x1400033cea0)
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/net/http/transport.go:2600 +0x94
        created by net/http.(*Transport).dialConn in goroutine 48
        	/opt/homebrew/Cellar/go/1.25.5/libexec/src/net/http/transport.go:1948 +0x1164
        ]
--- FAIL: TestPrometheusStats (0.45s)
FAIL
FAIL	github.com/slackhq/nebula/e2e	0.996s
FAIL
```



</details>

I'm certain there must be a simpler way to setup the graphite test, pls lmk if you have suggestions.
