### PR TITLE
fix: guard QueryCert against panic on short/empty QNAME

### DIFF
--- a/dns_server.go
+++ b/dns_server.go
@@ -241,6 +241,9 @@ func (d *dnsServer) Query(q uint16, data string) (netip.Addr, bool) {
 }
 
 func (d *dnsServer) QueryCert(data string) string {
+	if len(data) < 2 {
+		return ""
+	}
 	ip, err := netip.ParseAddr(data[:len(data)-1])
 	if err != nil {
 		return ""

--- a/dns_server_test.go
+++ b/dns_server_test.go
@@ -16,6 +16,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type stubDNSWriter struct{}
+
+func (stubDNSWriter) LocalAddr() net.Addr { return &net.UDPAddr{} }
+func (stubDNSWriter) RemoteAddr() net.Addr {
+	return &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5353}
+}
+func (stubDNSWriter) Write([]byte) (int, error) { return 0, nil }
+func (stubDNSWriter) WriteMsg(*dns.Msg) error   { return nil }
+func (stubDNSWriter) Close() error              { return nil }
+func (stubDNSWriter) TsigStatus() error         { return nil }
+func (stubDNSWriter) TsigTimersOnly(bool)       {}
+func (stubDNSWriter) Hijack()                   {}
+
 func TestParsequery(t *testing.T) {
 	l := logrus.New()
 	hostMap := &HostMap{}
@@ -68,6 +81,19 @@ func TestParsequery(t *testing.T) {
 	m = &dns.Msg{}
 	m.SetQuestion("unknown.com.com", dns.TypeA)
 	ds.parseQuery(m, nil)
+	assert.Empty(t, m.Answer)
+	assert.Equal(t, dns.RcodeNameError, m.Rcode)
+
+	// short lookups should not fail
+	m = &dns.Msg{}
+	m.Question = []dns.Question{{Name: "", Qtype: dns.TypeTXT, Qclass: dns.ClassINET}}
+	ds.parseQuery(m, stubDNSWriter{})
+	assert.Empty(t, m.Answer)
+	assert.Equal(t, dns.RcodeNameError, m.Rcode)
+
+	m = &dns.Msg{}
+	m.Question = []dns.Question{{Name: ".", Qtype: dns.TypeTXT, Qclass: dns.ClassINET}}
+	ds.parseQuery(m, stubDNSWriter{})
 	assert.Empty(t, m.Answer)
 	assert.Equal(t, dns.RcodeNameError, m.Rcode)
 }
@@ -313,40 +339,4 @@ func waitFor(t *testing.T, cond func() bool) {
 		time.Sleep(5 * time.Millisecond)
 	}
 	t.Fatal("timed out waiting for condition")
-}
-
-type stubDNSWriter struct{}
-
-func (stubDNSWriter) LocalAddr() net.Addr                { return &net.UDPAddr{} }
-func (stubDNSWriter) RemoteAddr() net.Addr               { return &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5353} }
-func (stubDNSWriter) Write([]byte) (int, error)          { return 0, nil }
-func (stubDNSWriter) WriteMsg(*dns.Msg) error            { return nil }
-func (stubDNSWriter) Close() error                       { return nil }
-func (stubDNSWriter) TsigStatus() error                  { return nil }
-func (stubDNSWriter) TsigTimersOnly(bool)                {}
-func (stubDNSWriter) Hijack()                            {}
-
-func TestQueryCert_short_inputs(t *testing.T) {
-	ds := newDnsRecords(logrus.New(), &CertState{}, &HostMap{})
-
-	assert.NotPanics(t, func() { ds.QueryCert("") })
-	assert.NotPanics(t, func() { ds.QueryCert(".") })
-	assert.Equal(t, "", ds.QueryCert(""))
-	assert.Equal(t, "", ds.QueryCert("."))
-}
-
-func TestParseQuery_TXT_empty_and_root_qname(t *testing.T) {
-	ds := newDnsRecords(logrus.New(), &CertState{}, &HostMap{})
-
-	// Root zone "." — must not panic, should return NXDOMAIN
-	m := new(dns.Msg)
-	m.SetQuestion(".", dns.TypeTXT)
-	assert.NotPanics(t, func() { ds.parseQuery(m, stubDNSWriter{}) })
-	assert.Equal(t, dns.RcodeNameError, m.Rcode)
-
-	// Directly injected empty Name — must not panic
-	m = new(dns.Msg)
-	m.Question = []dns.Question{{Name: "", Qtype: dns.TypeTXT, Qclass: dns.ClassINET}}
-	assert.NotPanics(t, func() { ds.parseQuery(m, stubDNSWriter{}) })
-	assert.Equal(t, dns.RcodeNameError, m.Rcode)
 }

