### PR TITLE
Move relay-manager and related items to slog

### DIFF
--- a/connection_manager.go
+++ b/connection_manager.go
@@ -15,6 +15,7 @@ import (
 	"github.com/slackhq/nebula/cert"
 	"github.com/slackhq/nebula/config"
 	"github.com/slackhq/nebula/header"
+	"github.com/slackhq/nebula/logbridge"
 )
 
 type trafficDecision int
@@ -254,7 +255,7 @@ func (cm *connectionManager) migrateRelayUsed(oldhostinfo, newhostinfo *HostInfo
 			cm.relayUsedLock.RUnlock()
 			// The relay doesn't exist at all; create some relay state and send the request.
 			var err error
-			index, err = AddRelay(cm.l, newhostinfo, cm.hostMap, r.PeerAddr, nil, r.Type, Requested)
+			index, err = AddRelay(logbridge.FromLogrus(cm.l), newhostinfo, cm.hostMap, r.PeerAddr, nil, r.Type, Requested)
 			if err != nil {
 				cm.l.WithError(err).Error("failed to migrate relay to new hostinfo")
 				continue

--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -9,6 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/slackhq/nebula/cert"
 	"github.com/slackhq/nebula/header"
+	"github.com/slackhq/nebula/logbridge"
 )
 
 // NOISE IX Handshakes
@@ -232,7 +233,7 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 		}
 	}
 
-	myIndex, err := generateIndex(f.l)
+	myIndex, err := generateIndex(logbridge.FromLogrus(f.l))
 	if err != nil {
 		f.l.WithError(err).WithField("vpnAddrs", vpnAddrs).WithField("from", via).
 			WithField("certName", certName).

--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"errors"
+	"log/slog"
 	"net/netip"
 	"slices"
 	"sync"
@@ -15,6 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/slackhq/nebula/cert"
 	"github.com/slackhq/nebula/header"
+	"github.com/slackhq/nebula/logbridge"
 	"github.com/slackhq/nebula/udp"
 )
 
