### PR TITLE
tests: Use less Argon2 memory to fix tests on 32-bit systems (#1597)

### DIFF
--- a/cmd/nebula-cert/ca_test.go
+++ b/cmd/nebula-cert/ca_test.go
@@ -176,7 +176,8 @@ func Test_ca(t *testing.T) {
 	os.Remove(crtF.Name())
 	ob.Reset()
 	eb.Reset()
-	args = []string{"-version", "1", "-encrypt", "-name", "test", "-duration", "100m", "-groups", "1,2,3,4,5", "-out-crt", crtF.Name(), "-out-key", keyF.Name()}
+	// Use -argon-memory < 2*1024*1024 for 32-bit archs
+	args = []string{"-version", "1", "-encrypt", "-name", "test", "-duration", "100m", "-groups", "1,2,3,4,5", "-out-crt", crtF.Name(), "-out-key", keyF.Name(), "-argon-memory", "262144"}
 	os.Setenv("NEBULA_CA_PASSPHRASE", string(passphrase))
 	require.NoError(t, ca(args, ob, eb, testpw))
 	assert.Empty(t, eb.String())
@@ -188,7 +189,7 @@ func Test_ca(t *testing.T) {
 	ned, err := cert.UnmarshalNebulaEncryptedData(k.Bytes)
 	require.NoError(t, err)
 	// we won't know salt in advance, so just check start of string
-	assert.Equal(t, uint32(2*1024*1024), ned.EncryptionMetadata.Argon2Parameters.Memory)
+	assert.Equal(t, uint32(256*1024), ned.EncryptionMetadata.Argon2Parameters.Memory)
 	assert.Equal(t, uint8(4), ned.EncryptionMetadata.Argon2Parameters.Parallelism)
 	assert.Equal(t, uint32(1), ned.EncryptionMetadata.Argon2Parameters.Iterations)
 


### PR DESCRIPTION
=== RUN   Test_ca
runtime: out of memory: cannot allocate 2147483648-byte block (2151251968 in use)
fatal error: out of memory
goroutine 22 gp=0x98870e8 m=3 mp=0x9845008 [running]:
...
github.com/slackhq/nebula/cmd/nebula-cert.Test_ca(0x9887328)
	/build/package/package/obj-i686-linux-gnu/src/github.com/slackhq/nebula/cmd/nebula-cert/ca_test.go:181 +0x2102 fp=0x9923f84 sp=0x9923e04 pc=0x8330ce2

<!--
Thank you for taking the time to submit a pull request!

Please be sure to provide a clear description of what you're trying to achieve with the change.

- If you're submitting a new feature, please explain how to use it and document any new config options in the example config.
- If you're submitting a bugfix, please link the related issue or describe the circumstances surrounding the issue.
- If you're changing a default, explain why you believe the new default is appropriate for most users.

P.S. If you're only updating the README or other docs, please file a pull request here instead: https://github.com/DefinedNet/nebula-docs
-->
