### PR TITLE
SSH handshake in goroutine and defer close

### DIFF
--- a/sshd/server.go
+++ b/sshd/server.go
@@ -2,10 +2,10 @@ package sshd
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"net"
-	"sync"
 
 	"github.com/armon/go-radix"
 	"github.com/sirupsen/logrus"
@@ -27,20 +27,21 @@ type SSHServer struct {
 	commands    *radix.Tree
 	listener    net.Listener
 
-	// Locks the conns/counter to avoid concurrent map access
-	connsLock sync.Mutex
-	conns     map[int]*session
-	counter   int
+	// Call the cancel() function to stop all active sessions
+	ctx    context.Context
+	cancel func()
 }
 
 // NewSSHServer creates a new ssh server rigged with default commands and prepares to listen
 func NewSSHServer(l *logrus.Entry) (*SSHServer, error) {
 
+	ctx, cancel := context.WithCancel(context.Background())
 	s := &SSHServer{
 		trustedKeys: make(map[string]map[string]bool),
 		l:           l,
 		commands:    radix.New(),
-		conns:       make(map[int]*session),
+		ctx:         ctx,
+		cancel:      cancel,
 	}
 
 	cc := ssh.CertChecker{
@@ -176,6 +177,15 @@ func (s *SSHServer) run() {
 			return
 		}
 		go func(c net.Conn) {
+			// NewServerConn may block while waiting for the client to complete the handshake.
+			// Ensure that a bad client doesn't hurt us by checking for the parent context
+			// cancellation before calling NewServerConn, and forcing the socket to close when
+			// the context is cancelled.
+			sessionContext, sessionCancel := context.WithCancel(s.ctx)
+			go func() {
+				<-sessionContext.Done()
+				c.Close()
+			}()
 			conn, chans, reqs, err := ssh.NewServerConn(c, s.config)
 			fp := ""
 			if conn != nil {
@@ -192,27 +202,17 @@ func (s *SSHServer) run() {
 					l = l.WithField("sshFingerprint", fp)
 				}
 				l.Warn("failed to handshake")
+				sessionCancel()
 				return
 			}
 
 			l := s.l.WithField("sshUser", conn.User())
 			l.WithField("remoteAddress", c.RemoteAddr()).WithField("sshFingerprint", fp).Info("ssh user logged in")
 
-			session := NewSession(s.commands, conn, chans, l.WithField("subsystem", "sshd.session"))
-			s.connsLock.Lock()
-			s.counter++
-			counter := s.counter
-			s.conns[counter] = session
-			s.connsLock.Unlock()
+			NewSession(s.commands, conn, chans, sessionCancel, l.WithField("subsystem", "sshd.session"))
 
 			go ssh.DiscardRequests(reqs)
 
-			s.l.WithField("id", counter).Debug("Wait for session to end...")
-			<-session.exitChan
-			s.l.WithField("id", counter).Debug("closing conn")
-			s.connsLock.Lock()
-			delete(s.conns, counter)
-			s.connsLock.Unlock()
 		}(c)
 	}
 }
@@ -227,9 +227,5 @@ func (s *SSHServer) Stop() {
 }
 
 func (s *SSHServer) closeSessions() {
-	s.connsLock.Lock()
-	for _, c := range s.conns {
-		c.Close()
-	}
-	s.connsLock.Unlock()
+	s.cancel()
 }

--- a/sshd/server.go
+++ b/sshd/server.go
@@ -175,44 +175,45 @@ func (s *SSHServer) run() {
 			}
 			return
 		}