@@ -290,7 +292,7 @@ func (hm *HandshakeManager) handleOutbound(vpnIp netip.Addr, lighthouseTriggered
 			if !ok {
 				// No relays exist or requested yet.
 				if relayHostInfo.remote.IsValid() {
-					idx, err := AddRelay(hm.l, relayHostInfo, hm.mainHostMap, vpnIp, nil, TerminalType, Requested)
+					idx, err := AddRelay(logbridge.FromLogrus(hm.l), relayHostInfo, hm.mainHostMap, vpnIp, nil, TerminalType, Requested)
 					if err != nil {
 						hostinfo.logger(hm.l).WithField("relay", relay.String()).WithError(err).Info("Failed to add relay to hostmap")
 					}
@@ -591,7 +593,7 @@ func (hm *HandshakeManager) allocateIndex(hh *HandshakeHostInfo) error {
 	defer hm.Unlock()
 
 	for range 32 {
-		index, err := generateIndex(hm.l)
+		index, err := generateIndex(logbridge.FromLogrus(hm.l))
 		if err != nil {
 			return err
 		}
@@ -700,7 +702,7 @@ func (hm *HandshakeManager) EmitStats() {
 
 // Utility functions below
 
-func generateIndex(l *logrus.Logger) (uint32, error) {
+func generateIndex(l *slog.Logger) (uint32, error) {
 	b := make([]byte, 4)
 
 	// Let zero mean we don't know the ID, so don't generate zero
@@ -708,16 +710,15 @@ func generateIndex(l *logrus.Logger) (uint32, error) {
 	for index == 0 {
 		_, err := rand.Read(b)
 		if err != nil {
-			l.Errorln(err)
+			l.Error("Failed to generate index", slog.Any("error", err))
 			return 0, err
 		}
 
 		index = binary.BigEndian.Uint32(b)
 	}
 
-	if l.Level >= logrus.DebugLevel {
-		l.WithField("index", index).
-			Debug("Generated index")
+	if l.Enabled(context.Background(), slog.LevelDebug) {
+		l.Debug("Generated index", slog.Any("index", index))
 	}
 	return index, nil
 }

--- a/main.go
+++ b/main.go
@@ -239,7 +239,7 @@ func Main(c *config.C, configTest bool, buildVersion string, logger *logrus.Logg
 		routines:              routines,
 		MessageMetrics:        messageMetrics,
 		version:               buildVersion,
-		relayManager:          NewRelayManager(ctx, l, hostMap, c),
+		relayManager:          NewRelayManager(ctx, logbridge.FromLogrus(l), hostMap, c),
 		punchy:                punchy,
 		ConntrackCacheTimeout: conntrackCacheTimeout,
 		l:                     l,

--- a/relay_manager.go
+++ b/relay_manager.go
@@ -5,22 +5,22 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/netip"
 	"sync/atomic"
 
-	"github.com/sirupsen/logrus"
 	"github.com/slackhq/nebula/cert"
 	"github.com/slackhq/nebula/config"
 	"github.com/slackhq/nebula/header"
 )
 
 type relayManager struct {
-	l       *logrus.Logger
+	l       *slog.Logger
 	hostmap *HostMap
 	amRelay atomic.Bool
 }
 
-func NewRelayManager(ctx context.Context, l *logrus.Logger, hostmap *HostMap, c *config.C) *relayManager {
+func NewRelayManager(ctx context.Context, l *slog.Logger, hostmap *HostMap, c *config.C) *relayManager {
 	rm := &relayManager{
 		l:       l,
 		hostmap: hostmap,
@@ -29,7 +29,7 @@ func NewRelayManager(ctx context.Context, l *logrus.Logger, hostmap *HostMap, c 
 	c.RegisterReloadCallback(func(c *config.C) {
 		err := rm.reload(c, false)
 		if err != nil {
-			l.WithError(err).Error("Failed to reload relay_manager")
+			rm.l.Error("Failed to reload relay_manager", slog.Any("error", err))
 		}
 	})
 	return rm
@@ -52,7 +52,7 @@ func (rm *relayManager) setAmRelay(v bool) {
 
 // AddRelay finds an available relay index on the hostmap, and associates the relay info with it.
 // relayHostInfo is the Nebula peer which can be used as a relay to access the target vpnIp.
-func AddRelay(l *logrus.Logger, relayHostInfo *HostInfo, hm *HostMap, vpnIp netip.Addr, remoteIdx *uint32, relayType int, state int) (uint32, error) {
+func AddRelay(l *slog.Logger, relayHostInfo *HostInfo, hm *HostMap, vpnIp netip.Addr, remoteIdx *uint32, relayType int, state int) (uint32, error) {
 	hm.Lock()
 	defer hm.Unlock()
 	for range 32 {
@@ -92,24 +92,24 @@ func AddRelay(l *logrus.Logger, relayHostInfo *HostInfo, hm *HostMap, vpnIp neti
 func (rm *relayManager) EstablishRelay(relayHostInfo *HostInfo, m *NebulaControl) (*Relay, error) {
 	relay, ok := relayHostInfo.relayState.CompleteRelayByIdx(m.InitiatorRelayIndex, m.ResponderRelayIndex)
 	if !ok {
-		fields := logrus.Fields{
-			"relay":               relayHostInfo.vpnAddrs[0],
-			"initiatorRelayIndex": m.InitiatorRelayIndex,
-		}
-
+		var relayFrom, relayTo any
 		if m.RelayFromAddr == nil {
-			fields["relayFrom"] = m.OldRelayFromAddr
+			relayFrom = m.OldRelayFromAddr
 		} else {
-			fields["relayFrom"] = m.RelayFromAddr
+			relayFrom = m.RelayFromAddr
 		}
-
 		if m.RelayToAddr == nil {
-			fields["relayTo"] = m.OldRelayToAddr
+			relayTo = m.OldRelayToAddr
 		} else {
-			fields["relayTo"] = m.RelayToAddr
+			relayTo = m.RelayToAddr
 		}
 
-		rm.l.WithFields(fields).Info("relayManager failed to update relay")
+		rm.l.Info("relayManager failed to update relay",
+			slog.Any("relay", relayHostInfo.vpnAddrs[0]),
+			slog.Any("initiatorRelayIndex", m.InitiatorRelayIndex),
+			slog.Any("relayFrom", relayFrom),
+			slog.Any("relayTo", relayTo),
+		)
 		return nil, fmt.Errorf("unknown relay")
 	}
 
@@ -147,20 +147,20 @@ func (rm *relayManager) HandleControlMsg(h *HostInfo, d []byte, f *Interface) {
 }
 
 func (rm *relayManager) handleCreateRelayResponse(v cert.Version, h *HostInfo, f *Interface, m *NebulaControl) {
-	rm.l.WithFields(logrus.Fields{
-		"relayFrom":           protoAddrToNetAddr(m.RelayFromAddr),
-		"relayTo":             protoAddrToNetAddr(m.RelayToAddr),
-		"initiatorRelayIndex": m.InitiatorRelayIndex,
-		"responderRelayIndex": m.ResponderRelayIndex,
-		"vpnAddrs":            h.vpnAddrs}).
-		Info("handleCreateRelayResponse")
+	rm.l.Info("handleCreateRelayResponse",
+		slog.Any("relayFrom", protoAddrToNetAddr(m.RelayFromAddr)),
+		slog.Any("relayTo", protoAddrToNetAddr(m.RelayToAddr)),
+		slog.Any("initiatorRelayIndex", m.InitiatorRelayIndex),
+		slog.Any("responderRelayIndex", m.ResponderRelayIndex),
+		slog.Any("vpnAddrs", h.vpnAddrs),
+	)
 
 	target := m.RelayToAddr
 	targetAddr := protoAddrToNetAddr(target)
 
 	relay, err := rm.EstablishRelay(h, m)
 	if err != nil {
-		rm.l.WithError(err).Error("Failed to update relay for relayTo")
+		rm.l.Error("Failed to update relay for relayTo", slog.Any("error", err))
 		return
 	}
 	// Do I need to complete the relays now?
@@ -170,12 +170,12 @@ func (rm *relayManager) handleCreateRelayResponse(v cert.Version, h *HostInfo, f
 	// I'm the middle man. Let the initiator know that the I've established the relay they requested.
 	peerHostInfo := rm.hostmap.QueryVpnAddr(relay.PeerAddr)
 	if peerHostInfo == nil {
-		rm.l.WithField("relayTo", relay.PeerAddr).Error("Can't find a HostInfo for peer")
+		rm.l.Error("Can't find a HostInfo for peer", slog.Any("relayTo", relay.PeerAddr))
 		return
 	}
 	peerRelay, ok := peerHostInfo.relayState.QueryRelayForByIp(targetAddr)
 	if !ok {
-		rm.l.WithField("relayTo", peerHostInfo.vpnAddrs[0]).Error("peerRelay does not have Relay state for relayTo")
+		rm.l.Error("peerRelay does not have Relay state for relayTo", slog.Any("relayTo", peerHostInfo.vpnAddrs[0]))
 		return
 	}
 	switch peerRelay.State {
@@ -193,12 +193,13 @@ func (rm *relayManager) handleCreateRelayResponse(v cert.Version, h *HostInfo, f
 		if v == cert.Version1 {
 			peer := peerHostInfo.vpnAddrs[0]
 			if !peer.Is4() {
-				rm.l.WithField("relayFrom", peer).
-					WithField("relayTo", target).
-					WithField("initiatorRelayIndex", resp.InitiatorRelayIndex).
-					WithField("responderRelayIndex", resp.ResponderRelayIndex).
-					WithField("vpnAddrs", peerHostInfo.vpnAddrs).
-					Error("Refusing to CreateRelayResponse for a v1 relay with an ipv6 address")
+				rm.l.Error("Refusing to CreateRelayResponse for a v1 relay with an ipv6 address",
+					slog.Any("relayFrom", peer),
+					slog.Any("relayTo", target),
+					slog.Any("initiatorRelayIndex", resp.InitiatorRelayIndex),
+					slog.Any("responderRelayIndex", resp.ResponderRelayIndex),
+					slog.Any("vpnAddrs", peerHostInfo.vpnAddrs),
+				)
 				return
 			}
 
@@ -213,17 +214,16 @@ func (rm *relayManager) handleCreateRelayResponse(v cert.Version, h *HostInfo, f
 
 		msg, err := resp.Marshal()
 		if err != nil {
-			rm.l.WithError(err).
-				Error("relayManager Failed to marshal Control CreateRelayResponse message to create relay")
+			rm.l.Error("relayManager Failed to marshal Control CreateRelayResponse message to create relay", slog.Any("error", err))
 		} else {
 			f.SendMessageToHostInfo(header.Control, 0, peerHostInfo, msg, make([]byte, 12), make([]byte, mtu))
-			rm.l.WithFields(logrus.Fields{
-				"relayFrom":           resp.RelayFromAddr,
-				"relayTo":             resp.RelayToAddr,
-				"initiatorRelayIndex": resp.InitiatorRelayIndex,
-				"responderRelayIndex": resp.ResponderRelayIndex,
-				"vpnAddrs":            peerHostInfo.vpnAddrs}).
-				Info("send CreateRelayResponse")
+			rm.l.Info("send CreateRelayResponse",
+				slog.Any("relayFrom", resp.RelayFromAddr),
+				slog.Any("relayTo", resp.RelayToAddr),
+				slog.Any("initiatorRelayIndex", resp.InitiatorRelayIndex),
+				slog.Any("responderRelayIndex", resp.ResponderRelayIndex),
+				slog.Any("vpnAddrs", peerHostInfo.vpnAddrs),
+			)
 		}
 	}
 }
@@ -232,17 +232,18 @@ func (rm *relayManager) handleCreateRelayRequest(v cert.Version, h *HostInfo, f 
 	from := protoAddrToNetAddr(m.RelayFromAddr)
 	target := protoAddrToNetAddr(m.RelayToAddr)
 
-	logMsg := rm.l.WithFields(logrus.Fields{
-		"relayFrom":           from,
-		"relayTo":             target,
-		"initiatorRelayIndex": m.InitiatorRelayIndex,
-		"vpnAddrs":            h.vpnAddrs})
+	logMsg := rm.l.With(
+		slog.Any("relayFrom", from),
+		slog.Any("relayTo", target),
+		slog.Any("initiatorRelayIndex", m.InitiatorRelayIndex),
+		slog.Any("vpnAddrs", h.vpnAddrs),
+	)
 
 	logMsg.Info("handleCreateRelayRequest")
 	// Is the source of the relay me? This should never happen, but did happen due to
 	// an issue migrating relays over to newly re-handshaked host info objects.
 	if f.myVpnAddrsTable.Contains(from) {
-		logMsg.WithField("myIP", from).Error("Discarding relay request from myself")
+		logMsg.Error("Discarding relay request from myself", slog.Any("myIP", from))
 		return
 	}
 
@@ -261,37 +262,37 @@ func (rm *relayManager) handleCreateRelayRequest(v cert.Version, h *HostInfo, f 
 				if existingRelay.RemoteIndex != m.InitiatorRelayIndex {
 					// We got a brand new Relay request, because its index is different than what we saw before.
 					// This should never happen. The peer should never change an index, once created.
-					logMsg.WithFields(logrus.Fields{
-						"existingRemoteIndex": existingRelay.RemoteIndex}).Error("Existing relay mismatch with CreateRelayRequest")
+					logMsg.Error("Existing relay mismatch with CreateRelayRequest",
+						slog.Any("existingRemoteIndex", existingRelay.RemoteIndex))
 					return
 				}
 			case Disestablished:
 				if existingRelay.RemoteIndex != m.InitiatorRelayIndex {
 					// We got a brand new Relay request, because its index is different than what we saw before.
 					// This should never happen. The peer should never change an index, once created.
-					logMsg.WithFields(logrus.Fields{
-						"existingRemoteIndex": existingRelay.RemoteIndex}).Error("Existing relay mismatch with CreateRelayRequest")
+					logMsg.Error("Existing relay mismatch with CreateRelayRequest",
+						slog.Any("existingRemoteIndex", existingRelay.RemoteIndex))
 					return
 				}
 				// Mark the relay as 'Established' because it's safe to use again
 				h.relayState.UpdateRelayForByIpState(from, Established)
 			case PeerRequested:
 				// I should never be in this state, because I am terminal, not forwarding.
-				logMsg.WithFields(logrus.Fields{
-					"existingRemoteIndex": existingRelay.RemoteIndex,
-					"state":               existingRelay.State}).Error("Unexpected Relay State found")
+				logMsg.Error("Unexpected Relay State found",
+					slog.Any("existingRemoteIndex", existingRelay.RemoteIndex),
+					slog.Any("state", existingRelay.State))
 			}
 		} else {
 			_, err := AddRelay(rm.l, h, f.hostMap, from, &m.InitiatorRelayIndex, TerminalType, Established)
 			if err != nil {
-				logMsg.WithError(err).Error("Failed to add relay")
+				logMsg.Error("Failed to add relay", slog.Any("error", err))
 				return
 			}
 		}
 
 		relay, ok := h.relayState.QueryRelayForByIp(from)
 		if !ok {
-			logMsg.WithField("from", from).Error("Relay State not found")
+			logMsg.Error("Relay State not found", slog.Any("from", from))
 			return
 		}
 
@@ -313,17 +314,16 @@ func (rm *relayManager) handleCreateRelayRequest(v cert.Version, h *HostInfo, f 
 
 		msg, err := resp.Marshal()
 		if err != nil {
-			logMsg.
-				WithError(err).Error("relayManager Failed to marshal Control CreateRelayResponse message to create relay")
+			logMsg.Error("relayManager Failed to marshal Control CreateRelayResponse message to create relay", slog.Any("error", err))
 		} else {
 			f.SendMessageToHostInfo(header.Control, 0, h, msg, make([]byte, 12), make([]byte, mtu))
-			rm.l.WithFields(logrus.Fields{
-				"relayFrom":           from,
-				"relayTo":             target,
-				"initiatorRelayIndex": resp.InitiatorRelayIndex,
-				"responderRelayIndex": resp.ResponderRelayIndex,
-				"vpnAddrs":            h.vpnAddrs}).
-				Info("send CreateRelayResponse")
+			rm.l.Info("send CreateRelayResponse",
+				slog.Any("relayFrom", from),
+				slog.Any("relayTo", target),
+				slog.Any("initiatorRelayIndex", resp.InitiatorRelayIndex),
+				slog.Any("responderRelayIndex", resp.ResponderRelayIndex),
+				slog.Any("vpnAddrs", h.vpnAddrs),
+			)
 		}
 		return
 	} else {
@@ -363,12 +363,13 @@ func (rm *relayManager) handleCreateRelayRequest(v cert.Version, h *HostInfo, f 
 
 		if v == cert.Version1 {
 			if !h.vpnAddrs[0].Is4() {
-				rm.l.WithField("relayFrom", h.vpnAddrs[0]).
-					WithField("relayTo", target).
-					WithField("initiatorRelayIndex", req.InitiatorRelayIndex).
-					WithField("responderRelayIndex", req.ResponderRelayIndex).
-					WithField("vpnAddr", target).
-					Error("Refusing to CreateRelayRequest for a v1 relay with an ipv6 address")
+				rm.l.Error("Refusing to CreateRelayRequest for a v1 relay with an ipv6 address",
+					slog.Any("relayFrom", h.vpnAddrs[0]),
+					slog.Any("relayTo", target),
+					slog.Any("initiatorRelayIndex", req.InitiatorRelayIndex),
+					slog.Any("responderRelayIndex", req.ResponderRelayIndex),
+					slog.Any("vpnAddr", target),
+				)
 				return
 			}
 
@@ -383,17 +384,16 @@ func (rm *relayManager) handleCreateRelayRequest(v cert.Version, h *HostInfo, f 
 
 		msg, err := req.Marshal()
 		if err != nil {
-			logMsg.
-				WithError(err).Error("relayManager Failed to marshal Control message to create relay")
+			logMsg.Error("relayManager Failed to marshal Control message to create relay", slog.Any("error", err))
 		} else {
 			f.SendMessageToHostInfo(header.Control, 0, peer, msg, make([]byte, 12), make([]byte, mtu))
-			rm.l.WithFields(logrus.Fields{
-				"relayFrom":           h.vpnAddrs[0],
-				"relayTo":             target,
-				"initiatorRelayIndex": req.InitiatorRelayIndex,
-				"responderRelayIndex": req.ResponderRelayIndex,
-				"vpnAddr":             target}).
-				Info("send CreateRelayRequest")
+			rm.l.Info("send CreateRelayRequest",
+				slog.Any("relayFrom", h.vpnAddrs[0]),
+				slog.Any("relayTo", target),
+				slog.Any("initiatorRelayIndex", req.InitiatorRelayIndex),
+				slog.Any("responderRelayIndex", req.ResponderRelayIndex),
+				slog.Any("vpnAddr", target),
+			)
 		}
 
 		// Also track the half-created Relay state just received
@@ -401,8 +401,7 @@ func (rm *relayManager) handleCreateRelayRequest(v cert.Version, h *HostInfo, f 
 		if !ok {
 			_, err := AddRelay(rm.l, h, f.hostMap, target, &m.InitiatorRelayIndex, ForwardingType, PeerRequested)
 			if err != nil {
-				logMsg.
-					WithError(err).Error("relayManager Failed to allocate a local index for relay")
+				logMsg.Error("relayManager Failed to allocate a local index for relay", slog.Any("error", err))
 				return
 			}
 		}


### PR DESCRIPTION
Moves relay manager to use slog. Continuation of https://github.com/slackhq/nebula/pull/1672