--- a/dns_server_test.go
+++ b/dns_server_test.go
@@ -314,3 +314,39 @@ func waitFor(t *testing.T, cond func() bool) {
 	}
 	t.Fatal("timed out waiting for condition")
 }
+
+type stubDNSWriter struct{}
+
+func (stubDNSWriter) LocalAddr() net.Addr                { return &net.UDPAddr{} }
+func (stubDNSWriter) RemoteAddr() net.Addr               { return &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5353} }
+func (stubDNSWriter) Write([]byte) (int, error)          { return 0, nil }
+func (stubDNSWriter) WriteMsg(*dns.Msg) error            { return nil }
+func (stubDNSWriter) Close() error                       { return nil }
+func (stubDNSWriter) TsigStatus() error                  { return nil }
+func (stubDNSWriter) TsigTimersOnly(bool)                {}
+func (stubDNSWriter) Hijack()                            {}
+
+func TestQueryCert_short_inputs(t *testing.T) {
+	ds := newDnsRecords(logrus.New(), &CertState{}, &HostMap{})
+
+	assert.NotPanics(t, func() { ds.QueryCert("") })
+	assert.NotPanics(t, func() { ds.QueryCert(".") })
+	assert.Equal(t, "", ds.QueryCert(""))
+	assert.Equal(t, "", ds.QueryCert("."))
+}
+
+func TestParseQuery_TXT_empty_and_root_qname(t *testing.T) {
+	ds := newDnsRecords(logrus.New(), &CertState{}, &HostMap{})
+
+	// Root zone "." — must not panic, should return NXDOMAIN
+	m := new(dns.Msg)
+	m.SetQuestion(".", dns.TypeTXT)
+	assert.NotPanics(t, func() { ds.parseQuery(m, stubDNSWriter{}) })
+	assert.Equal(t, dns.RcodeNameError, m.Rcode)
+
+	// Directly injected empty Name — must not panic
+	m = new(dns.Msg)
+	m.Question = []dns.Question{{Name: "", Qtype: dns.TypeTXT, Qclass: dns.ClassINET}}
+	assert.NotPanics(t, func() { ds.parseQuery(m, stubDNSWriter{}) })
+	assert.Equal(t, dns.RcodeNameError, m.Rcode)
+}


### PR DESCRIPTION
## Summary
- `QueryCert` slices `data[:len(data)-1]` to strip a trailing dot, which panics when `data` is empty (slice bounds `[:-1]`)
- Added a `len(data) < 2` guard to return early for inputs shorter than a minimal valid `x.` form
- While `miekg/dns` currently rejects wire-format packets that would produce an empty QNAME, Nebula should not rely on library behavior for crash safety

## Test plan
- [x] `TestQueryCert_short_inputs` — verifies `QueryCert("")` and `QueryCert(".")` return `""` without panic
- [x] `TestParseQuery_TXT_empty_and_root_qname` — verifies `parseQuery` handles root zone `"."` and empty `Name` TXT queries without panic, returning NXDOMAIN
- [x] Existing `TestParsequery` and `Test_getDnsServerAddr` still pass

Discovered this while looking for security vulnerabilities, this isn't a bug bounty level issue but still seemed worth a fix (done via llm)