### PR TITLE
Remove more os.Exit calls and give a more reliable wait for stop function (attempt 3)

### DIFF
--- a/cmd/nebula-service/main.go
+++ b/cmd/nebula-service/main.go
@@ -78,8 +78,16 @@ func main() {
 	}
 
 	if !*configTest {
-		ctrl.Start()
-		ctrl.ShutdownBlock()
+		wait, err := ctrl.Start()
+		if err != nil {
+			util.LogWithContextIfNeeded("Error while running", err, l)
+			os.Exit(1)
+		}
+
+		go ctrl.ShutdownBlock()
+		wait()
+
+		l.Info("Goodbye")
 	}
 
 	os.Exit(0)

--- a/cmd/nebula-service/main.go
+++ b/cmd/nebula-service/main.go
@@ -85,7 +85,12 @@ func main() {
 		}
 
 		go ctrl.ShutdownBlock()
-		wait()
+
+		if err := wait(); err != nil {
+			l.WithError(err).Error("Nebula stopped due to fatal error")
+			l.Info("Goodbye")
+			os.Exit(2)
+		}
 
 		l.Info("Goodbye")
 	}

--- a/cmd/nebula-service/main.go
+++ b/cmd/nebula-service/main.go
@@ -88,7 +88,6 @@ func main() {
 
 		if err := wait(); err != nil {
 			l.WithError(err).Error("Nebula stopped due to fatal error")
-			l.Info("Goodbye")
 			os.Exit(2)
 		}
 

--- a/cmd/nebula/main.go
+++ b/cmd/nebula/main.go
@@ -72,9 +72,17 @@ func main() {
 	}
 
 	if !*configTest {
-		ctrl.Start()
+		wait, err := ctrl.Start()
+		if err != nil {
+			util.LogWithContextIfNeeded("Error while running", err, l)
+			os.Exit(1)
+		}
+
+		go ctrl.ShutdownBlock()
 		notifyReady(l)
-		ctrl.ShutdownBlock()
+		wait()
+
+		l.Info("Goodbye")
 	}
 
 	os.Exit(0)

--- a/cmd/nebula/main.go
+++ b/cmd/nebula/main.go
@@ -83,7 +83,6 @@ func main() {
 
 		if err := wait(); err != nil {
 			l.WithError(err).Error("Nebula stopped due to fatal error")
-			l.Info("Goodbye")
 			os.Exit(2)
 		}
 

--- a/cmd/nebula/main.go
+++ b/cmd/nebula/main.go
@@ -80,7 +80,12 @@ func main() {
 
 		go ctrl.ShutdownBlock()
 		notifyReady(l)
-		wait()
+
+		if err := wait(); err != nil {
+			l.WithError(err).Error("Nebula stopped due to fatal error")
+			l.Info("Goodbye")
+			os.Exit(2)
+		}
 
 		l.Info("Goodbye")
 	}

--- a/control.go
+++ b/control.go
@@ -133,7 +133,9 @@ func (c *Control) Stop() {
 	if err := c.f.Close(); err != nil {
 		c.l.WithError(err).Error("Close interface failed")
 	}
+	c.stateLock.Lock()
 	c.state = Stopped
+	c.stateLock.Unlock()
 }
 
 // ShutdownBlock will listen for and block on term and interrupt signals, calling Control.Stop() once signalled

--- a/control.go
+++ b/control.go
@@ -18,12 +18,15 @@ import (
 type RunState int
 
 const (
-	Stopped  RunState = 0 // The control has yet to be started
-	Started  RunState = 1 // The control has been started
-	Stopping RunState = 2 // The control is stopping
+	StateUnknown RunState = iota
+	StateReady
+	StateStarted
+	StateStopping
+	StateStopped
 )
 
 var ErrAlreadyStarted = errors.New("nebula is already started")
+var ErrAlreadyStopped = errors.New("nebula cannot be restarted")
 
 // Every interaction here needs to take extra care to copy memory and not return or use arguments "as is" when touching
 // core. This means copying IP objects, slices, de-referencing pointers and taking the actual value, etc
@@ -71,15 +74,21 @@ type ControlHostInfo struct {
 // triggered the shutdown.
 func (c *Control) Start() (func() error, error) {
 	c.stateLock.Lock()
-	if c.state != Stopped {
-		c.stateLock.Unlock()
+	defer c.stateLock.Unlock()
+	switch c.state {
+	case StateReady:
+		//yay!
+	case StateStopped, StateStopping:
+		return nil, ErrAlreadyStopped
+	case StateStarted:
 		return nil, ErrAlreadyStarted
+	default:
+		return nil, errors.New("invalid state")
 	}
 
 	// Activate the interface
 	err := c.f.activate()
 	if err != nil {
-		c.stateLock.Unlock()
 		return nil, err
 	}
 
@@ -103,9 +112,13 @@ func (c *Control) Start() (func() error, error) {
 	c.f.triggerShutdown = c.Stop
 
 	// Start reading packets.
-	c.state = Started
-	c.stateLock.Unlock()
-	return c.f.run()
+	out, err := c.f.run()
+	if err != nil {
+		c.state = StateStopped
+		return nil, err
+	}
+	c.state = StateStarted
+	return out, nil
 }
 
 func (c *Control) State() RunState {
@@ -121,13 +134,13 @@ func (c *Control) Context() context.Context {
 // Stop is a non-blocking call that signals nebula to close all tunnels and shut down
 func (c *Control) Stop() {
 	c.stateLock.Lock()
-	if c.state != Started {
+	if c.state != StateStarted {
 		c.stateLock.Unlock()
 		// We are stopping or stopped already
 		return
 	}
 
-	c.state = Stopping
+	c.state = StateStopping
 	c.stateLock.Unlock()
 
 	// Stop the handshakeManager (and other services), to prevent new tunnels from
@@ -139,7 +152,7 @@ func (c *Control) Stop() {
 		c.l.WithError(err).Error("Close interface failed")
 	}
 	c.stateLock.Lock()
-	c.state = Stopped
+	c.state = StateStopped
 	c.stateLock.Unlock()
 }
 

--- a/control.go
+++ b/control.go
@@ -65,8 +65,11 @@ type ControlHostInfo struct {
 }
 
 // Start actually runs nebula, this is a nonblocking call.
-// The returned function can be used to wait for nebula to fully stop.
-func (c *Control) Start() (func(), error) {
+// The returned function blocks until nebula has fully stopped and returns the
+// first fatal reader error (if any). A nil error means nebula shut down
+// gracefully; a non-nil error means a reader hit an unexpected failure that
+// triggered the shutdown.
+func (c *Control) Start() (func() error, error) {
 	c.stateLock.Lock()
 	if c.state != Stopped {
 		c.stateLock.Unlock()
@@ -96,6 +99,8 @@ func (c *Control) Start() (func(), error) {
 	if c.lighthouseStart != nil {
 		c.lighthouseStart()
 	}
+
+	c.f.triggerShutdown = c.Stop
 
 	// Start reading packets.
 	c.state = Started

--- a/control.go
+++ b/control.go
@@ -27,6 +27,7 @@ const (
 
 var ErrAlreadyStarted = errors.New("nebula is already started")
 var ErrAlreadyStopped = errors.New("nebula cannot be restarted")
+var ErrUnknownState = errors.New("nebula state is invalid")
 
 // Every interaction here needs to take extra care to copy memory and not return or use arguments "as is" when touching
 // core. This means copying IP objects, slices, de-referencing pointers and taking the actual value, etc
@@ -83,12 +84,13 @@ func (c *Control) Start() (func() error, error) {
 	case StateStarted:
 		return nil, ErrAlreadyStarted
 	default:
-		return nil, errors.New("invalid state")
+		return nil, ErrUnknownState
 	}
 
 	// Activate the interface
 	err := c.f.activate()
 	if err != nil {
+		c.state = StateStopped
 		return nil, err
 	}
 

--- a/control_test.go
+++ b/control_test.go
@@ -79,6 +79,7 @@ func TestControl_GetHostInfoByVpnIp(t *testing.T) {
 	}, &Interface{})
 
 	c := Control{
+		state: StateReady,
 		f: &Interface{
 			hostMap: hm,
 		},

--- a/interface.go
+++ b/interface.go
@@ -319,7 +319,7 @@ func (f *Interface) listenOut(i int) {
 		f.onFatal(err)
 	}
 
-	f.l.Infof("underlay reader %v is done", i)
+	f.l.Debugf("underlay reader %v is done", i)
 }
 
 func (f *Interface) listenIn(reader io.ReadWriteCloser, i int) {
@@ -343,7 +343,7 @@ func (f *Interface) listenIn(reader io.ReadWriteCloser, i int) {
 		f.consumeInsidePacket(packet[:n], fwPacket, nb, out, i, conntrackCache.Get(f.l))
 	}
 
-	f.l.Infof("overlay reader %v is done", i)
+	f.l.Debugf("overlay reader %v is done", i)
 }
 
 func (f *Interface) RegisterConfigChangeCallbacks(c *config.C) {
@@ -518,19 +518,23 @@ func (f *Interface) GetCertState() *CertState {
 }
 
 func (f *Interface) Close() error {
-	var err error
+	var errs []error
 	f.closed.Store(true)
 
 	// Release the udp readers
 	for i, u := range f.writers {
-		err = u.Close()
+		err := u.Close()
 		if err != nil {
 			f.l.WithError(err).WithField("writer", i).Error("Error while closing udp socket")
+			errs = append(errs, err)
 		}
 	}
 
 	// Release the tun device (closing the tun also closes all readers)
-	err = f.inside.Close()
+	closeErr := f.inside.Close()
+	if closeErr != nil {
+		errs = append(errs, closeErr)
+	}
 	f.wg.Done()
-	return err
+	return errors.Join(errs...)
 }

--- a/interface.go
+++ b/interface.go
@@ -290,7 +290,7 @@ func (f *Interface) listenOut(i int) {
 	})
 
 	if err != nil && !f.closed.Load() {
-		f.l.WithError(err).Error("Error while reading packet inbound packet, closing")
+		f.l.WithError(err).Error("Error while reading inbound packet, closing")
 		//TODO: Trigger Control to close
 	}
 

--- a/interface.go
+++ b/interface.go
@@ -485,15 +485,7 @@ func (f *Interface) Close() error {
 			f.l.WithError(err).Error("Error while closing udp socket")
 		}
 	}
-	for i, r := range f.readers {
-		if i == 0 {
-			continue // f.readers[0] is f.inside, which we want to save for last
-		}
-		if err := r.Close(); err != nil {
-			f.l.WithError(err).Error("Error while closing tun reader")
-		}
-	}
 
-	// Release the tun device
+	// Release the tun device (closing the tun also closes all readers)
 	return f.inside.Close()
 }

--- a/interface.go
+++ b/interface.go
@@ -294,7 +294,7 @@ func (f *Interface) listenOut(i int) {
 		//TODO: Trigger Control to close
 	}
 
-	f.l.Debugf("underlay reader %v is done", i)
+	f.l.Infof("underlay reader %v is done", i)
 }
 
 func (f *Interface) listenIn(reader io.ReadWriteCloser, i int) {
@@ -318,7 +318,7 @@ func (f *Interface) listenIn(reader io.ReadWriteCloser, i int) {
 		f.consumeInsidePacket(packet[:n], fwPacket, nb, out, i, conntrackCache.Get(f.l))
 	}
 
-	f.l.Debugf("overlay reader %v is done", i)
+	f.l.Infof("overlay reader %v is done", i)
 }
 
 func (f *Interface) RegisterConfigChangeCallbacks(c *config.C) {
@@ -493,13 +493,14 @@ func (f *Interface) GetCertState() *CertState {
 }
 
 func (f *Interface) Close() error {
+	var err error
 	f.closed.Store(true)
 
 	// Release the udp readers
-	for _, u := range f.writers {
-		err := u.Close()
+	for i, u := range f.writers {
+		err = u.Close()
 		if err != nil {
-			f.l.WithError(err).Error("Error while closing udp socket")
+			f.l.WithError(err).WithField("writer", i).Error("Error while closing udp socket")
 		}
 	}
 

--- a/interface.go
+++ b/interface.go
@@ -89,6 +89,12 @@ type Interface struct {
 	readers []io.ReadWriteCloser
 	wg      sync.WaitGroup
 
+	// fatalErr holds the first unexpected reader error that caused shutdown.
+	// nil means "no fatal error" (yet)
+	fatalErr atomic.Pointer[error]
+	// triggerShutdown is a function that will be run exactly once, when onFatal swaps something non-nil into fatalErr
+	triggerShutdown func()
+
 	metricHandshakes    metrics.Histogram
 	messageMetrics      *MessageMetrics
 	cachedPacketMetrics *cachedPacketMetrics
@@ -244,6 +250,7 @@ func (f *Interface) activate() error {
 		f.readers[i] = reader
 	}
 
+	f.wg.Add(1) // for us to wait on Close() to return
 	if err = f.inside.Activate(); err != nil {
 		f.inside.Close()
 		return err
@@ -252,7 +259,7 @@ func (f *Interface) activate() error {
 	return nil
 }
 
-func (f *Interface) run() (func(), error) {
+func (f *Interface) run() (func() error, error) {
 	// Launch n queues to read packets from udp
 	for i := 0; i < f.routines; i++ {
 		f.wg.Go(func() {
@@ -267,7 +274,24 @@ func (f *Interface) run() (func(), error) {
 		})
 	}
 
-	return f.wg.Wait, nil
+	return func() error {
+		f.wg.Wait()
+		if e := f.fatalErr.Load(); e != nil {
+			return *e
+		}
+		return nil
+	}, nil
+}
+
+// onFatal stores the first fatal reader error, and calls triggerShutdown if it was the first one
+func (f *Interface) onFatal(err error) {
+	swapped := f.fatalErr.CompareAndSwap(nil, &err)
+	if !swapped {
+		return
+	}
+	if f.triggerShutdown != nil {
+		f.triggerShutdown()
+	}
 }
 
 func (f *Interface) listenOut(i int) {
@@ -291,7 +315,7 @@ func (f *Interface) listenOut(i int) {
 
 	if err != nil && !f.closed.Load() {
 		f.l.WithError(err).Error("Error while reading inbound packet, closing")
-		//TODO: Trigger Control to close
+		f.onFatal(err)
 	}
 
 	f.l.Infof("underlay reader %v is done", i)
@@ -310,7 +334,7 @@ func (f *Interface) listenIn(reader io.ReadWriteCloser, i int) {
 		if err != nil {
 			if !f.closed.Load() {
 				f.l.WithError(err).WithField("reader", i).Error("Error while reading outbound packet, closing")
-				//TODO: Trigger Control to close
+				f.onFatal(err)
 			}
 			break
 		}
@@ -505,5 +529,7 @@ func (f *Interface) Close() error {
 	}
 
 	// Release the tun device (closing the tun also closes all readers)
-	return f.inside.Close()
+	err = f.inside.Close()
+	f.wg.Done()
+	return err
 }

--- a/interface.go
+++ b/interface.go
@@ -295,7 +295,6 @@ func (f *Interface) listenOut(i int) {
 	}
 
 	f.l.Debugf("underlay reader %v is done", i)
-	f.wg.Done()
 }
 
 func (f *Interface) listenIn(reader io.ReadWriteCloser, i int) {
@@ -320,7 +319,6 @@ func (f *Interface) listenIn(reader io.ReadWriteCloser, i int) {
 	}
 
 	f.l.Debugf("overlay reader %v is done", i)
-	f.wg.Done()
 }
 
 func (f *Interface) RegisterConfigChangeCallbacks(c *config.C) {

--- a/interface.go
+++ b/interface.go
@@ -252,6 +252,7 @@ func (f *Interface) activate() error {
 
 	f.wg.Add(1) // for us to wait on Close() to return
 	if err = f.inside.Activate(); err != nil {
+		f.wg.Done()
 		f.inside.Close()
 		return err
 	}

--- a/interface.go
+++ b/interface.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/netip"
-	"os"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -87,6 +87,7 @@ type Interface struct {
 
 	writers []udp.Conn
 	readers []io.ReadWriteCloser
+	wg      sync.WaitGroup
 
 	metricHandshakes    metrics.Histogram
 	messageMetrics      *MessageMetrics
@@ -209,7 +210,7 @@ func NewInterface(ctx context.Context, c *InterfaceConfig) (*Interface, error) {
 // activate creates the interface on the host. After the interface is created, any
 // other services that want to bind listeners to its IP may do so successfully. However,
 // the interface isn't going to process anything until run() is called.
-func (f *Interface) activate() {
+func (f *Interface) activate() error {
 	// actually turn on tun dev
 
 	addr, err := f.outside.LocalAddr()
@@ -237,28 +238,36 @@ func (f *Interface) activate() {
 		if i > 0 {
 			reader, err = f.inside.NewMultiQueueReader()
 			if err != nil {
-				f.l.Fatal(err)
+				return err
 			}
 		}
 		f.readers[i] = reader
 	}
 
-	if err := f.inside.Activate(); err != nil {
+	if err = f.inside.Activate(); err != nil {
 		f.inside.Close()
-		f.l.Fatal(err)
+		return err
 	}
+
+	return nil
 }
 
-func (f *Interface) run() {
+func (f *Interface) run() (func(), error) {
 	// Launch n queues to read packets from udp
 	for i := 0; i < f.routines; i++ {
-		go f.listenOut(i)
+		f.wg.Go(func() {
+			f.listenOut(i)
+		})
 	}
 
 	// Launch n queues to read packets from tun dev
 	for i := 0; i < f.routines; i++ {
-		go f.listenIn(f.readers[i], i)
+		f.wg.Go(func() {
+			f.listenIn(f.readers[i], i)
+		})
 	}
+
+	return f.wg.Wait, nil
 }
 
 func (f *Interface) listenOut(i int) {
@@ -276,9 +285,17 @@ func (f *Interface) listenOut(i int) {
 	fwPacket := &firewall.Packet{}
 	nb := make([]byte, 12, 12)
 
-	li.ListenOut(func(fromUdpAddr netip.AddrPort, payload []byte) {
+	err := li.ListenOut(func(fromUdpAddr netip.AddrPort, payload []byte) {
 		f.readOutsidePackets(ViaSender{UdpAddr: fromUdpAddr}, plaintext[:0], payload, h, fwPacket, lhh, nb, i, ctCache.Get(f.l))
 	})
+
+	if err != nil && !f.closed.Load() {
+		f.l.WithError(err).Error("Error while reading packet inbound packet, closing")
+		//TODO: Trigger Control to close
+	}
+
+	f.l.Debugf("underlay reader %v is done", i)
+	f.wg.Done()
 }
 
 func (f *Interface) listenIn(reader io.ReadWriteCloser, i int) {
@@ -292,17 +309,18 @@ func (f *Interface) listenIn(reader io.ReadWriteCloser, i int) {
 	for {
 		n, err := reader.Read(packet)
 		if err != nil {
-			if errors.Is(err, os.ErrClosed) && f.closed.Load() {
-				return
+			if !f.closed.Load() {
+				f.l.WithError(err).WithField("reader", i).Error("Error while reading outbound packet, closing")
+				//TODO: Trigger Control to close
 			}
-
-			f.l.WithError(err).Error("Error while reading outbound packet")
-			// This only seems to happen when something fatal happens to the fd, so exit.
-			os.Exit(2)
+			break
 		}
 
 		f.consumeInsidePacket(packet[:n], fwPacket, nb, out, i, conntrackCache.Get(f.l))
 	}
+
+	f.l.Debugf("overlay reader %v is done", i)
+	f.wg.Done()
 }
 
 func (f *Interface) RegisterConfigChangeCallbacks(c *config.C) {
@@ -479,6 +497,7 @@ func (f *Interface) GetCertState() *CertState {
 func (f *Interface) Close() error {
 	f.closed.Store(true)
 
+	// Release the udp readers
 	for _, u := range f.writers {
 		err := u.Close()
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -288,15 +288,15 @@ func Main(c *config.C, configTest bool, buildVersion string, logger *logrus.Logg
 	}
 
 	return &Control{
-		ifce,
-		l,
-		ctx,
-		cancel,
-		sshStart,
-		statsStart,
-		dnsStart,
-		lightHouse.StartUpdateWorker,
-		connManager.Start,
+		f:                      ifce,
+		l:                      l,
+		ctx:                    ctx,
+		cancel:                 cancel,
+		sshStart:               sshStart,
+		statsStart:             statsStart,
+		dnsStart:               dnsStart,
+		lighthouseStart:        lightHouse.StartUpdateWorker,
+		connectionManagerStart: connManager.Start,
 	}, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -288,6 +288,7 @@ func Main(c *config.C, configTest bool, buildVersion string, logger *logrus.Logg
 	}
 
 	return &Control{
+		state:                  StateReady,
 		f:                      ifce,
 		l:                      l,
 		ctx:                    ctx,

--- a/overlay/tun_file_linux_test.go
+++ b/overlay/tun_file_linux_test.go
@@ -1,0 +1,120 @@
+//go:build linux && !android && !e2e_testing
+// +build linux,!android,!e2e_testing
+
+package overlay
+
+import (
+	"errors"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// newReadPipe returns a read fd. The matching write fd is registered for cleanup.
+// The caller takes ownership of the read fd (pass it to newTunFd / newFriend).
+func newReadPipe(t *testing.T) int {
+	t.Helper()
+	var fds [2]int
+	if err := unix.Pipe2(fds[:], unix.O_CLOEXEC); err != nil {
+		t.Fatalf("pipe2: %v", err)
+	}
+	t.Cleanup(func() { _ = unix.Close(fds[1]) })
+	return fds[0]
+}
+
+func TestTunFile_WakeForShutdown_UnblocksRead(t *testing.T) {
+	tf, err := newTunFd(newReadPipe(t))
+	if err != nil {
+		t.Fatalf("newTunFd: %v", err)
+	}
+	t.Cleanup(func() { _ = tf.Close() })
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := tf.Read(make([]byte, 64))
+		done <- err
+	}()
+
+	// Verify Read is actually blocked in poll.
+	select {
+	case err := <-done:
+		t.Fatalf("Read returned before shutdown signal: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	if err := tf.wakeForShutdown(); err != nil {
+		t.Fatalf("wakeForShutdown: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, os.ErrClosed) {
+			t.Fatalf("expected os.ErrClosed, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Read did not wake on shutdown")
+	}
+}
+
+func TestTunFile_WakeForShutdown_WakesFriends(t *testing.T) {
+	parent, err := newTunFd(newReadPipe(t))
+	if err != nil {
+		t.Fatalf("newTunFd: %v", err)
+	}
+	friend, err := parent.newFriend(newReadPipe(t))
+	if err != nil {
+		_ = parent.Close()
+		t.Fatalf("newFriend: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = friend.Close()
+		_ = parent.Close()
+	})
+
+	readers := []*tunFile{parent, friend}
+	errs := make([]error, len(readers))
+	var wg sync.WaitGroup
+	for i, r := range readers {
+		wg.Add(1)
+		go func(i int, r *tunFile) {
+			defer wg.Done()
+			_, errs[i] = r.Read(make([]byte, 64))
+		}(i, r)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	if err := parent.wakeForShutdown(); err != nil {
+		t.Fatalf("wakeForShutdown: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("readers did not wake")
+	}
+
+	for i, err := range errs {
+		if !errors.Is(err, os.ErrClosed) {
+			t.Errorf("reader %d: expected os.ErrClosed, got %v", i, err)
+		}
+	}
+}
+
+func TestTunFile_Close_Idempotent(t *testing.T) {
+	tf, err := newTunFd(newReadPipe(t))
+	if err != nil {
+		t.Fatalf("newTunFd: %v", err)
+	}
+	if err := tf.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := tf.Close(); err != nil {
+		t.Fatalf("second Close should be a no-op, got %v", err)
+	}
+}

--- a/overlay/tun_linux.go
+++ b/overlay/tun_linux.go
@@ -4,6 +4,7 @@
 package overlay
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 	"net"

--- a/overlay/tun_linux.go
+++ b/overlay/tun_linux.go
@@ -143,6 +143,8 @@ func (r *tunFile) Read(buf []byte) (int, error) {
 				return 0, err
 			}
 			continue
+		} else if err == unix.EINTR {
+			continue
 		} else if err == unix.EBADF {
 			return 0, os.ErrClosed
 		} else {

--- a/overlay/tun_linux.go
+++ b/overlay/tun_linux.go
@@ -831,18 +831,18 @@ func (t *tun) Close() error {
 		}
 		err := t.readers[i].Close()
 		if err != nil {
-			t.l.WithField("reader", i).WithError(err).Error("Error closing tun reader")
+			t.l.WithField("reader", i).WithError(err).Error("error closing tun reader")
 		} else {
-			t.l.WithField("reader", i).Info("Closed tun reader")
+			t.l.WithField("reader", i).Info("closed tun reader")
 		}
 	}
 
 	//this is t.readers[0] too
 	err := t.tunFile.Close()
 	if err != nil {
-		t.l.WithField("reader", 0).WithError(err).Error("Error closing tun reader")
+		t.l.WithField("reader", 0).WithError(err).Error("error closing tun reader")
 	} else {
-		t.l.WithField("reader", 0).Info("Closed tun reader")
+		t.l.WithField("reader", 0).Info("closed tun reader")
 	}
 	return err
 }

--- a/overlay/tun_linux.go
+++ b/overlay/tun_linux.go
@@ -25,61 +25,118 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// tunFd wraps a non-blocking TUN file descriptor with poll-based reads.
+// tunFile wraps a TUN file descriptor with poll-based reads. The FD provided will be changed to non-blocking.
 // A shared eventfd allows Close to wake all readers blocked in poll.
-type tunFd struct {
+type tunFile struct {
 	fd      int
+	lastOne bool
 	pollFds [2]unix.PollFd
+	closed  bool
 }
 
-func newTunFd(fd, shutdownFd int) *tunFd {
-	return &tunFd{
+// newFriend makes a tunFile for a MultiQueueReader that copies the shutdown eventfd from the parent tun
+func (r *tunFile) newFriend(fd int) (*tunFile, error) {
+	if err := unix.SetNonblock(fd, true); err != nil {
+		return nil, fmt.Errorf("failed to set tun fd non-blocking: %w", err)
+	}
+	return &tunFile{
 		fd: fd,
+		pollFds: [2]unix.PollFd{
+			{Fd: int32(fd), Events: unix.POLLIN},
+			{Fd: r.pollFds[1].Fd, Events: unix.POLLIN},
+		},
+	}, nil
+}
+
+func newTunFd(fd int) (*tunFile, error) {
+	if err := unix.SetNonblock(fd, true); err != nil {
+		return nil, fmt.Errorf("failed to set tun fd non-blocking: %w", err)
+	}
+
+	shutdownFd, err := unix.Eventfd(0, unix.EFD_NONBLOCK|unix.EFD_CLOEXEC)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create eventfd: %w", err)
+	}
+
+	out := &tunFile{
+		fd:      fd,
+		lastOne: true,
 		pollFds: [2]unix.PollFd{
 			{Fd: int32(fd), Events: unix.POLLIN},
 			{Fd: int32(shutdownFd), Events: unix.POLLIN},
 		},
 	}
+
+	return out, nil
 }
 
-func (r *tunFd) Read(buf []byte) (int, error) {
+func (r *tunFile) block() error {
+	const problemFlags = unix.POLLHUP | unix.POLLNVAL | unix.POLLERR
+	var err error
 	for {
-		n, err := unix.Read(r.fd, buf)
-		if err != nil {
-			if err == unix.EAGAIN {
-				for {
-					_, err = unix.Poll(r.pollFds[:], -1)
-					if err != unix.EINTR {
-						break
-					}
-				}
-				if err != nil {
-					return 0, err
-				}
-				if r.pollFds[1].Revents&unix.POLLIN != 0 {
-					return 0, os.ErrClosed
-				}
-				r.pollFds[0].Revents = 0
-				r.pollFds[1].Revents = 0
-				continue
+		_, err = unix.Poll(r.pollFds[:], -1)
+		if err != unix.EINTR {
+			break
+		}
+	}
+	//always reset these!
+	tunEvents := r.pollFds[0].Revents
+	shutdownEvents := r.pollFds[1].Revents
+	r.pollFds[0].Revents = 0
+	r.pollFds[1].Revents = 0
+	//do the err check before trusting the potentially bogus bits we just got
+	if err != nil {
+		return err
+	}
+	if shutdownEvents&(unix.POLLIN|problemFlags) != 0 {
+		return os.ErrClosed
+	} else if tunEvents&problemFlags != 0 {
+		return os.ErrClosed
+	}
+	return nil
+}
+
+func (r *tunFile) Read(buf []byte) (int, error) {
+	for {
+		if n, err := unix.Read(r.fd, buf); err == nil {
+			return n, nil
+		} else if err == unix.EAGAIN {
+			if err = r.block(); err != nil {
+				return 0, err
 			}
+			continue
+		} else {
 			return 0, err
 		}
-		return n, nil
 	}
 }
 
-func (r *tunFd) Write(buf []byte) (int, error) {
+func (r *tunFile) Write(buf []byte) (int, error) {
 	return unix.Write(r.fd, buf)
 }
 
-func (r *tunFd) Close() error {
+func (r *tunFile) wakeForShutdown() error {
+	var buf [8]byte
+	binary.NativeEndian.PutUint64(buf[:], 1)
+	_, err := unix.Write(int(r.pollFds[1].Fd), buf[:])
+	return err
+}
+
+func (r *tunFile) Close() error {
+	if r.closed { // avoid closing more than once. Technically a fd could get re-used, which would be a problem
+		return nil
+	}
+	r.closed = true
+	if r.lastOne {
+		_ = unix.Close(int(r.pollFds[1].Fd))
+	}
 	return unix.Close(r.fd)
 }
 
 type tun struct {
-	*tunFd
-	shutdownFd  int
+	*tunFile
+	readers     []*tunFile
+	closeLock   sync.Mutex
 	Device      string
 	vpnNetworks []netip.Prefix
 	MaxMTU      int
@@ -166,6 +223,7 @@ func newTun(c *config.C, l *logrus.Logger, vpnNetworks []netip.Prefix, multiqueu
 	nameStr := c.GetString("tun.dev", "")
 	copy(req.Name[:], nameStr)
 	if err = ioctl(uintptr(fd), uintptr(unix.TUNSETIFF), uintptr(unsafe.Pointer(&req))); err != nil {
+		_ = unix.Close(fd)
 		return nil, &NameError{
 			Name:       nameStr,
 			Underlying: err,
@@ -183,22 +241,17 @@ func newTun(c *config.C, l *logrus.Logger, vpnNetworks []netip.Prefix, multiqueu
 	return t, nil
 }
 
+// newTunGeneric does all the stuff common to different tun initialization paths. It will close your files on error.
 func newTunGeneric(c *config.C, l *logrus.Logger, fd int, vpnNetworks []netip.Prefix) (*tun, error) {
-	shutdownFd, err := unix.Eventfd(0, unix.EFD_NONBLOCK|unix.EFD_CLOEXEC)
+	tfd, err := newTunFd(fd)
 	if err != nil {
 		_ = unix.Close(fd)
-		return nil, fmt.Errorf("failed to create eventfd: %w", err)
+		return nil, err
 	}
-
-	if err = unix.SetNonblock(fd, true); err != nil {
-		_ = unix.Close(fd)
-		_ = unix.Close(shutdownFd)
-		return nil, fmt.Errorf("failed to set tun fd non-blocking: %w", err)
-	}
-
 	t := &tun{
-		tunFd:                     newTunFd(fd, shutdownFd),
-		shutdownFd:                shutdownFd,
+		tunFile:                   tfd,
+		readers:                   []*tunFile{tfd},
+		closeLock:                 sync.Mutex{},
 		vpnNetworks:               vpnNetworks,
 		TXQueueLen:                c.GetInt("tun.tx_queue", 500),
 		useSystemRoutes:           c.GetBool("tun.use_system_route_table", false),
@@ -207,7 +260,8 @@ func newTunGeneric(c *config.C, l *logrus.Logger, fd int, vpnNetworks []netip.Pr
 		l:                         l,
 	}
 
-	if err := t.reload(c, true); err != nil {
+	if err = t.reload(c, true); err != nil {
+		_ = t.Close()
 		return nil, err
 	}
 
@@ -300,6 +354,9 @@ func (t *tun) SupportsMultiqueue() bool {
 }
 
 func (t *tun) NewMultiQueueReader() (io.ReadWriteCloser, error) {
+	t.closeLock.Lock()
+	defer t.closeLock.Unlock()
+
 	fd, err := unix.Open("/dev/net/tun", os.O_RDWR, 0)
 	if err != nil {
 		return nil, err
@@ -313,12 +370,15 @@ func (t *tun) NewMultiQueueReader() (io.ReadWriteCloser, error) {
 		return nil, err
 	}
 
-	if err = unix.SetNonblock(fd, true); err != nil {
+	out, err := t.tunFile.newFriend(fd)
+	if err != nil {
 		_ = unix.Close(fd)
 		return nil, err
 	}
 
-	return newTunFd(fd, t.shutdownFd), nil
+	t.readers = append(t.readers, out)
+
+	return out, nil
 }
 
 func (t *tun) RoutesFor(ip netip.Addr) routing.Gateways {
@@ -749,30 +809,40 @@ func (t *tun) updateRoutes(r netlink.RouteUpdate) {
 }
 
 func (t *tun) Close() error {
+	t.closeLock.Lock()
+	defer t.closeLock.Unlock()
+
 	if t.routeChan != nil {
 		close(t.routeChan)
+		t.routeChan = nil
 	}
 
 	// Signal all readers blocked in poll to wake up and exit
-	if t.shutdownFd >= 0 {
-		var buf [8]byte
-		binary.NativeEndian.PutUint64(buf[:], 1)
-		_, _ = unix.Write(t.shutdownFd, buf[:])
-	}
-
-	if t.tunFd != nil {
-		_ = t.tunFd.Close()
-	}
-
-	if t.shutdownFd >= 0 {
-		_ = unix.Close(t.shutdownFd)
-		t.shutdownFd = -1
-	}
+	_ = t.tunFile.wakeForShutdown()
 
 	if t.ioctlFd > 0 {
-		_ = os.NewFile(t.ioctlFd, "ioctlFd").Close()
+		_ = unix.Close(int(t.ioctlFd))
 		t.ioctlFd = 0
 	}
 
-	return nil
+	for i := range t.readers {
+		if i == 0 {
+			continue //we want to close the zeroth reader last
+		}
+		err := t.readers[i].Close()
+		if err != nil {
+			t.l.WithField("reader", i).WithError(err).Error("Error closing tun reader")
+		} else {
+			t.l.WithField("reader", i).Info("Closed tun reader")
+		}
+	}
+
+	//this is t.readers[0] too
+	err := t.tunFile.Close()
+	if err != nil {
+		t.l.WithField("reader", 0).WithError(err).Error("Error closing tun reader")
+	} else {
+		t.l.WithField("reader", 0).Info("Closed tun reader")
+	}
+	return err
 }

--- a/overlay/tun_linux.go
+++ b/overlay/tun_linux.go
@@ -143,6 +143,8 @@ func (r *tunFile) Read(buf []byte) (int, error) {
 				return 0, err
 			}
 			continue
+		} else if err == unix.EBADF {
+			return 0, os.ErrClosed
 		} else {
 			return 0, err
 		}
@@ -160,6 +162,8 @@ func (r *tunFile) Write(buf []byte) (int, error) {
 			continue
 		} else if err == unix.EINTR {
 			continue
+		} else if err == unix.EBADF {
+			return 0, os.ErrClosed
 		} else {
 			return 0, err
 		}

--- a/overlay/tun_linux.go
+++ b/overlay/tun_linux.go
@@ -4,7 +4,6 @@
 package overlay
 
 import (
-	"encoding/binary"
 	"fmt"
 	"io"
 	"net"

--- a/overlay/tun_linux.go
+++ b/overlay/tun_linux.go
@@ -4,6 +4,7 @@
 package overlay
 
 import (
+	"encoding/binary"
 	"fmt"
 	"io"
 	"net"
@@ -24,9 +25,61 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// tunFd wraps a non-blocking TUN file descriptor with poll-based reads.
+// A shared eventfd allows Close to wake all readers blocked in poll.
+type tunFd struct {
+	fd      int
+	pollFds [2]unix.PollFd
+}
+
+func newTunFd(fd, shutdownFd int) *tunFd {
+	return &tunFd{
+		fd: fd,
+		pollFds: [2]unix.PollFd{
+			{Fd: int32(fd), Events: unix.POLLIN},
+			{Fd: int32(shutdownFd), Events: unix.POLLIN},
+		},
+	}
+}
+
+func (r *tunFd) Read(buf []byte) (int, error) {
+	for {
+		n, err := unix.Read(r.fd, buf)
+		if err != nil {
+			if err == unix.EAGAIN {
+				for {
+					_, err = unix.Poll(r.pollFds[:], -1)
+					if err != unix.EINTR {
+						break
+					}
+				}
+				if err != nil {
+					return 0, err
+				}
+				if r.pollFds[1].Revents&unix.POLLIN != 0 {
+					return 0, os.ErrClosed
+				}
+				r.pollFds[0].Revents = 0
+				r.pollFds[1].Revents = 0
+				continue
+			}
+			return 0, err
+		}
+		return n, nil
+	}
+}
+
+func (r *tunFd) Write(buf []byte) (int, error) {
+	return unix.Write(r.fd, buf)
+}
+
+func (r *tunFd) Close() error {
+	return unix.Close(r.fd)
+}
+
 type tun struct {
-	io.ReadWriteCloser
-	fd          int
+	*tunFd
+	shutdownFd  int
 	Device      string
 	vpnNetworks []netip.Prefix
 	MaxMTU      int
@@ -72,9 +125,7 @@ type ifreqQLEN struct {
 }
 
 func newTunFromFd(c *config.C, l *logrus.Logger, deviceFd int, vpnNetworks []netip.Prefix) (*tun, error) {
-	file := os.NewFile(uintptr(deviceFd), "/dev/net/tun")
-
-	t, err := newTunGeneric(c, l, file, vpnNetworks)
+	t, err := newTunGeneric(c, l, deviceFd, vpnNetworks)
 	if err != nil {
 		return nil, err
 	}
@@ -122,8 +173,7 @@ func newTun(c *config.C, l *logrus.Logger, vpnNetworks []netip.Prefix, multiqueu
 	}
 	name := strings.Trim(string(req.Name[:]), "\x00")
 
-	file := os.NewFile(uintptr(fd), "/dev/net/tun")
-	t, err := newTunGeneric(c, l, file, vpnNetworks)
+	t, err := newTunGeneric(c, l, fd, vpnNetworks)
 	if err != nil {
 		return nil, err
 	}
@@ -133,10 +183,22 @@ func newTun(c *config.C, l *logrus.Logger, vpnNetworks []netip.Prefix, multiqueu
 	return t, nil
 }
 
-func newTunGeneric(c *config.C, l *logrus.Logger, file *os.File, vpnNetworks []netip.Prefix) (*tun, error) {
+func newTunGeneric(c *config.C, l *logrus.Logger, fd int, vpnNetworks []netip.Prefix) (*tun, error) {
+	shutdownFd, err := unix.Eventfd(0, unix.EFD_NONBLOCK|unix.EFD_CLOEXEC)
+	if err != nil {
+		unix.Close(fd)
+		return nil, fmt.Errorf("failed to create eventfd: %w", err)
+	}
+
+	if err := unix.SetNonblock(fd, true); err != nil {
+		unix.Close(fd)
+		unix.Close(shutdownFd)
+		return nil, fmt.Errorf("failed to set tun fd non-blocking: %w", err)
+	}
+
 	t := &tun{
-		ReadWriteCloser:           file,
-		fd:                        int(file.Fd()),
+		tunFd:                     newTunFd(fd, shutdownFd),
+		shutdownFd:                shutdownFd,
 		vpnNetworks:               vpnNetworks,
 		TXQueueLen:                c.GetInt("tun.tx_queue", 500),
 		useSystemRoutes:           c.GetBool("tun.use_system_route_table", false),
@@ -145,8 +207,7 @@ func newTunGeneric(c *config.C, l *logrus.Logger, file *os.File, vpnNetworks []n
 		l:                         l,
 	}
 
-	err := t.reload(c, true)
-	if err != nil {
+	if err := t.reload(c, true); err != nil {
 		return nil, err
 	}
 
@@ -248,12 +309,16 @@ func (t *tun) NewMultiQueueReader() (io.ReadWriteCloser, error) {
 	req.Flags = uint16(unix.IFF_TUN | unix.IFF_NO_PI | unix.IFF_MULTI_QUEUE)
 	copy(req.Name[:], t.Device)
 	if err = ioctl(uintptr(fd), uintptr(unix.TUNSETIFF), uintptr(unsafe.Pointer(&req))); err != nil {
+		unix.Close(fd)
 		return nil, err
 	}
 
-	file := os.NewFile(uintptr(fd), "/dev/net/tun")
+	if err = unix.SetNonblock(fd, true); err != nil {
+		unix.Close(fd)
+		return nil, err
+	}
 
-	return file, nil
+	return newTunFd(fd, t.shutdownFd), nil
 }
 
 func (t *tun) RoutesFor(ip netip.Addr) routing.Gateways {
@@ -688,8 +753,20 @@ func (t *tun) Close() error {
 		close(t.routeChan)
 	}
 
-	if t.ReadWriteCloser != nil {
-		_ = t.ReadWriteCloser.Close()
+	// Signal all readers blocked in poll to wake up and exit
+	if t.shutdownFd >= 0 {
+		var buf [8]byte
+		binary.NativeEndian.PutUint64(buf[:], 1)
+		unix.Write(t.shutdownFd, buf[:])
+	}
+
+	if t.tunFd != nil {
+		_ = t.tunFd.Close()
+	}
+
+	if t.shutdownFd >= 0 {
+		unix.Close(t.shutdownFd)
+		t.shutdownFd = -1
 	}
 
 	if t.ioctlFd > 0 {

--- a/overlay/tun_linux.go
+++ b/overlay/tun_linux.go
@@ -186,13 +186,13 @@ func newTun(c *config.C, l *logrus.Logger, vpnNetworks []netip.Prefix, multiqueu
 func newTunGeneric(c *config.C, l *logrus.Logger, fd int, vpnNetworks []netip.Prefix) (*tun, error) {
 	shutdownFd, err := unix.Eventfd(0, unix.EFD_NONBLOCK|unix.EFD_CLOEXEC)
 	if err != nil {
-		unix.Close(fd)
+		_ = unix.Close(fd)
 		return nil, fmt.Errorf("failed to create eventfd: %w", err)
 	}
 
-	if err := unix.SetNonblock(fd, true); err != nil {
-		unix.Close(fd)
-		unix.Close(shutdownFd)
+	if err = unix.SetNonblock(fd, true); err != nil {
+		_ = unix.Close(fd)
+		_ = unix.Close(shutdownFd)
 		return nil, fmt.Errorf("failed to set tun fd non-blocking: %w", err)
 	}
 
@@ -309,12 +309,12 @@ func (t *tun) NewMultiQueueReader() (io.ReadWriteCloser, error) {
 	req.Flags = uint16(unix.IFF_TUN | unix.IFF_NO_PI | unix.IFF_MULTI_QUEUE)
 	copy(req.Name[:], t.Device)
 	if err = ioctl(uintptr(fd), uintptr(unix.TUNSETIFF), uintptr(unsafe.Pointer(&req))); err != nil {
-		unix.Close(fd)
+		_ = unix.Close(fd)
 		return nil, err
 	}
 
 	if err = unix.SetNonblock(fd, true); err != nil {
-		unix.Close(fd)
+		_ = unix.Close(fd)
 		return nil, err
 	}
 
@@ -757,7 +757,7 @@ func (t *tun) Close() error {
 	if t.shutdownFd >= 0 {
 		var buf [8]byte
 		binary.NativeEndian.PutUint64(buf[:], 1)
-		unix.Write(t.shutdownFd, buf[:])
+		_, _ = unix.Write(t.shutdownFd, buf[:])
 	}
 
 	if t.tunFd != nil {
@@ -765,7 +765,7 @@ func (t *tun) Close() error {
 	}
 
 	if t.shutdownFd >= 0 {
-		unix.Close(t.shutdownFd)
+		_ = unix.Close(t.shutdownFd)
 		t.shutdownFd = -1
 	}
 

--- a/overlay/tun_linux.go
+++ b/overlay/tun_linux.go
@@ -28,10 +28,12 @@ import (
 // tunFile wraps a TUN file descriptor with poll-based reads. The FD provided will be changed to non-blocking.
 // A shared eventfd allows Close to wake all readers blocked in poll.
 type tunFile struct {
-	fd      int
-	lastOne bool
-	pollFds [2]unix.PollFd
-	closed  bool
+	fd         int
+	shutdownFd int
+	lastOne    bool
+	readPoll   [2]unix.PollFd
+	writePoll  [2]unix.PollFd
+	closed     bool
 }
 
 // newFriend makes a tunFile for a MultiQueueReader that copies the shutdown eventfd from the parent tun
@@ -40,10 +42,15 @@ func (r *tunFile) newFriend(fd int) (*tunFile, error) {
 		return nil, fmt.Errorf("failed to set tun fd non-blocking: %w", err)
 	}
 	return &tunFile{
-		fd: fd,
-		pollFds: [2]unix.PollFd{
+		fd:         fd,
+		shutdownFd: r.shutdownFd,
+		readPoll: [2]unix.PollFd{
 			{Fd: int32(fd), Events: unix.POLLIN},
-			{Fd: r.pollFds[1].Fd, Events: unix.POLLIN},
+			{Fd: int32(r.shutdownFd), Events: unix.POLLIN},
+		},
+		writePoll: [2]unix.PollFd{
+			{Fd: int32(fd), Events: unix.POLLOUT},
+			{Fd: int32(r.shutdownFd), Events: unix.POLLIN},
 		},
 	}, nil
 }
@@ -59,10 +66,15 @@ func newTunFd(fd int) (*tunFile, error) {
 	}
 
 	out := &tunFile{
-		fd:      fd,
-		lastOne: true,
-		pollFds: [2]unix.PollFd{
+		fd:         fd,
+		shutdownFd: shutdownFd,
+		lastOne:    true,
+		readPoll: [2]unix.PollFd{
 			{Fd: int32(fd), Events: unix.POLLIN},
+			{Fd: int32(shutdownFd), Events: unix.POLLIN},
+		},
+		writePoll: [2]unix.PollFd{
+			{Fd: int32(fd), Events: unix.POLLOUT},
 			{Fd: int32(shutdownFd), Events: unix.POLLIN},
 		},
 	}
@@ -70,20 +82,46 @@ func newTunFd(fd int) (*tunFile, error) {
 	return out, nil
 }
 
-func (r *tunFile) block() error {
+func (r *tunFile) blockOnRead() error {
 	const problemFlags = unix.POLLHUP | unix.POLLNVAL | unix.POLLERR
 	var err error
 	for {
-		_, err = unix.Poll(r.pollFds[:], -1)
+		_, err = unix.Poll(r.readPoll[:], -1)
 		if err != unix.EINTR {
 			break
 		}
 	}
 	//always reset these!
-	tunEvents := r.pollFds[0].Revents
-	shutdownEvents := r.pollFds[1].Revents
-	r.pollFds[0].Revents = 0
-	r.pollFds[1].Revents = 0
+	tunEvents := r.readPoll[0].Revents
+	shutdownEvents := r.readPoll[1].Revents
+	r.readPoll[0].Revents = 0
+	r.readPoll[1].Revents = 0
+	//do the err check before trusting the potentially bogus bits we just got
+	if err != nil {
+		return err
+	}
+	if shutdownEvents&(unix.POLLIN|problemFlags) != 0 {
+		return os.ErrClosed
+	} else if tunEvents&problemFlags != 0 {
+		return os.ErrClosed
+	}
+	return nil
+}
+
+func (r *tunFile) blockOnWrite() error {
+	const problemFlags = unix.POLLHUP | unix.POLLNVAL | unix.POLLERR
+	var err error
+	for {
+		_, err = unix.Poll(r.writePoll[:], -1)
+		if err != unix.EINTR {
+			break
+		}
+	}
+	//always reset these!
+	tunEvents := r.writePoll[0].Revents
+	shutdownEvents := r.writePoll[1].Revents
+	r.writePoll[0].Revents = 0
+	r.writePoll[1].Revents = 0
 	//do the err check before trusting the potentially bogus bits we just got
 	if err != nil {
 		return err
@@ -101,7 +139,7 @@ func (r *tunFile) Read(buf []byte) (int, error) {
 		if n, err := unix.Read(r.fd, buf); err == nil {
 			return n, nil
 		} else if err == unix.EAGAIN {
-			if err = r.block(); err != nil {
+			if err = r.blockOnRead(); err != nil {
 				return 0, err
 			}
 			continue
@@ -112,13 +150,26 @@ func (r *tunFile) Read(buf []byte) (int, error) {
 }
 
 func (r *tunFile) Write(buf []byte) (int, error) {
-	return unix.Write(r.fd, buf)
+	for {
+		if n, err := unix.Write(r.fd, buf); err == nil {
+			return n, nil
+		} else if err == unix.EAGAIN {
+			if err = r.blockOnWrite(); err != nil {
+				return 0, err
+			}
+			continue
+		} else if err == unix.EINTR {
+			continue
+		} else {
+			return 0, err
+		}
+	}
 }
 
 func (r *tunFile) wakeForShutdown() error {
 	var buf [8]byte
 	binary.NativeEndian.PutUint64(buf[:], 1)
-	_, err := unix.Write(int(r.pollFds[1].Fd), buf[:])
+	_, err := unix.Write(int(r.readPoll[1].Fd), buf[:])
 	return err
 }
 
@@ -128,7 +179,7 @@ func (r *tunFile) Close() error {
 	}
 	r.closed = true
 	if r.lastOne {
-		_ = unix.Close(int(r.pollFds[1].Fd))
+		_ = unix.Close(r.shutdownFd)
 	}
 	return unix.Close(r.fd)
 }

--- a/service/service.go
+++ b/service/service.go
@@ -44,7 +44,10 @@ type Service struct {
 }
 
 func New(control *nebula.Control) (*Service, error) {
-	control.Start()
+	wait, err := control.Start()
+	if err != nil {
+		return nil, err
+	}
 
 	ctx := control.Context()
 	eg, ctx := errgroup.WithContext(ctx)
@@ -139,6 +142,12 @@ func New(control *nebula.Control) (*Service, error) {
 			}
 			bufView.Release()
 		}
+	})
+
+	// Add the nebula wait function to the group
+	eg.Go(func() error {
+		wait()
+		return nil
 	})
 
 	return &s, nil

--- a/service/service.go
+++ b/service/service.go
@@ -144,10 +144,10 @@ func New(control *nebula.Control) (*Service, error) {
 		}
 	})
 
-	// Add the nebula wait function to the group
+	// Add the nebula wait function to the group so a fatal reader error
+	// propagates out through errgroup.Wait().
 	eg.Go(func() error {
-		wait()
-		return nil
+		return wait()
 	})
 
 	return &s, nil

--- a/udp/conn.go
+++ b/udp/conn.go
@@ -16,7 +16,7 @@ type EncReader func(
 type Conn interface {
 	Rebind() error
 	LocalAddr() (netip.AddrPort, error)
-	ListenOut(r EncReader)
+	ListenOut(r EncReader) error
 	WriteTo(b []byte, addr netip.AddrPort) error
 	ReloadConfig(c *config.C)
 	SupportsMultipleReaders() bool
@@ -31,8 +31,8 @@ func (NoopConn) Rebind() error {
 func (NoopConn) LocalAddr() (netip.AddrPort, error) {
 	return netip.AddrPort{}, nil
 }
-func (NoopConn) ListenOut(_ EncReader) {
-	return
+func (NoopConn) ListenOut(_ EncReader) error {
+	return nil
 }
 func (NoopConn) SupportsMultipleReaders() bool {
 	return false

--- a/udp/udp_darwin.go
+++ b/udp/udp_darwin.go
@@ -165,7 +165,7 @@ func NewUDPStatsEmitter(udpConns []Conn) func() {
 	return func() {}
 }
 
-func (u *StdConn) ListenOut(r EncReader) {
+func (u *StdConn) ListenOut(r EncReader) error {
 	buffer := make([]byte, MTU)
 
 	for {
@@ -173,8 +173,7 @@ func (u *StdConn) ListenOut(r EncReader) {
 		n, rua, err := u.ReadFromUDPAddrPort(buffer)
 		if err != nil {
 			if errors.Is(err, net.ErrClosed) {
-				u.l.WithError(err).Debug("udp socket is closed, exiting read loop")
-				return
+				return err
 			}
 
 			u.l.WithError(err).Error("unexpected udp socket receive error")

--- a/udp/udp_generic.go
+++ b/udp/udp_generic.go
@@ -10,9 +10,11 @@ package udp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/slackhq/nebula/config"
@@ -74,11 +76,22 @@ type rawMessage struct {
 func (u *GenericConn) ListenOut(r EncReader) error {
 	buffer := make([]byte, MTU)
 
+	var lastRecvErr time.Time
+
 	for {
 		// Just read one packet at a time
 		n, rua, err := u.ReadFromUDPAddrPort(buffer)
 		if err != nil {
-			return err
+			if errors.Is(err, net.ErrClosed) {
+				u.l.WithError(err).Debug("udp socket is closed, exiting read loop")
+				return err
+			}
+			// Dampen unexpected message warns to once per minute
+			if lastRecvErr.IsZero() || time.Since(lastRecvErr) > time.Minute {
+				lastRecvErr = time.Now()
+				u.l.WithError(err).Warn("unexpected udp socket receive error")
+			}
+			continue
 		}
 
 		r(netip.AddrPortFrom(rua.Addr().Unmap(), rua.Port()), buffer[:n])

--- a/udp/udp_generic.go
+++ b/udp/udp_generic.go
@@ -83,7 +83,6 @@ func (u *GenericConn) ListenOut(r EncReader) error {
 		n, rua, err := u.ReadFromUDPAddrPort(buffer)
 		if err != nil {
 			if errors.Is(err, net.ErrClosed) {
-				u.l.WithError(err).Debug("udp socket is closed, exiting read loop")
 				return err
 			}
 			// Dampen unexpected message warns to once per minute

--- a/udp/udp_linux.go
+++ b/udp/udp_linux.go
@@ -171,7 +171,7 @@ func recvmmsg(fd uintptr, msgs []rawMessage) (int, bool, error) {
 	return int(n), true, nil
 }
 
-func (u *StdConn) listenOutSingle(r EncReader) {
+func (u *StdConn) listenOutSingle(r EncReader) error {
 	var err error
 	var n int
 	var from netip.AddrPort
@@ -180,15 +180,14 @@ func (u *StdConn) listenOutSingle(r EncReader) {
 	for {
 		n, from, err = u.udpConn.ReadFromUDPAddrPort(buffer)
 		if err != nil {
-			u.l.WithError(err).Debug("udp socket is closed, exiting read loop")
-			return
+			return err
 		}
 		from = netip.AddrPortFrom(from.Addr().Unmap(), from.Port())
 		r(from, buffer[:n])
 	}
 }
 
-func (u *StdConn) listenOutBatch(r EncReader) {
+func (u *StdConn) listenOutBatch(r EncReader) error {
 	var ip netip.Addr
 	var n int
 	var operr error
@@ -205,12 +204,10 @@ func (u *StdConn) listenOutBatch(r EncReader) {
 	for {
 		err := u.rawConn.Read(reader)
 		if err != nil {
-			u.l.WithError(err).Debug("udp socket is closed, exiting read loop")
-			return
+			return err
 		}
 		if operr != nil {
-			u.l.WithError(operr).Debug("operr: udp socket is closed, exiting read loop")
-			return
+			return operr
 		}
 
 		for i := 0; i < n; i++ {
@@ -225,14 +222,11 @@ func (u *StdConn) listenOutBatch(r EncReader) {
 	}
 }
 
-func (u *StdConn) ListenOut(r EncReader) {
+func (u *StdConn) ListenOut(r EncReader) error {
 	if u.batch == 1 {
-		//save some ram by not calling PrepareRawMessages for fields we won't use
-		//we could also make this path more common by calling recvmmsg with msgs[:1],
-		//but that's still the recvmmsg syscall, which would be a change
-		u.listenOutSingle(r)
+		return u.listenOutSingle(r)
 	} else {
-		u.listenOutBatch(r)
+		return u.listenOutBatch(r)
 	}
 }
 
@@ -290,7 +284,7 @@ func (u *StdConn) ReloadConfig(c *config.C) {
 }
 
 func (u *StdConn) getMemInfo(meminfo *[unix.SK_MEMINFO_VARS]uint32) error {
-	var vallen uint32 = 4 * unix.SK_MEMINFO_VARS
+	const vallen uint32 = 4 * unix.SK_MEMINFO_VARS
 
 	if u.rawConn == nil {
 		return fmt.Errorf("no UDP connection")

--- a/udp/udp_linux.go
+++ b/udp/udp_linux.go
@@ -284,7 +284,7 @@ func (u *StdConn) ReloadConfig(c *config.C) {
 }
 
 func (u *StdConn) getMemInfo(meminfo *[unix.SK_MEMINFO_VARS]uint32) error {
-	const vallen uint32 = 4 * unix.SK_MEMINFO_VARS
+	var vallen uint32 = 4 * unix.SK_MEMINFO_VARS
 
 	if u.rawConn == nil {
 		return fmt.Errorf("no UDP connection")

--- a/udp/udp_rio_windows.go
+++ b/udp/udp_rio_windows.go
@@ -140,7 +140,7 @@ func (u *RIOConn) bind(l *logrus.Logger, sa windows.Sockaddr) error {
 	return nil
 }
 
-func (u *RIOConn) ListenOut(r EncReader) {
+func (u *RIOConn) ListenOut(r EncReader) error {
 	buffer := make([]byte, MTU)
 
 	var lastRecvErr time.Time
@@ -151,8 +151,7 @@ func (u *RIOConn) ListenOut(r EncReader) {
 
 		if err != nil {
 			if errors.Is(err, net.ErrClosed) {
-				u.l.WithError(err).Debug("udp socket is closed, exiting read loop")
-				return
+				return err
 			}
 			// Dampen unexpected message warns to once per minute
 			if lastRecvErr.IsZero() || time.Since(lastRecvErr) > time.Minute {

--- a/udp/udp_tester.go
+++ b/udp/udp_tester.go
@@ -6,6 +6,7 @@ package udp
 import (
 	"io"
 	"net/netip"
+	"os"
 	"sync/atomic"
 
 	"github.com/sirupsen/logrus"
@@ -106,11 +107,11 @@ func (u *TesterConn) WriteTo(b []byte, addr netip.AddrPort) error {
 	return nil
 }
 
-func (u *TesterConn) ListenOut(r EncReader) {
+func (u *TesterConn) ListenOut(r EncReader) error {
 	for {
 		p, ok := <-u.RxPackets
 		if !ok {
-			return
+			return os.ErrClosed
 		}
 		r(p.From, p.Data)
 	}


### PR DESCRIPTION
replaces #1375, #1658 

notes from Slack because I'm a mongrel who provided no description

The broad strokes summary is Nebula was using blocking IO on the tun file

This is great for performance, and not a problem when you get restarted by the init system murdering your process

But if you want to restart in-process, you need to unblock those threads somehow. And if they're blocking reads, you can only do that (on linux) by signalling their thread ID (which we don't have) or by feeding them something to read (which we agreed was too gross, because they're tuns, we'd have to open a socket and send a packet to nowhere)

So, we made the tun non-blocking, which comes with other compromises wrt performance. The one we landed on was to do a blocking read on a poll, which lets us wait for one or more file-descriptors to be "ready to read".  When we get a packet, the thread wakes and reads the tun fd, and when we want to shutdown, we write 0x1 to the "shutdown fd", which unblocks the reader threads and tells them its time to pack up and go home

Why didn't you just use os.File which would let you use go's netpoller? Because it benchmarked noticeably worse than what we ended up doing. It has locks and is thread safe, we don't and aren't.