-
-		conn, chans, reqs, err := ssh.NewServerConn(c, s.config)
-		fp := ""
-		if conn != nil {
-			fp = conn.Permissions.Extensions["fp"]
-		}
-
-		if err != nil {
-			l := s.l.WithError(err).WithField("remoteAddress", c.RemoteAddr())
+		go func(c net.Conn) {
+			conn, chans, reqs, err := ssh.NewServerConn(c, s.config)
+			fp := ""
 			if conn != nil {
-				l = l.WithField("sshUser", conn.User())
-				conn.Close()
+				fp = conn.Permissions.Extensions["fp"]
 			}
-			if fp != "" {
-				l = l.WithField("sshFingerprint", fp)
+
+			if err != nil {
+				l := s.l.WithError(err).WithField("remoteAddress", c.RemoteAddr())
+				if conn != nil {
+					l = l.WithField("sshUser", conn.User())
+					conn.Close()
+				}
+				if fp != "" {
+					l = l.WithField("sshFingerprint", fp)
+				}
+				l.Warn("failed to handshake")
+				return
 			}
-			l.Warn("failed to handshake")
-			continue
-		}
 
-		l := s.l.WithField("sshUser", conn.User())
-		l.WithField("remoteAddress", c.RemoteAddr()).WithField("sshFingerprint", fp).Info("ssh user logged in")
+			l := s.l.WithField("sshUser", conn.User())
+			l.WithField("remoteAddress", c.RemoteAddr()).WithField("sshFingerprint", fp).Info("ssh user logged in")
 
-		session := NewSession(s.commands, conn, chans, l.WithField("subsystem", "sshd.session"))
-		s.connsLock.Lock()
-		s.counter++
-		counter := s.counter
-		s.conns[counter] = session
-		s.connsLock.Unlock()
+			session := NewSession(s.commands, conn, chans, l.WithField("subsystem", "sshd.session"))
+			s.connsLock.Lock()
+			s.counter++
+			counter := s.counter
+			s.conns[counter] = session
+			s.connsLock.Unlock()
 
-		go ssh.DiscardRequests(reqs)
-		go func() {
+			go ssh.DiscardRequests(reqs)
+
+			s.l.WithField("id", counter).Debug("Wait for session to end...")
 			<-session.exitChan
 			s.l.WithField("id", counter).Debug("closing conn")
 			s.connsLock.Lock()
 			delete(s.conns, counter)
 			s.connsLock.Unlock()
-		}()
+		}(c)
 	}
 }
 

--- a/sshd/session.go
+++ b/sshd/session.go
@@ -172,5 +172,6 @@ func (s *session) dispatchCommand(line string, w StringWriter) {
 }
 
 func (s *session) Close() {
+	s.c.Close()
 	s.cancel()
 }

--- a/sshd/session.go
+++ b/sshd/session.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/anmitsu/go-shlex"
 	"github.com/armon/go-radix"
@@ -13,11 +14,12 @@ import (
 )
 
 type session struct {
-	l        *logrus.Entry
-	c        *ssh.ServerConn
-	term     *term.Terminal
-	commands *radix.Tree
-	exitChan chan bool
+	l         *logrus.Entry
+	c         *ssh.ServerConn
+	term      *term.Terminal
+	commands  *radix.Tree
+	exitChan  chan struct{}
+	closeOnce sync.Once
 }
 
 func NewSession(commands *radix.Tree, conn *ssh.ServerConn, chans <-chan ssh.NewChannel, l *logrus.Entry) *session {
@@ -25,7 +27,7 @@ func NewSession(commands *radix.Tree, conn *ssh.ServerConn, chans <-chan ssh.New
 		commands: radix.NewFromMap(commands.ToMap()),
 		l:        l,
 		c:        conn,
-		exitChan: make(chan bool),
+		exitChan: make(chan struct{}),
 	}
 
 	s.commands.Insert("logout", &Command{
@@ -101,7 +103,6 @@ func (s *session) handleRequests(in <-chan *ssh.Request, channel ssh.Channel) {
 
 		if err != nil {
 			s.l.WithError(err).Info("Error handling ssh session requests")
-			s.Close()
 			return
 		}
 	}
@@ -124,11 +125,11 @@ func (s *session) createTerm(channel ssh.Channel) *term.Terminal {
 		return "", 0, false
 	}
 
-	go s.handleInput(channel)
+	go s.handleInput()
 	return term
 }
 
-func (s *session) handleInput(channel ssh.Channel) {
+func (s *session) handleInput() {
 	defer s.Close()
 	w := &stringWriter{w: s.term}
 	for {
@@ -171,10 +172,11 @@ func (s *session) dispatchCommand(line string, w StringWriter) {
 	}
 
 	_ = execCommand(c, args[1:], w)
-	return
 }
 
 func (s *session) Close() {
-	s.c.Close()
-	s.exitChan <- true
+	s.closeOnce.Do(func() {
+		s.c.Close()
+		close(s.exitChan)
+	})
 }

--- a/sshd/session.go
+++ b/sshd/session.go
@@ -44,6 +44,7 @@ func NewSession(commands *radix.Tree, conn *ssh.ServerConn, chans <-chan ssh.New
 }
 
 func (s *session) handleChannels(chans <-chan ssh.NewChannel) {
+	defer s.Close()
 	for newChannel := range chans {
 		if newChannel.ChannelType() != "session" {
 			s.l.WithField("sshChannelType", newChannel.ChannelType()).Error("unknown channel type")
@@ -62,7 +63,6 @@ func (s *session) handleChannels(chans <-chan ssh.NewChannel) {
 }
 
 func (s *session) handleRequests(in <-chan *ssh.Request, channel ssh.Channel) {
-	defer s.Close()
 	for req := range in {
 		var err error
 		switch req.Type {
@@ -130,7 +130,6 @@ func (s *session) createTerm(channel ssh.Channel) *term.Terminal {
 }
 
 func (s *session) handleInput() {
-	defer s.Close()
 	w := &stringWriter{w: s.term}
 	for {
 		line, err := s.term.ReadLine()

--- a/sshd/session.go
+++ b/sshd/session.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"sync"
 
 	"github.com/anmitsu/go-shlex"
 	"github.com/armon/go-radix"
@@ -14,20 +13,19 @@ import (
 )
 
 type session struct {
-	l         *logrus.Entry
-	c         *ssh.ServerConn
-	term      *term.Terminal
-	commands  *radix.Tree
-	exitChan  chan struct{}
-	closeOnce sync.Once
+	l        *logrus.Entry
+	c        *ssh.ServerConn
+	term     *term.Terminal
+	commands *radix.Tree
+	cancel   func()
 }
 
-func NewSession(commands *radix.Tree, conn *ssh.ServerConn, chans <-chan ssh.NewChannel, l *logrus.Entry) *session {
+func NewSession(commands *radix.Tree, conn *ssh.ServerConn, chans <-chan ssh.NewChannel, cancel func(), l *logrus.Entry) *session {
 	s := &session{
 		commands: radix.NewFromMap(commands.ToMap()),
 		l:        l,
 		c:        conn,
-		exitChan: make(chan struct{}),
+		cancel:   cancel,
 	}
 
 	s.commands.Insert("logout", &Command{
@@ -174,8 +172,5 @@ func (s *session) dispatchCommand(line string, w StringWriter) {
 }
 
 func (s *session) Close() {
-	s.closeOnce.Do(func() {
-		s.c.Close()
-		close(s.exitChan)
-	})
+	s.cancel()
 }

--- a/sshd/session.go
+++ b/sshd/session.go
@@ -60,6 +60,7 @@ func (s *session) handleChannels(chans <-chan ssh.NewChannel) {
 }
 
 func (s *session) handleRequests(in <-chan *ssh.Request, channel ssh.Channel) {
+	defer s.Close()
 	for req := range in {
 		var err error
 		switch req.Type {


### PR DESCRIPTION
- SSH handshakes happen in the Accept goroutine, so a slow handshake could block ssh access to other clients
- defer s.Close in handleRequests ensures all resources are cleaned up in all cases
- This is my artisanal take on #1634 