### PR TITLE
Switch to key/value pair for speed

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,7 +2,21 @@ version: "2"
 linters:
   default: none
   enable:
+    - sloglint
     - testifylint
+  settings:
+    sloglint:
+      # Enforce key-value pair form for Info/Debug/Warn/Error/Log/With and
+      # the package-level slog equivalents. Use l.Log(ctx, level, ...) for
+      # custom levels instead of LogAttrs when you can.
+      #
+      # LogAttrs is also flagged by this rule because it takes ...slog.Attr;
+      # the few legitimate sites (where attrs is built up as a []slog.Attr)
+      # carry a //nolint:sloglint with rationale.
+      kv-only: true
+      # no-mixed-args is on by default: forbids mixing kv and attrs in one call.
+      # discard-handler is on by default (since Go 1.24): suggests
+      # slog.DiscardHandler over slog.NewTextHandler(io.Discard, nil).
   exclusions:
     generated: lax
     presets:

--- a/bits.go
+++ b/bits.go
@@ -46,8 +46,8 @@ func (b *Bits) Check(l *slog.Logger, i uint64) bool {
 	// Not within the window
 	if l.Enabled(context.Background(), slog.LevelDebug) {
 		l.Debug("rejected a packet (top)",
-			slog.Uint64("current", b.current),
-			slog.Uint64("incoming", i),
+			"current", b.current,
+			"incoming", i,
 		)
 	}
 	return false
@@ -94,10 +94,10 @@ func (b *Bits) Update(l *slog.Logger, i uint64) bool {
 		if b.current == i || b.bits[i%b.length] == true {
 			if l.Enabled(context.Background(), slog.LevelDebug) {
 				l.Debug("Receive window",
-					slog.Bool("accepted", false),
-					slog.Uint64("currentCounter", b.current),
-					slog.Uint64("incomingCounter", i),
-					slog.String("reason", "duplicate"),
+					"accepted", false,
+					"currentCounter", b.current,
+					"incomingCounter", i,
+					"reason", "duplicate",
 				)
 			}
 			b.dupeCounter.Inc(1)
@@ -112,10 +112,10 @@ func (b *Bits) Update(l *slog.Logger, i uint64) bool {
 	b.outOfWindowCounter.Inc(1)
 	if l.Enabled(context.Background(), slog.LevelDebug) {
 		l.Debug("Receive window",
-			slog.Bool("accepted", false),
-			slog.Uint64("currentCounter", b.current),
-			slog.Uint64("incomingCounter", i),
-			slog.String("reason", "nonsense"),
+			"accepted", false,
+			"currentCounter", b.current,
+			"incomingCounter", i,
+			"reason", "nonsense",
 		)
 	}
 	return false

--- a/cmd/nebula-service/main.go
+++ b/cmd/nebula-service/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log/slog"
 	"os"
 	"runtime/debug"
 	"strings"
@@ -54,7 +53,7 @@ func main() {
 
 	if *serviceFlag != "" {
 		if err := doService(configPath, configTest, Build, serviceFlag); err != nil {
-			l.Error("Service command failed", slog.Any("error", err))
+			l.Error("Service command failed", "error", err)
 			os.Exit(1)
 		}
 		return
@@ -89,7 +88,7 @@ func main() {
 		go ctrl.ShutdownBlock()
 
 		if err := wait(); err != nil {
-			l.Error("Nebula stopped due to fatal error", slog.Any("error", err))
+			l.Error("Nebula stopped due to fatal error", "error", err)
 			os.Exit(2)
 		}
 

--- a/cmd/nebula/main.go
+++ b/cmd/nebula/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log/slog"
 	"os"
 	"runtime/debug"
 	"strings"
@@ -81,7 +80,7 @@ func main() {
 		notifyReady(l)
 
 		if err := wait(); err != nil {
-			l.Error("Nebula stopped due to fatal error", slog.Any("error", err))
+			l.Error("Nebula stopped due to fatal error", "error", err)
 			os.Exit(2)
 		}
 

--- a/cmd/nebula/notify_linux.go
+++ b/cmd/nebula/notify_linux.go
@@ -21,19 +21,19 @@ func notifyReady(l *slog.Logger) {
 
 	conn, err := net.DialTimeout("unixgram", sockName, time.Second)
 	if err != nil {
-		l.Error("failed to connect to systemd notification socket", slog.Any("error", err))
+		l.Error("failed to connect to systemd notification socket", "error", err)
 		return
 	}
 	defer conn.Close()
 
 	err = conn.SetWriteDeadline(time.Now().Add(time.Second))
 	if err != nil {
-		l.Error("failed to set the write deadline for the systemd notification socket", slog.Any("error", err))
+		l.Error("failed to set the write deadline for the systemd notification socket", "error", err)
 		return
 	}
 
 	if _, err = conn.Write([]byte(SdNotifyReady)); err != nil {
-		l.Error("failed to signal the systemd notification socket", slog.Any("error", err))
+		l.Error("failed to signal the systemd notification socket", "error", err)
 		return
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -108,16 +108,16 @@ func (c *C) HasChanged(k string) bool {
 	newVals, err := yaml.Marshal(nv)
 	if err != nil {
 		c.l.Error("Error while marshaling new config",
-			slog.String("config_path", k),
-			slog.Any("error", err),
+			"config_path", k,
+			"error", err,
 		)
 	}
 
 	oldVals, err := yaml.Marshal(ov)
 	if err != nil {
 		c.l.Error("Error while marshaling old config",
-			slog.String("config_path", k),
-			slog.Any("error", err),
+			"config_path", k,
+			"error", err,
 		)
 	}
 
@@ -161,8 +161,8 @@ func (c *C) ReloadConfig() {
 	err := c.Load(c.path)
 	if err != nil {
 		c.l.Error("Error occurred while reloading config",
-			slog.String("config_path", c.path),
-			slog.Any("error", err),
+			"config_path", c.path,
+			"error", err,
 		)
 		return
 	}

--- a/connection_manager.go
+++ b/connection_manager.go
@@ -86,8 +86,8 @@ func (cm *connectionManager) reload(c *config.C, initial bool) {
 		cm.inactivityTimeout.Store((int64)(c.GetDuration("tunnels.inactivity_timeout", 10*time.Minute)))
 		if !initial {
 			cm.l.Info("Inactivity timeout has changed",
-				slog.Duration("oldDuration", old),
-				slog.Duration("newDuration", cm.getInactivityTimeout()),
+				"oldDuration", old,
+				"newDuration", cm.getInactivityTimeout(),
 			)
 		}
 	}
@@ -97,8 +97,8 @@ func (cm *connectionManager) reload(c *config.C, initial bool) {
 		cm.dropInactive.Store(c.GetBool("tunnels.drop_inactive", false))
 		if !initial {
 			cm.l.Info("Drop inactive setting has changed",
-				slog.Bool("oldBool", old),
-				slog.Bool("newBool", cm.dropInactive.Load()),
+				"oldBool", old,
+				"newBool", cm.dropInactive.Load(),
 			)
 		}
 	}
@@ -258,7 +258,7 @@ func (cm *connectionManager) migrateRelayUsed(oldhostinfo, newhostinfo *HostInfo
 			var err error
 			index, err = AddRelay(cm.l, newhostinfo, cm.hostMap, r.PeerAddr, nil, r.Type, Requested)
 			if err != nil {
-				cm.l.Error("failed to migrate relay to new hostinfo", slog.Any("error", err))
+				cm.l.Error("failed to migrate relay to new hostinfo", "error", err)
 				continue
 			}
 			switch r.Type {
@@ -306,15 +306,15 @@ func (cm *connectionManager) migrateRelayUsed(oldhostinfo, newhostinfo *HostInfo
 
 		msg, err := req.Marshal()
 		if err != nil {
-			cm.l.Error("failed to marshal Control message to migrate relay", slog.Any("error", err))
+			cm.l.Error("failed to marshal Control message to migrate relay", "error", err)
 		} else {
 			cm.intf.SendMessageToHostInfo(header.Control, 0, newhostinfo, msg, make([]byte, 12), make([]byte, mtu))
 			cm.l.Info("send CreateRelayRequest",
-				slog.Any("relayFrom", req.RelayFromAddr),
-				slog.Any("relayTo", req.RelayToAddr),
-				slog.Uint64("initiatorRelayIndex", uint64(req.InitiatorRelayIndex)),
-				slog.Uint64("responderRelayIndex", uint64(req.ResponderRelayIndex)),
-				slog.Any("vpnAddrs", newhostinfo.vpnAddrs),
+				"relayFrom", req.RelayFromAddr,
+				"relayTo", req.RelayToAddr,
+				"initiatorRelayIndex", uint64(req.InitiatorRelayIndex),
+				"responderRelayIndex", uint64(req.ResponderRelayIndex),
+				"vpnAddrs", newhostinfo.vpnAddrs,
 			)
 		}
 	}
@@ -327,7 +327,7 @@ func (cm *connectionManager) makeTrafficDecision(localIndex uint32, now time.Tim
 
 	hostinfo := cm.hostMap.Indexes[localIndex]
 	if hostinfo == nil {
-		cm.l.Debug("Not found in hostmap", slog.Uint64("localIndex", uint64(localIndex)))
+		cm.l.Debug("Not found in hostmap", "localIndex", uint64(localIndex))
 		return doNothing, nil, nil
 	}
 
@@ -349,7 +349,7 @@ func (cm *connectionManager) makeTrafficDecision(localIndex uint32, now time.Tim
 		decision := doNothing
 		if cm.l.Enabled(context.Background(), slog.LevelDebug) {
 			hostinfo.logger(cm.l).Debug("Tunnel status",
-				slog.Any("tunnelCheck", m{"state": "alive", "method": "passive"}),
+				"tunnelCheck", m{"state": "alive", "method": "passive"},
 			)
 		}
 		hostinfo.pendingDeletion.Store(false)
@@ -378,7 +378,7 @@ func (cm *connectionManager) makeTrafficDecision(localIndex uint32, now time.Tim
 	if hostinfo.pendingDeletion.Load() {
 		// We have already sent a test packet and nothing was returned, this hostinfo is dead
 		hostinfo.logger(cm.l).Info("Tunnel status",
-			slog.Any("tunnelCheck", m{"state": "dead", "method": "active"}),
+			"tunnelCheck", m{"state": "dead", "method": "active"},
 		)
 
 		return deleteTunnel, hostinfo, nil
@@ -391,8 +391,8 @@ func (cm *connectionManager) makeTrafficDecision(localIndex uint32, now time.Tim
 			if isInactive {
 				// Tunnel is inactive, tear it down
 				hostinfo.logger(cm.l).Info("Dropping tunnel due to inactivity",
-					slog.Duration("inactiveDuration", inactiveFor),
-					slog.Bool("primary", mainHostInfo),
+					"inactiveDuration", inactiveFor,
+					"primary", mainHostInfo,
 				)
 
 				return closeTunnel, hostinfo, primary
@@ -414,7 +414,7 @@ func (cm *connectionManager) makeTrafficDecision(localIndex uint32, now time.Tim
 
 		if cm.l.Enabled(context.Background(), slog.LevelDebug) {
 			hostinfo.logger(cm.l).Debug("Tunnel status",
-				slog.Any("tunnelCheck", m{"state": "testing", "method": "active"}),
+				"tunnelCheck", m{"state": "testing", "method": "active"},
 			)
 		}
 
@@ -496,14 +496,14 @@ func (cm *connectionManager) isInvalidCertificate(now time.Time, hostinfo *HostI
 	} else if err == cert.ErrBlockListed { //avoiding errors.Is for speed
 		// Block listed certificates should always be disconnected
 		hostinfo.logger(cm.l).Info("Remote certificate is blocked, tearing down the tunnel",
-			slog.Any("error", err),
-			slog.Any("fingerprint", remoteCert.Fingerprint),
+			"error", err,
+			"fingerprint", remoteCert.Fingerprint,
 		)
 		return true
 	} else if cm.intf.disconnectInvalid.Load() {
 		hostinfo.logger(cm.l).Info("Remote certificate is no longer valid, tearing down the tunnel",
-			slog.Any("error", err),
-			slog.Any("fingerprint", remoteCert.Fingerprint),
+			"error", err,
+			"fingerprint", remoteCert.Fingerprint,
 		)
 		return true
 	} else {
@@ -544,9 +544,9 @@ func (cm *connectionManager) tryRehandshake(hostinfo *HostInfo) {
 	myCrt := cs.getCertificate(curCrtVersion)
 	if myCrt == nil {
 		cm.l.Info("Re-handshaking with remote",
-			slog.Any("vpnAddrs", hostinfo.vpnAddrs),
-			slog.Any("version", curCrtVersion),
-			slog.String("reason", "local certificate removed"),
+			"vpnAddrs", hostinfo.vpnAddrs,
+			"version", curCrtVersion,
+			"reason", "local certificate removed",
 		)
 		cm.intf.handshakeManager.StartHandshake(hostinfo.vpnAddrs[0], nil)
 		return
@@ -556,10 +556,10 @@ func (cm *connectionManager) tryRehandshake(hostinfo *HostInfo) {
 		// if our certificate version is less than theirs, and we have a matching version available, rehandshake?
 		if cs.getCertificate(peerCrt.Certificate.Version()) != nil {
 			cm.l.Info("Re-handshaking with remote",
-				slog.Any("vpnAddrs", hostinfo.vpnAddrs),
-				slog.Any("version", curCrtVersion),
-				slog.Any("peerVersion", peerCrt.Certificate.Version()),
-				slog.String("reason", "local certificate version lower than peer, attempting to correct"),
+				"vpnAddrs", hostinfo.vpnAddrs,
+				"version", curCrtVersion,
+				"peerVersion", peerCrt.Certificate.Version(),
+				"reason", "local certificate version lower than peer, attempting to correct",
 			)
 			cm.intf.handshakeManager.StartHandshake(hostinfo.vpnAddrs[0], func(hh *HandshakeHostInfo) {
 				hh.initiatingVersionOverride = peerCrt.Certificate.Version()
@@ -569,8 +569,8 @@ func (cm *connectionManager) tryRehandshake(hostinfo *HostInfo) {
 	}
 	if !bytes.Equal(curCrt.Signature(), myCrt.Signature()) {
 		cm.l.Info("Re-handshaking with remote",
-			slog.Any("vpnAddrs", hostinfo.vpnAddrs),
-			slog.String("reason", "local certificate is not current"),
+			"vpnAddrs", hostinfo.vpnAddrs,
+			"reason", "local certificate is not current",
 		)
 
 		cm.intf.handshakeManager.StartHandshake(hostinfo.vpnAddrs[0], nil)
@@ -578,8 +578,8 @@ func (cm *connectionManager) tryRehandshake(hostinfo *HostInfo) {
 	}
 	if curCrtVersion < cs.initiatingVersion {
 		cm.l.Info("Re-handshaking with remote",
-			slog.Any("vpnAddrs", hostinfo.vpnAddrs),
-			slog.String("reason", "current cert version < pki.initiatingVersion"),
+			"vpnAddrs", hostinfo.vpnAddrs,
+			"reason", "current cert version < pki.initiatingVersion",
 		)
 
 		cm.intf.handshakeManager.StartHandshake(hostinfo.vpnAddrs[0], nil)

--- a/control.go
+++ b/control.go
@@ -151,7 +151,7 @@ func (c *Control) Stop() {
 
 	c.CloseAllTunnels(false)
 	if err := c.f.Close(); err != nil {
-		c.l.Error("Close interface failed", slog.Any("error", err))
+		c.l.Error("Close interface failed", "error", err)
 	}
 	c.stateLock.Lock()
 	c.state = StateStopped
@@ -166,7 +166,7 @@ func (c *Control) ShutdownBlock() {
 
 	rawSig := <-sigChan
 	sig := rawSig.String()
-	c.l.Info("Caught signal, shutting down", slog.String("signal", sig))
+	c.l.Info("Caught signal, shutting down", "signal", sig)
 	c.Stop()
 }
 
@@ -304,8 +304,8 @@ func (c *Control) CloseAllTunnels(excludeLighthouses bool) (closed int) {
 		c.f.closeTunnel(h)
 
 		c.l.Debug("Sending close tunnel message",
-			slog.Any("vpnAddrs", h.vpnAddrs),
-			slog.Any("udpAddr", h.remote),
+			"vpnAddrs", h.vpnAddrs,
+			"udpAddr", h.remote,
 		)
 		closed++
 	}

--- a/dns_server.go
+++ b/dns_server.go
@@ -69,7 +69,7 @@ func newDnsServerFromConfig(ctx context.Context, l *slog.Logger, cs *CertState, 
 
 	c.RegisterReloadCallback(func(c *config.C) {
 		if err := ds.reload(c, false); err != nil {
-			ds.l.Error("Failed to reload DNS responder from config", slog.Any("error", err))
+			ds.l.Error("Failed to reload DNS responder from config", "error", err)
 		}
 	})
 
@@ -145,7 +145,7 @@ func (d *dnsServer) shutdownServer(srv *dns.Server, started chan struct{}, reaso
 		<-started
 	}
 	if err := srv.Shutdown(); err != nil {
-		d.l.Warn("Failed to shut down the DNS responder", slog.String("reason", reason), slog.Any("error", err))
+		d.l.Warn("Failed to shut down the DNS responder", "reason", reason, "error", err)
 	}
 }
 
@@ -188,7 +188,7 @@ func (d *dnsServer) Start() {
 		}
 	}()
 
-	d.l.Info("Starting DNS responder", slog.String("dnsListener", addr))
+	d.l.Info("Starting DNS responder", "dnsListener", addr)
 	err := server.ListenAndServe()
 	close(done)
 
@@ -201,7 +201,7 @@ func (d *dnsServer) Start() {
 	}
 
 	if err != nil {
-		d.l.Warn("Failed to run the DNS responder", slog.Any("error", err))
+		d.l.Warn("Failed to run the DNS responder", "error", err)
 	}
 }
 
@@ -325,7 +325,7 @@ func (d *dnsServer) parseQuery(m *dns.Msg, w dns.ResponseWriter) {
 		case dns.TypeA, dns.TypeAAAA:
 			qType := dns.TypeToString[q.Qtype]
 			if debugEnabled {
-				d.l.Debug("DNS query", slog.String("type", qType), slog.String("name", q.Name))
+				d.l.Debug("DNS query", "type", qType, "name", q.Name)
 			}
 			ip, nameExists := d.Query(q.Qtype, q.Name)
 			if nameExists {
@@ -343,7 +343,7 @@ func (d *dnsServer) parseQuery(m *dns.Msg, w dns.ResponseWriter) {
 				return
 			}
 			if debugEnabled {
-				d.l.Debug("DNS query", slog.String("type", "TXT"), slog.String("name", q.Name))
+				d.l.Debug("DNS query", "type", "TXT", "name", q.Name)
 			}
 			ip := d.QueryCert(q.Name)
 			if ip != "" {

--- a/dns_server_test.go
+++ b/dns_server_test.go
@@ -2,7 +2,6 @@ package nebula
 
 import (
 	"context"
-	"io"
 	"log/slog"
 	"net"
 	"net/netip"
@@ -30,7 +29,7 @@ func (stubDNSWriter) TsigTimersOnly(bool)       {}
 func (stubDNSWriter) Hijack()                   {}
 
 func TestParsequery(t *testing.T) {
-	l := slog.New(slog.NewTextHandler(io.Discard, nil))
+	l := slog.New(slog.DiscardHandler)
 	hostMap := &HostMap{}
 	ds := &dnsServer{
 		l:       l,
@@ -137,7 +136,7 @@ func Test_getDnsServerAddr(t *testing.T) {
 
 func newTestDnsServer(t *testing.T) (*dnsServer, *config.C) {
 	t.Helper()
-	sl := slog.New(slog.NewTextHandler(io.Discard, nil))
+	sl := slog.New(slog.DiscardHandler)
 	ds := &dnsServer{
 		l:       sl,
 		ctx:     context.Background(),

--- a/e2e/handshakes_test.go
+++ b/e2e/handshakes_test.go
@@ -799,18 +799,18 @@ func TestStage1RaceRelays2(t *testing.T) {
 	t.Log("Wait until we remove extra tunnels")
 	l.Info("Wait until we remove extra tunnels")
 	l.Info("Waiting for hostinfos to be removed...",
-		slog.Int("myControl", len(myControl.GetHostmap().Indexes)),
-		slog.Int("theirControl", len(theirControl.GetHostmap().Indexes)),
-		slog.Int("relayControl", len(relayControl.GetHostmap().Indexes)),
+		"myControl", len(myControl.GetHostmap().Indexes),
+		"theirControl", len(theirControl.GetHostmap().Indexes),
+		"relayControl", len(relayControl.GetHostmap().Indexes),
 	)
 	hostInfos := len(myControl.GetHostmap().Indexes) + len(theirControl.GetHostmap().Indexes) + len(relayControl.GetHostmap().Indexes)
 	retries := 60
 	for hostInfos > 6 && retries > 0 {
 		hostInfos = len(myControl.GetHostmap().Indexes) + len(theirControl.GetHostmap().Indexes) + len(relayControl.GetHostmap().Indexes)
 		l.Info("Waiting for hostinfos to be removed...",
-			slog.Int("myControl", len(myControl.GetHostmap().Indexes)),
-			slog.Int("theirControl", len(theirControl.GetHostmap().Indexes)),
-			slog.Int("relayControl", len(relayControl.GetHostmap().Indexes)),
+			"myControl", len(myControl.GetHostmap().Indexes),
+			"theirControl", len(theirControl.GetHostmap().Indexes),
+			"relayControl", len(relayControl.GetHostmap().Indexes),
 		)
 		assertTunnel(t, myVpnIpNet[0].Addr(), theirVpnIpNet[0].Addr(), myControl, theirControl, r)
 		t.Log("Connection manager hasn't ticked yet")

--- a/e2e/handshakes_test.go
+++ b/e2e/handshakes_test.go
@@ -4,7 +4,6 @@
 package e2e
 
 import (
-	"log/slog"
 	"net/netip"
 	"slices"
 	"testing"

--- a/e2e/handshakes_test.go
+++ b/e2e/handshakes_test.go
@@ -748,7 +748,6 @@ func TestStage1RaceRelays2(t *testing.T) {
 	myControl, myVpnIpNet, myUdpAddr, _ := newSimpleServer(cert.Version1, ca, caKey, "me     ", "10.128.0.1/24", m{"relay": m{"use_relays": true}})
 	relayControl, relayVpnIpNet, relayUdpAddr, _ := newSimpleServer(cert.Version1, ca, caKey, "relay  ", "10.128.0.128/24", m{"relay": m{"am_relay": true}})
 	theirControl, theirVpnIpNet, theirUdpAddr, _ := newSimpleServer(cert.Version1, ca, caKey, "them   ", "10.128.0.2/24", m{"relay": m{"use_relays": true}})
-	l := NewTestLogger()
 
 	// Teach my how to get to the relay and that their can be reached via the relay
 	myControl.InjectLightHouseAddr(relayVpnIpNet[0].Addr(), relayUdpAddr)
@@ -770,46 +769,40 @@ func TestStage1RaceRelays2(t *testing.T) {
 	theirControl.Start()
 
 	r.Log("Get a tunnel between me and relay")
-	l.Info("Get a tunnel between me and relay")
 	assertTunnel(t, myVpnIpNet[0].Addr(), relayVpnIpNet[0].Addr(), myControl, relayControl, r)
 
 	r.Log("Get a tunnel between them and relay")
-	l.Info("Get a tunnel between them and relay")
 	assertTunnel(t, theirVpnIpNet[0].Addr(), relayVpnIpNet[0].Addr(), theirControl, relayControl, r)
 
 	r.Log("Trigger a handshake from both them and me via relay to them and me")
-	l.Info("Trigger a handshake from both them and me via relay to them and me")
 	myControl.InjectTunUDPPacket(theirVpnIpNet[0].Addr(), 80, myVpnIpNet[0].Addr(), 80, []byte("Hi from me"))
 	theirControl.InjectTunUDPPacket(myVpnIpNet[0].Addr(), 80, theirVpnIpNet[0].Addr(), 80, []byte("Hi from them"))
 
 	//r.RouteUntilAfterMsgType(myControl, header.Control, header.MessageNone)
 	//r.RouteUntilAfterMsgType(theirControl, header.Control, header.MessageNone)
 
-	r.Log("Wait for a packet from them to me")
-	l.Info("Wait for a packet from them to me; myControl")
+	r.Log("Wait for a packet from them to me; myControl")
 	r.RouteForAllUntilTxTun(myControl)
-	l.Info("Wait for a packet from them to me; theirControl")
+	r.Log("Wait for a packet from them to me; theirControl")
 	r.RouteForAllUntilTxTun(theirControl)
 
 	r.Log("Assert the tunnel works")
-	l.Info("Assert the tunnel works")
 	assertTunnel(t, theirVpnIpNet[0].Addr(), myVpnIpNet[0].Addr(), theirControl, myControl, r)
 
 	t.Log("Wait until we remove extra tunnels")
-	l.Info("Wait until we remove extra tunnels")
-	l.Info("Waiting for hostinfos to be removed...",
-		"myControl", len(myControl.GetHostmap().Indexes),
-		"theirControl", len(theirControl.GetHostmap().Indexes),
-		"relayControl", len(relayControl.GetHostmap().Indexes),
+	t.Logf("Waiting for hostinfos to be removed... myControl=%d theirControl=%d relayControl=%d",
+		len(myControl.GetHostmap().Indexes),
+		len(theirControl.GetHostmap().Indexes),
+		len(relayControl.GetHostmap().Indexes),
 	)
 	hostInfos := len(myControl.GetHostmap().Indexes) + len(theirControl.GetHostmap().Indexes) + len(relayControl.GetHostmap().Indexes)
 	retries := 60
 	for hostInfos > 6 && retries > 0 {
 		hostInfos = len(myControl.GetHostmap().Indexes) + len(theirControl.GetHostmap().Indexes) + len(relayControl.GetHostmap().Indexes)
-		l.Info("Waiting for hostinfos to be removed...",
-			"myControl", len(myControl.GetHostmap().Indexes),
-			"theirControl", len(theirControl.GetHostmap().Indexes),
-			"relayControl", len(relayControl.GetHostmap().Indexes),
+		t.Logf("Waiting for hostinfos to be removed... myControl=%d theirControl=%d relayControl=%d",
+			len(myControl.GetHostmap().Indexes),
+			len(theirControl.GetHostmap().Indexes),
+			len(relayControl.GetHostmap().Indexes),
 		)
 		assertTunnel(t, myVpnIpNet[0].Addr(), theirVpnIpNet[0].Addr(), myControl, theirControl, r)
 		t.Log("Connection manager hasn't ticked yet")
@@ -818,7 +811,6 @@ func TestStage1RaceRelays2(t *testing.T) {
 	}
 
 	r.Log("Assert the tunnel works")
-	l.Info("Assert the tunnel works")
 	assertTunnel(t, theirVpnIpNet[0].Addr(), myVpnIpNet[0].Addr(), theirControl, myControl, r)
 
 	myControl.Stop()

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -4,7 +4,6 @@
 package e2e
 
 import (
-	"fmt"
 	"io"
 	"net/netip"
 	"os"
@@ -134,8 +133,7 @@ func newSimpleServerWithUdpAndUnsafeNetworks(v cert.Version, caCrt cert.Certific
 			"port": udpAddr.Port(),
 		},
 		"logging": m{
-			"timestamp_format": fmt.Sprintf("%v 15:04:05.000000", name),
-			"level":            testLogLevelName(),
+			"level": testLogLevelName(),
 		},
 		"timers": m{
 			"pending_deletion_interval": 2,
@@ -236,8 +234,7 @@ func newServer(caCrt []cert.Certificate, certs []cert.Certificate, key []byte, o
 			"port": udpAddr.Port(),
 		},
 		"logging": m{
-			"timestamp_format": fmt.Sprintf("%v 15:04:05.000000", certs[0].Name()),
-			"level":            testLogLevelName(),
+			"level": testLogLevelName(),
 		},
 		"timers": m{
 			"pending_deletion_interval": 2,

--- a/firewall.go
+++ b/firewall.go
@@ -220,7 +220,7 @@ func NewFirewallFromConfig(l *slog.Logger, cs *CertState, c *config.C) (*Firewal
 	case "drop":
 		fw.InSendReject = false
 	default:
-		l.Warn("invalid firewall.inbound_action, defaulting to `drop`", slog.String("action", inboundAction))
+		l.Warn("invalid firewall.inbound_action, defaulting to `drop`", "action", inboundAction)
 		fw.InSendReject = false
 	}
 
@@ -231,7 +231,7 @@ func NewFirewallFromConfig(l *slog.Logger, cs *CertState, c *config.C) (*Firewal
 	case "drop":
 		fw.OutSendReject = false
 	default:
-		l.Warn("invalid firewall.outbound_action, defaulting to `drop`", slog.String("action", outboundAction))
+		l.Warn("invalid firewall.outbound_action, defaulting to `drop`", "action", outboundAction)
 		fw.OutSendReject = false
 	}
 
@@ -269,7 +269,7 @@ func (f *Firewall) AddRule(incoming bool, proto uint8, startPort int32, endPort 
 	case firewall.ProtoICMP, firewall.ProtoICMPv6:
 		//ICMP traffic doesn't have ports, so we always coerce to "any", even if a value is provided
 		if startPort != firewall.PortAny {
-			f.l.Warn("ignoring port specification for ICMP firewall rule", slog.Any("startPort", startPort))
+			f.l.Warn("ignoring port specification for ICMP firewall rule", "startPort", startPort)
 		}
 		startPort = firewall.PortAny
 		endPort = firewall.PortAny
@@ -291,8 +291,9 @@ func (f *Firewall) AddRule(incoming bool, proto uint8, startPort int32, endPort 
 	if !incoming {
 		direction = "outgoing"
 	}
-	f.l.With(slog.Any("firewallRule", m{"direction": direction, "proto": proto, "startPort": startPort, "endPort": endPort, "groups": groups, "host": host, "cidr": cidr, "localCidr": localCidr, "caName": caName, "caSha": caSha})).
-		Info("Firewall rule added")
+	f.l.Info("Firewall rule added",
+		"firewallRule", m{"direction": direction, "proto": proto, "startPort": startPort, "endPort": endPort, "groups": groups, "host": host, "cidr": cidr, "localCidr": localCidr, "caName": caName, "caSha": caSha},
+	)
 
 	return fp.addRule(f, startPort, endPort, groups, host, cidr, localCidr, caName, caSha)
 }
@@ -373,7 +374,7 @@ func AddFirewallRulesFromConfig(l *slog.Logger, inbound bool, c *config.C, fw Fi
 			startPort = firewall.PortAny
 			endPort = firewall.PortAny
 			if sPort != "" {
-				l.Warn("ignoring port specification for ICMP firewall rule", slog.String("port", sPort))
+				l.Warn("ignoring port specification for ICMP firewall rule", "port", sPort)
 			}
 		default:
 			return fmt.Errorf("%s rule #%v; proto was not understood; `%s`", table, i, r.Proto)
@@ -398,9 +399,9 @@ func AddFirewallRulesFromConfig(l *slog.Logger, inbound bool, c *config.C, fw Fi
 
 		if warning := r.sanity(); warning != nil {
 			l.Warn("firewall rule sanity check",
-				slog.String("table", table),
-				slog.Int("rule", i),
-				slog.Any("warning", warning),
+				"table", table,
+				"rule", i,
+				"warning", warning,
 			)
 		}
 
@@ -535,10 +536,10 @@ func (f *Firewall) inConns(fp firewall.Packet, h *HostInfo, caPool *cert.CAPool,
 		if !table.match(fp, c.incoming, h.ConnectionState.peerCert, caPool) {
 			if f.l.Enabled(context.Background(), slog.LevelDebug) {
 				h.logger(f.l).Debug("dropping old conntrack entry, does not match new ruleset",
-					slog.Any("fwPacket", fp),
-					slog.Bool("incoming", c.incoming),
-					slog.Any("rulesVersion", f.rulesVersion),
-					slog.Any("oldRulesVersion", c.rulesVersion),
+					"fwPacket", fp,
+					"incoming", c.incoming,
+					"rulesVersion", f.rulesVersion,
+					"oldRulesVersion", c.rulesVersion,
 				)
 			}
 			delete(conntrack.Conns, fp)
@@ -548,10 +549,10 @@ func (f *Firewall) inConns(fp firewall.Packet, h *HostInfo, caPool *cert.CAPool,
 
 		if f.l.Enabled(context.Background(), slog.LevelDebug) {
 			h.logger(f.l).Debug("keeping old conntrack entry, does match new ruleset",
-				slog.Any("fwPacket", fp),
-				slog.Bool("incoming", c.incoming),
-				slog.Any("rulesVersion", f.rulesVersion),
-				slog.Any("oldRulesVersion", c.rulesVersion),
+				"fwPacket", fp,
+				"incoming", c.incoming,
+				"rulesVersion", f.rulesVersion,
+				"oldRulesVersion", c.rulesVersion,
 			)
 		}
 
@@ -972,8 +973,8 @@ func convertRule(l *slog.Logger, p any, table string, i int) (rule, error) {
 		}
 
 		l.Warn("group was an array with a single value, converting to simple value",
-			slog.String("table", table),
-			slog.Int("rule", i),
+			"table", table,
+			"rule", i,
 		)
 		m["group"] = v[0]
 	}

--- a/firewall/cache.go
+++ b/firewall/cache.go
@@ -57,7 +57,7 @@ func (c *ConntrackCacheTicker) Get() ConntrackCache {
 		c.cacheV = tick
 		if ll := len(c.cache); ll > 0 {
 			if c.l.Enabled(context.Background(), slog.LevelDebug) {
-				c.l.Debug("resetting conntrack cache", slog.Int("len", ll))
+				c.l.Debug("resetting conntrack cache", "len", ll)
 			}
 			c.cache = make(ConntrackCache, ll)
 		}

--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -20,9 +20,9 @@ func ixHandshakeStage0(f *Interface, hh *HandshakeHostInfo) bool {
 	err := f.handshakeManager.allocateIndex(hh)
 	if err != nil {
 		f.l.Error("Failed to generate index",
-			slog.Any("error", err),
-			slog.Any("vpnAddrs", hh.hostinfo.vpnAddrs),
-			slog.Any("handshake", m{"stage": 0, "style": "ix_psk0"}),
+			"error", err,
+			"vpnAddrs", hh.hostinfo.vpnAddrs,
+			"handshake", m{"stage": 0, "style": "ix_psk0"},
 		)
 		return false
 	}
@@ -44,9 +44,9 @@ func ixHandshakeStage0(f *Interface, hh *HandshakeHostInfo) bool {
 	crt := cs.getCertificate(v)
 	if crt == nil {
 		f.l.Error("Unable to handshake with host because no certificate is available",
-			slog.Any("vpnAddrs", hh.hostinfo.vpnAddrs),
-			slog.Any("handshake", m{"stage": 0, "style": "ix_psk0"}),
-			slog.Any("certVersion", v),
+			"vpnAddrs", hh.hostinfo.vpnAddrs,
+			"handshake", m{"stage": 0, "style": "ix_psk0"},
+			"certVersion", v,
 		)
 		return false
 	}
@@ -54,9 +54,9 @@ func ixHandshakeStage0(f *Interface, hh *HandshakeHostInfo) bool {
 	crtHs := cs.getHandshakeBytes(v)
 	if crtHs == nil {
 		f.l.Error("Unable to handshake with host because no certificate handshake bytes is available",
-			slog.Any("vpnAddrs", hh.hostinfo.vpnAddrs),
-			slog.Any("handshake", m{"stage": 0, "style": "ix_psk0"}),
-			slog.Any("certVersion", v),
+			"vpnAddrs", hh.hostinfo.vpnAddrs,
+			"handshake", m{"stage": 0, "style": "ix_psk0"},
+			"certVersion", v,
 		)
 		return false
 	}
@@ -64,10 +64,10 @@ func ixHandshakeStage0(f *Interface, hh *HandshakeHostInfo) bool {
 	ci, err := NewConnectionState(cs, crt, true, noise.HandshakeIX)
 	if err != nil {
 		f.l.Error("Failed to create connection state",
-			slog.Any("error", err),
-			slog.Any("vpnAddrs", hh.hostinfo.vpnAddrs),
-			slog.Any("handshake", m{"stage": 0, "style": "ix_psk0"}),
-			slog.Any("certVersion", v),
+			"error", err,
+			"vpnAddrs", hh.hostinfo.vpnAddrs,
+			"handshake", m{"stage": 0, "style": "ix_psk0"},
+			"certVersion", v,
 		)
 		return false
 	}
@@ -85,10 +85,10 @@ func ixHandshakeStage0(f *Interface, hh *HandshakeHostInfo) bool {
 	hsBytes, err := hs.Marshal()
 	if err != nil {
 		f.l.Error("Failed to marshal handshake message",
-			slog.Any("error", err),
-			slog.Any("vpnAddrs", hh.hostinfo.vpnAddrs),
-			slog.Any("certVersion", v),
-			slog.Any("handshake", m{"stage": 0, "style": "ix_psk0"}),
+			"error", err,
+			"vpnAddrs", hh.hostinfo.vpnAddrs,
+			"certVersion", v,
+			"handshake", m{"stage": 0, "style": "ix_psk0"},
 		)
 		return false
 	}
@@ -98,9 +98,9 @@ func ixHandshakeStage0(f *Interface, hh *HandshakeHostInfo) bool {
 	msg, _, _, err := ci.H.WriteMessage(h, hsBytes)
 	if err != nil {
 		f.l.Error("Failed to call noise.WriteMessage",
-			slog.Any("error", err),
-			slog.Any("vpnAddrs", hh.hostinfo.vpnAddrs),
-			slog.Any("handshake", m{"stage": 0, "style": "ix_psk0"}),
+			"error", err,
+			"vpnAddrs", hh.hostinfo.vpnAddrs,
+			"handshake", m{"stage": 0, "style": "ix_psk0"},
 		)
 		return false
 	}
@@ -119,9 +119,9 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 	crt := cs.GetDefaultCertificate()
 	if crt == nil {
 		f.l.Error("Unable to handshake with host because no certificate is available",
-			slog.Any("from", via),
-			slog.Any("handshake", m{"stage": 0, "style": "ix_psk0"}),
-			slog.Any("certVersion", cs.initiatingVersion),
+			"from", via,
+			"handshake", m{"stage": 0, "style": "ix_psk0"},
+			"certVersion", cs.initiatingVersion,
 		)
 		return
 	}
@@ -129,9 +129,9 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 	ci, err := NewConnectionState(cs, crt, false, noise.HandshakeIX)
 	if err != nil {
 		f.l.Error("Failed to create connection state",
-			slog.Any("error", err),
-			slog.Any("from", via),
-			slog.Any("handshake", m{"stage": 1, "style": "ix_psk0"}),
+			"error", err,
+			"from", via,
+			"handshake", m{"stage": 1, "style": "ix_psk0"},
 		)
 		return
 	}
@@ -142,9 +142,9 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 	msg, _, _, err := ci.H.ReadMessage(nil, packet[header.Len:])
 	if err != nil {
 		f.l.Error("Failed to call noise.ReadMessage",
-			slog.Any("error", err),
-			slog.Any("from", via),
-			slog.Any("handshake", m{"stage": 1, "style": "ix_psk0"}),
+			"error", err,
+			"from", via,
+			"handshake", m{"stage": 1, "style": "ix_psk0"},
 		)
 		return
 	}
@@ -153,9 +153,9 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 	err = hs.Unmarshal(msg)
 	if err != nil || hs.Details == nil {
 		f.l.Error("Failed unmarshal handshake message",
-			slog.Any("error", err),
-			slog.Any("from", via),
-			slog.Any("handshake", m{"stage": 1, "style": "ix_psk0"}),
+			"error", err,
+			"from", via,
+			"handshake", m{"stage": 1, "style": "ix_psk0"},
 		)
 		return
 	}
@@ -163,9 +163,9 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 	rc, err := cert.Recombine(cert.Version(hs.Details.CertVersion), hs.Details.Cert, ci.H.PeerStatic(), ci.Curve())
 	if err != nil {
 		f.l.Info("Handshake did not contain a certificate",
-			slog.Any("error", err),
-			slog.Any("from", via),
-			slog.Any("handshake", m{"stage": 1, "style": "ix_psk0"}),
+			"error", err,
+			"from", via,
+			"handshake", m{"stage": 1, "style": "ix_psk0"},
 		)
 		return
 	}
@@ -188,15 +188,18 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 			attrs = append(attrs, slog.Any("cert", rc))
 		}
 
+		// LogAttrs is intentional: attrs is a pre-built []slog.Attr slice that
+		// callers grow conditionally, which has no pair-form equivalent.
+		//nolint:sloglint
 		f.l.LogAttrs(context.Background(), slog.LevelInfo, "Invalid certificate from host", attrs...)
 		return
 	}
 
 	if !bytes.Equal(remoteCert.Certificate.PublicKey(), ci.H.PeerStatic()) {
 		f.l.Info("public key mismatch between certificate and handshake",
-			slog.Any("from", via),
-			slog.Any("handshake", m{"stage": 1, "style": "ix_psk0"}),
-			slog.Any("cert", remoteCert),
+			"from", via,
+			"handshake", m{"stage": 1, "style": "ix_psk0"},
+			"cert", remoteCert,
 		)
 		return
 	}
@@ -207,10 +210,10 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 		if myCertOtherVersion == nil {
 			if f.l.Enabled(context.Background(), slog.LevelDebug) {
 				f.l.Debug("Might be unable to handshake with host due to missing certificate version",
-					slog.Any("error", err),
-					slog.Any("from", via),
-					slog.Any("handshake", m{"stage": 1, "style": "ix_psk0"}),
-					slog.Any("cert", remoteCert),
+					"error", err,
+					"from", via,
+					"handshake", m{"stage": 1, "style": "ix_psk0"},
+					"cert", remoteCert,
 				)
 			}
 		} else {
@@ -221,10 +224,10 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 
 	if len(remoteCert.Certificate.Networks()) == 0 {
 		f.l.Info("No networks in certificate",
-			slog.Any("error", err),
-			slog.Any("from", via),
-			slog.Any("cert", remoteCert),
-			slog.Any("handshake", m{"stage": 1, "style": "ix_psk0"}),
+			"error", err,
+			"from", via,
+			"cert", remoteCert,
+			"handshake", m{"stage": 1, "style": "ix_psk0"},
 		)
 		return
 	}
@@ -240,13 +243,13 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 	for i, network := range vpnNetworks {
 		if f.myVpnAddrsTable.Contains(network.Addr()) {
 			f.l.Error("Refusing to handshake with myself",
-				slog.Any("vpnNetworks", vpnNetworks),
-				slog.Any("from", via),
-				slog.String("certName", certName),
-				slog.Any("certVersion", certVersion),
-				slog.String("fingerprint", fingerprint),
-				slog.String("issuer", issuer),
-				slog.Any("handshake", m{"stage": 1, "style": "ix_psk0"}),
+				"vpnNetworks", vpnNetworks,
+				"from", via,
+				"certName", certName,
+				"certVersion", certVersion,
+				"fingerprint", fingerprint,
+				"issuer", issuer,
+				"handshake", m{"stage": 1, "style": "ix_psk0"},
 			)
 			return
 		}
@@ -261,8 +264,8 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 		if !f.lightHouse.GetRemoteAllowList().AllowAll(vpnAddrs, via.UdpAddr.Addr()) {
 			if f.l.Enabled(context.Background(), slog.LevelDebug) {
 				f.l.Debug("lighthouse.remote_allow_list denied incoming handshake",
-					slog.Any("vpnAddrs", vpnAddrs),
-					slog.Any("from", via),
+					"vpnAddrs", vpnAddrs,
+					"from", via,
 				)
 			}
 			return
@@ -272,14 +275,14 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 	myIndex, err := generateIndex(f.l)
 	if err != nil {
 		f.l.Error("Failed to generate index",
-			slog.Any("error", err),
-			slog.Any("vpnAddrs", vpnAddrs),
-			slog.Any("from", via),
-			slog.String("certName", certName),
-			slog.Any("certVersion", certVersion),
-			slog.String("fingerprint", fingerprint),
-			slog.String("issuer", issuer),
-			slog.Any("handshake", m{"stage": 1, "style": "ix_psk0"}),
+			"error", err,
+			"vpnAddrs", vpnAddrs,
+			"from", via,
+			"certName", certName,
+			"certVersion", certVersion,
+			"fingerprint", fingerprint,
+			"issuer", issuer,
+			"handshake", m{"stage": 1, "style": "ix_psk0"},
 		)
 		return
 	}
@@ -299,16 +302,16 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 	}
 
 	msgRxL := f.l.With(
-		slog.Any("vpnAddrs", vpnAddrs),
-		slog.Any("from", via),
-		slog.String("certName", certName),
-		slog.Any("certVersion", certVersion),
-		slog.String("fingerprint", fingerprint),
-		slog.String("issuer", issuer),
-		slog.Uint64("initiatorIndex", uint64(hs.Details.InitiatorIndex)),
-		slog.Uint64("responderIndex", uint64(hs.Details.ResponderIndex)),
-		slog.Uint64("remoteIndex", uint64(h.RemoteIndex)),
-		slog.Any("handshake", m{"stage": 1, "style": "ix_psk0"}),
+		"vpnAddrs", vpnAddrs,
+		"from", via,
+		"certName", certName,
+		"certVersion", certVersion,
+		"fingerprint", fingerprint,
+		"issuer", issuer,
+		"initiatorIndex", uint64(hs.Details.InitiatorIndex),
+		"responderIndex", uint64(hs.Details.ResponderIndex),
+		"remoteIndex", uint64(h.RemoteIndex),
+		"handshake", m{"stage": 1, "style": "ix_psk0"},
 	)
 
 	if anyVpnAddrsInCommon {
@@ -322,7 +325,7 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 	hs.Details.Cert = cs.getHandshakeBytes(ci.myCert.Version())
 	if hs.Details.Cert == nil {
 		msgRxL.Error("Unable to handshake with host because no certificate handshake bytes is available",
-			slog.Any("myCertVersion", ci.myCert.Version()),
+			"myCertVersion", ci.myCert.Version(),
 		)
 		return
 	}
@@ -334,14 +337,14 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 	hsBytes, err := hs.Marshal()
 	if err != nil {
 		f.l.Error("Failed to marshal handshake message",
-			slog.Any("error", err),
-			slog.Any("vpnAddrs", hostinfo.vpnAddrs),
-			slog.Any("from", via),
-			slog.String("certName", certName),
-			slog.Any("certVersion", certVersion),
-			slog.String("fingerprint", fingerprint),
-			slog.String("issuer", issuer),
-			slog.Any("handshake", m{"stage": 1, "style": "ix_psk0"}),
+			"error", err,
+			"vpnAddrs", hostinfo.vpnAddrs,
+			"from", via,
+			"certName", certName,
+			"certVersion", certVersion,
+			"fingerprint", fingerprint,
+			"issuer", issuer,
+			"handshake", m{"stage": 1, "style": "ix_psk0"},
 		)
 		return
 	}
@@ -350,25 +353,25 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 	msg, dKey, eKey, err := ci.H.WriteMessage(nh, hsBytes)
 	if err != nil {
 		f.l.Error("Failed to call noise.WriteMessage",
-			slog.Any("error", err),
-			slog.Any("vpnAddrs", hostinfo.vpnAddrs),
-			slog.Any("from", via),
-			slog.String("certName", certName),
-			slog.Any("certVersion", certVersion),
-			slog.String("fingerprint", fingerprint),
-			slog.String("issuer", issuer),
-			slog.Any("handshake", m{"stage": 1, "style": "ix_psk0"}),
+			"error", err,
+			"vpnAddrs", hostinfo.vpnAddrs,
+			"from", via,
+			"certName", certName,
+			"certVersion", certVersion,
+			"fingerprint", fingerprint,
+			"issuer", issuer,
+			"handshake", m{"stage": 1, "style": "ix_psk0"},
 		)
 		return
 	} else if dKey == nil || eKey == nil {
 		f.l.Error("Noise did not arrive at a key",
-			slog.Any("vpnAddrs", hostinfo.vpnAddrs),
-			slog.Any("from", via),
-			slog.String("certName", certName),
-			slog.Any("certVersion", certVersion),
-			slog.String("fingerprint", fingerprint),
-			slog.String("issuer", issuer),
-			slog.Any("handshake", m{"stage": 1, "style": "ix_psk0"}),
+			"vpnAddrs", hostinfo.vpnAddrs,
+			"from", via,
+			"certName", certName,
+			"certVersion", certVersion,
+			"fingerprint", fingerprint,
+			"issuer", issuer,
+			"handshake", m{"stage": 1, "style": "ix_psk0"},
 		)
 		return
 	}
@@ -412,18 +415,18 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 				err := f.outside.WriteTo(msg, via.UdpAddr)
 				if err != nil {
 					f.l.Error("Failed to send handshake message",
-						slog.Any("vpnAddrs", existing.vpnAddrs),
-						slog.Any("from", via),
-						slog.Any("handshake", m{"stage": 2, "style": "ix_psk0"}),
-						slog.Bool("cached", true),
-						slog.Any("error", err),
+						"vpnAddrs", existing.vpnAddrs,
+						"from", via,
+						"handshake", m{"stage": 2, "style": "ix_psk0"},
+						"cached", true,
+						"error", err,
 					)
 				} else {
 					f.l.Info("Handshake message sent",
-						slog.Any("vpnAddrs", existing.vpnAddrs),
-						slog.Any("from", via),
-						slog.Any("handshake", m{"stage": 2, "style": "ix_psk0"}),
-						slog.Bool("cached", true),
+						"vpnAddrs", existing.vpnAddrs,
+						"from", via,
+						"handshake", m{"stage": 2, "style": "ix_psk0"},
+						"cached", true,
 					)
 				}
 				return
@@ -435,28 +438,28 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 				hostinfo.relayState.InsertRelayTo(via.relayHI.vpnAddrs[0])
 				f.SendVia(via.relayHI, via.relay, msg, make([]byte, 12), make([]byte, mtu), false)
 				f.l.Info("Handshake message sent",
-					slog.Any("vpnAddrs", existing.vpnAddrs),
-					slog.Any("relay", via.relayHI.vpnAddrs[0]),
-					slog.Any("handshake", m{"stage": 2, "style": "ix_psk0"}),
-					slog.Bool("cached", true),
+					"vpnAddrs", existing.vpnAddrs,
+					"relay", via.relayHI.vpnAddrs[0],
+					"handshake", m{"stage": 2, "style": "ix_psk0"},
+					"cached", true,
 				)
 				return
 			}
 		case ErrExistingHostInfo:
 			// This means there was an existing tunnel and this handshake was older than the one we are currently based on
 			f.l.Info("Handshake too old",
-				slog.Any("vpnAddrs", vpnAddrs),
-				slog.Any("from", via),
-				slog.String("certName", certName),
-				slog.Any("certVersion", certVersion),
-				slog.Uint64("oldHandshakeTime", existing.lastHandshakeTime),
-				slog.Uint64("newHandshakeTime", hostinfo.lastHandshakeTime),
-				slog.String("fingerprint", fingerprint),
-				slog.String("issuer", issuer),
-				slog.Uint64("initiatorIndex", uint64(hs.Details.InitiatorIndex)),
-				slog.Uint64("responderIndex", uint64(hs.Details.ResponderIndex)),
-				slog.Uint64("remoteIndex", uint64(h.RemoteIndex)),
-				slog.Any("handshake", m{"stage": 1, "style": "ix_psk0"}),
+				"vpnAddrs", vpnAddrs,
+				"from", via,
+				"certName", certName,
+				"certVersion", certVersion,
+				"oldHandshakeTime", existing.lastHandshakeTime,
+				"newHandshakeTime", hostinfo.lastHandshakeTime,
+				"fingerprint", fingerprint,
+				"issuer", issuer,
+				"initiatorIndex", uint64(hs.Details.InitiatorIndex),
+				"responderIndex", uint64(hs.Details.ResponderIndex),
+				"remoteIndex", uint64(h.RemoteIndex),
+				"handshake", m{"stage": 1, "style": "ix_psk0"},
 			)
 
 			// Send a test packet to trigger an authenticated tunnel test, this should suss out any lingering tunnel issues
@@ -465,35 +468,35 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 		case ErrLocalIndexCollision:
 			// This means we failed to insert because of collision on localIndexId. Just let the next handshake packet retry
 			f.l.Error("Failed to add HostInfo due to localIndex collision",
-				slog.Any("vpnAddrs", vpnAddrs),
-				slog.Any("from", via),
-				slog.String("certName", certName),
-				slog.Any("certVersion", certVersion),
-				slog.String("fingerprint", fingerprint),
-				slog.String("issuer", issuer),
-				slog.Uint64("initiatorIndex", uint64(hs.Details.InitiatorIndex)),
-				slog.Uint64("responderIndex", uint64(hs.Details.ResponderIndex)),
-				slog.Uint64("remoteIndex", uint64(h.RemoteIndex)),
-				slog.Any("handshake", m{"stage": 1, "style": "ix_psk0"}),
-				slog.Uint64("localIndex", uint64(hostinfo.localIndexId)),
-				slog.Any("collision", existing.vpnAddrs),
+				"vpnAddrs", vpnAddrs,
+				"from", via,
+				"certName", certName,
+				"certVersion", certVersion,
+				"fingerprint", fingerprint,
+				"issuer", issuer,
+				"initiatorIndex", uint64(hs.Details.InitiatorIndex),
+				"responderIndex", uint64(hs.Details.ResponderIndex),
+				"remoteIndex", uint64(h.RemoteIndex),
+				"handshake", m{"stage": 1, "style": "ix_psk0"},
+				"localIndex", uint64(hostinfo.localIndexId),
+				"collision", existing.vpnAddrs,
 			)
 			return
 		default:
 			// Shouldn't happen, but just in case someone adds a new error type to CheckAndComplete
 			// And we forget to update it here
 			f.l.Error("Failed to add HostInfo to HostMap",
-				slog.Any("error", err),
-				slog.Any("vpnAddrs", vpnAddrs),
-				slog.Any("from", via),
-				slog.String("certName", certName),
-				slog.Any("certVersion", certVersion),
-				slog.String("fingerprint", fingerprint),
-				slog.String("issuer", issuer),
-				slog.Uint64("initiatorIndex", uint64(hs.Details.InitiatorIndex)),
-				slog.Uint64("responderIndex", uint64(hs.Details.ResponderIndex)),
-				slog.Uint64("remoteIndex", uint64(h.RemoteIndex)),
-				slog.Any("handshake", m{"stage": 1, "style": "ix_psk0"}),
+				"error", err,
+				"vpnAddrs", vpnAddrs,
+				"from", via,
+				"certName", certName,
+				"certVersion", certVersion,
+				"fingerprint", fingerprint,
+				"issuer", issuer,
+				"initiatorIndex", uint64(hs.Details.InitiatorIndex),
+				"responderIndex", uint64(hs.Details.ResponderIndex),
+				"remoteIndex", uint64(h.RemoteIndex),
+				"handshake", m{"stage": 1, "style": "ix_psk0"},
 			)
 			return
 		}
@@ -504,19 +507,19 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 	if !via.IsRelayed {
 		err = f.outside.WriteTo(msg, via.UdpAddr)
 		log := f.l.With(
-			slog.Any("vpnAddrs", vpnAddrs),
-			slog.Any("from", via),
-			slog.String("certName", certName),
-			slog.Any("certVersion", certVersion),
-			slog.String("fingerprint", fingerprint),
-			slog.String("issuer", issuer),
-			slog.Uint64("initiatorIndex", uint64(hs.Details.InitiatorIndex)),
-			slog.Uint64("responderIndex", uint64(hs.Details.ResponderIndex)),
-			slog.Uint64("remoteIndex", uint64(h.RemoteIndex)),
-			slog.Any("handshake", m{"stage": 2, "style": "ix_psk0"}),
+			"vpnAddrs", vpnAddrs,
+			"from", via,
+			"certName", certName,
+			"certVersion", certVersion,
+			"fingerprint", fingerprint,
+			"issuer", issuer,
+			"initiatorIndex", uint64(hs.Details.InitiatorIndex),
+			"responderIndex", uint64(hs.Details.ResponderIndex),
+			"remoteIndex", uint64(h.RemoteIndex),
+			"handshake", m{"stage": 2, "style": "ix_psk0"},
 		)
 		if err != nil {
-			log.Error("Failed to send handshake", slog.Any("error", err))
+			log.Error("Failed to send handshake", "error", err)
 		} else {
 			log.Info("Handshake message sent")
 		}
@@ -531,16 +534,16 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 		via.relayHI.relayState.UpdateRelayForByIdxState(via.remoteIdx, Established)
 		f.SendVia(via.relayHI, via.relay, msg, make([]byte, 12), make([]byte, mtu), false)
 		f.l.Info("Handshake message sent",
-			slog.Any("vpnAddrs", vpnAddrs),
-			slog.Any("relay", via.relayHI.vpnAddrs[0]),
-			slog.String("certName", certName),
-			slog.Any("certVersion", certVersion),
-			slog.String("fingerprint", fingerprint),
-			slog.String("issuer", issuer),
-			slog.Uint64("initiatorIndex", uint64(hs.Details.InitiatorIndex)),
-			slog.Uint64("responderIndex", uint64(hs.Details.ResponderIndex)),
-			slog.Uint64("remoteIndex", uint64(h.RemoteIndex)),
-			slog.Any("handshake", m{"stage": 2, "style": "ix_psk0"}),
+			"vpnAddrs", vpnAddrs,
+			"relay", via.relayHI.vpnAddrs[0],
+			"certName", certName,
+			"certVersion", certVersion,
+			"fingerprint", fingerprint,
+			"issuer", issuer,
+			"initiatorIndex", uint64(hs.Details.InitiatorIndex),
+			"responderIndex", uint64(hs.Details.ResponderIndex),
+			"remoteIndex", uint64(h.RemoteIndex),
+			"handshake", m{"stage": 2, "style": "ix_psk0"},
 		)
 	}
 
@@ -571,8 +574,8 @@ func ixHandshakeStage2(f *Interface, via ViaSender, hh *HandshakeHostInfo, packe
 		if !f.lightHouse.GetRemoteAllowList().AllowAll(hostinfo.vpnAddrs, via.UdpAddr.Addr()) {
 			if f.l.Enabled(context.Background(), slog.LevelDebug) {
 				f.l.Debug("lighthouse.remote_allow_list denied incoming handshake",
-					slog.Any("vpnAddrs", hostinfo.vpnAddrs),
-					slog.Any("from", via),
+					"vpnAddrs", hostinfo.vpnAddrs,
+					"from", via,
 				)
 			}
 			return false
@@ -583,11 +586,11 @@ func ixHandshakeStage2(f *Interface, via ViaSender, hh *HandshakeHostInfo, packe
 	msg, eKey, dKey, err := ci.H.ReadMessage(nil, packet[header.Len:])
 	if err != nil {
 		f.l.Error("Failed to call noise.ReadMessage",
-			slog.Any("error", err),
-			slog.Any("vpnAddrs", hostinfo.vpnAddrs),
-			slog.Any("from", via),
-			slog.Any("handshake", m{"stage": 2, "style": "ix_psk0"}),
-			slog.Any("header", h),
+			"error", err,
+			"vpnAddrs", hostinfo.vpnAddrs,
+			"from", via,
+			"handshake", m{"stage": 2, "style": "ix_psk0"},
+			"header", h,
 		)
 
 		// We don't want to tear down the connection on a bad ReadMessage because it could be an attacker trying
@@ -596,9 +599,9 @@ func ixHandshakeStage2(f *Interface, via ViaSender, hh *HandshakeHostInfo, packe
 		return false
 	} else if dKey == nil || eKey == nil {
 		f.l.Error("Noise did not arrive at a key",
-			slog.Any("vpnAddrs", hostinfo.vpnAddrs),
-			slog.Any("from", via),
-			slog.Any("handshake", m{"stage": 2, "style": "ix_psk0"}),
+			"vpnAddrs", hostinfo.vpnAddrs,
+			"from", via,
+			"handshake", m{"stage": 2, "style": "ix_psk0"},
 		)
 
 		// This should be impossible in IX but just in case, if we get here then there is no chance to recover
@@ -610,10 +613,10 @@ func ixHandshakeStage2(f *Interface, via ViaSender, hh *HandshakeHostInfo, packe
 	err = hs.Unmarshal(msg)
 	if err != nil || hs.Details == nil {
 		f.l.Error("Failed unmarshal handshake message",
-			slog.Any("error", err),
-			slog.Any("vpnAddrs", hostinfo.vpnAddrs),
-			slog.Any("from", via),
-			slog.Any("handshake", m{"stage": 2, "style": "ix_psk0"}),
+			"error", err,
+			"vpnAddrs", hostinfo.vpnAddrs,
+			"from", via,
+			"handshake", m{"stage": 2, "style": "ix_psk0"},
 		)
 
 		// The handshake state machine is complete, if things break now there is no chance to recover. Tear down and start again
@@ -623,10 +626,10 @@ func ixHandshakeStage2(f *Interface, via ViaSender, hh *HandshakeHostInfo, packe
 	rc, err := cert.Recombine(cert.Version(hs.Details.CertVersion), hs.Details.Cert, ci.H.PeerStatic(), ci.Curve())
 	if err != nil {
 		f.l.Info("Handshake did not contain a certificate",
-			slog.Any("error", err),
-			slog.Any("from", via),
-			slog.Any("vpnAddrs", hostinfo.vpnAddrs),
-			slog.Any("handshake", m{"stage": 2, "style": "ix_psk0"}),
+			"error", err,
+			"from", via,
+			"vpnAddrs", hostinfo.vpnAddrs,
+			"handshake", m{"stage": 2, "style": "ix_psk0"},
 		)
 		return true
 	}
@@ -650,25 +653,28 @@ func ixHandshakeStage2(f *Interface, via ViaSender, hh *HandshakeHostInfo, packe
 			attrs = append(attrs, slog.Any("cert", rc))
 		}
 
+		// LogAttrs is intentional: attrs is a pre-built []slog.Attr slice that
+		// callers grow conditionally, which has no pair-form equivalent.
+		//nolint:sloglint
 		f.l.LogAttrs(context.Background(), slog.LevelInfo, "Invalid certificate from host", attrs...)
 		return true
 	}
 	if !bytes.Equal(remoteCert.Certificate.PublicKey(), ci.H.PeerStatic()) {
 		f.l.Info("public key mismatch between certificate and handshake",
-			slog.Any("from", via),
-			slog.Any("handshake", m{"stage": 2, "style": "ix_psk0"}),
-			slog.Any("cert", remoteCert),
+			"from", via,
+			"handshake", m{"stage": 2, "style": "ix_psk0"},
+			"cert", remoteCert,
 		)
 		return true
 	}
 
 	if len(remoteCert.Certificate.Networks()) == 0 {
 		f.l.Info("No networks in certificate",
-			slog.Any("error", err),
-			slog.Any("from", via),
-			slog.Any("vpnAddrs", hostinfo.vpnAddrs),
-			slog.Any("cert", remoteCert),
-			slog.Any("handshake", m{"stage": 2, "style": "ix_psk0"}),
+			"error", err,
+			"from", via,
+			"vpnAddrs", hostinfo.vpnAddrs,
+			"cert", remoteCert,
+			"handshake", m{"stage": 2, "style": "ix_psk0"},
 		)
 		return true
 	}
@@ -711,12 +717,12 @@ func ixHandshakeStage2(f *Interface, via ViaSender, hh *HandshakeHostInfo, packe
 	// Ensure the right host responded
 	if !correctHostResponded {
 		f.l.Info("Incorrect host responded to handshake",
-			slog.Any("intendedVpnAddrs", hostinfo.vpnAddrs),
-			slog.Any("haveVpnNetworks", vpnNetworks),
-			slog.Any("from", via),
-			slog.String("certName", certName),
-			slog.Any("certVersion", certVersion),
-			slog.Any("handshake", m{"stage": 2, "style": "ix_psk0"}),
+			"intendedVpnAddrs", hostinfo.vpnAddrs,
+			"haveVpnNetworks", vpnNetworks,
+			"from", via,
+			"certName", certName,
+			"certVersion", certVersion,
+			"handshake", m{"stage": 2, "style": "ix_psk0"},
 		)
 
 		// Release our old handshake from pending, it should not continue
@@ -730,9 +736,9 @@ func ixHandshakeStage2(f *Interface, via ViaSender, hh *HandshakeHostInfo, packe
 			newHH.hostinfo.remotes.BlockRemote(via)
 
 			f.l.Info("Blocked addresses for handshakes",
-				slog.Any("blockedUdpAddrs", newHH.hostinfo.remotes.CopyBlockedRemotes()),
-				slog.Any("vpnNetworks", vpnNetworks),
-				slog.Any("remotes", newHH.hostinfo.remotes.CopyAddrs(f.hostMap.GetPreferredRanges())),
+				"blockedUdpAddrs", newHH.hostinfo.remotes.CopyBlockedRemotes(),
+				"vpnNetworks", vpnNetworks,
+				"remotes", newHH.hostinfo.remotes.CopyAddrs(f.hostMap.GetPreferredRanges()),
 			)
 
 			// Swap the packet store to benefit the original intended recipient
@@ -752,18 +758,18 @@ func ixHandshakeStage2(f *Interface, via ViaSender, hh *HandshakeHostInfo, packe
 
 	duration := time.Since(hh.startTime).Nanoseconds()
 	msgRxL := f.l.With(
-		slog.Any("vpnAddrs", vpnAddrs),
-		slog.Any("from", via),
-		slog.String("certName", certName),
-		slog.Any("certVersion", certVersion),
-		slog.String("fingerprint", fingerprint),
-		slog.String("issuer", issuer),
-		slog.Uint64("initiatorIndex", uint64(hs.Details.InitiatorIndex)),
-		slog.Uint64("responderIndex", uint64(hs.Details.ResponderIndex)),
-		slog.Uint64("remoteIndex", uint64(h.RemoteIndex)),
-		slog.Any("handshake", m{"stage": 2, "style": "ix_psk0"}),
-		slog.Int64("durationNs", duration),
-		slog.Int("sentCachedPackets", len(hh.packetStore)),
+		"vpnAddrs", vpnAddrs,
+		"from", via,
+		"certName", certName,
+		"certVersion", certVersion,
+		"fingerprint", fingerprint,
+		"issuer", issuer,
+		"initiatorIndex", uint64(hs.Details.InitiatorIndex),
+		"responderIndex", uint64(hs.Details.ResponderIndex),
+		"remoteIndex", uint64(h.RemoteIndex),
+		"handshake", m{"stage": 2, "style": "ix_psk0"},
+		"durationNs", duration,
+		"sentCachedPackets", len(hh.packetStore),
 	)
 	if anyVpnAddrsInCommon {
 		msgRxL.Info("Handshake message received")
@@ -782,7 +788,7 @@ func ixHandshakeStage2(f *Interface, via ViaSender, hh *HandshakeHostInfo, packe
 
 	if f.l.Enabled(context.Background(), slog.LevelDebug) {
 		hostinfo.logger(f.l).Debug("Sending stored packets",
-			slog.Int("count", len(hh.packetStore)),
+			"count", len(hh.packetStore),
 		)
 	}
 

--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -86,8 +86,8 @@ func (hh *HandshakeHostInfo) cachePacket(l *slog.Logger, t header.MessageType, s
 		hh.packetStore = append(hh.packetStore, &cachedPacket{t, st, f, tempPacket})
 		if l.Enabled(context.Background(), slog.LevelDebug) {
 			hh.hostinfo.logger(l).Debug("Packet store",
-				slog.Int("length", len(hh.packetStore)),
-				slog.Bool("stored", true),
+				"length", len(hh.packetStore),
+				"stored", true,
 			)
 		}
 
@@ -96,8 +96,8 @@ func (hh *HandshakeHostInfo) cachePacket(l *slog.Logger, t header.MessageType, s
 
 		if l.Enabled(context.Background(), slog.LevelDebug) {
 			hh.hostinfo.logger(l).Debug("Packet store",
-				slog.Int("length", len(hh.packetStore)),
-				slog.Bool("stored", false),
+				"length", len(hh.packetStore),
+				"stored", false,
 			)
 		}
 	}
@@ -140,7 +140,7 @@ func (hm *HandshakeManager) HandleIncoming(via ViaSender, packet []byte, h *head
 	// First remote allow list check before we know the vpnIp
 	if !via.IsRelayed {
 		if !hm.lightHouse.GetRemoteAllowList().AllowUnknownVpnAddr(via.UdpAddr.Addr()) {
-			hm.l.Debug("lighthouse.remote_allow_list denied incoming handshake", slog.Any("from", via))
+			hm.l.Debug("lighthouse.remote_allow_list denied incoming handshake", "from", via)
 			return
 		}
 	}
@@ -184,11 +184,11 @@ func (hm *HandshakeManager) handleOutbound(vpnIp netip.Addr, lighthouseTriggered
 	// If we are out of time, clean up
 	if hh.counter >= hm.config.retries {
 		hh.hostinfo.logger(hm.l).Info("Handshake timed out",
-			slog.Any("udpAddrs", hh.hostinfo.remotes.CopyAddrs(hm.mainHostMap.GetPreferredRanges())),
-			slog.Uint64("initiatorIndex", uint64(hh.hostinfo.localIndexId)),
-			slog.Uint64("remoteIndex", uint64(hh.hostinfo.remoteIndexId)),
-			slog.Any("handshake", m{"stage": 1, "style": "ix_psk0"}),
-			slog.Int64("durationNs", time.Since(hh.startTime).Nanoseconds()),
+			"udpAddrs", hh.hostinfo.remotes.CopyAddrs(hm.mainHostMap.GetPreferredRanges()),
+			"initiatorIndex", uint64(hh.hostinfo.localIndexId),
+			"remoteIndex", uint64(hh.hostinfo.remoteIndexId),
+			"handshake", m{"stage": 1, "style": "ix_psk0"},
+			"durationNs", time.Since(hh.startTime).Nanoseconds(),
 		)
 		hm.metricTimedOut.Inc(1)
 		hm.DeleteHostInfo(hostinfo)
@@ -243,10 +243,10 @@ func (hm *HandshakeManager) handleOutbound(vpnIp netip.Addr, lighthouseTriggered
 		err := hm.outside.WriteTo(hostinfo.HandshakePacket[0], addr)
 		if err != nil {
 			hostinfo.logger(hm.l).Error("Failed to send handshake message",
-				slog.Any("udpAddr", addr),
-				slog.Uint64("initiatorIndex", uint64(hostinfo.localIndexId)),
-				slog.Any("handshake", m{"stage": 1, "style": "ix_psk0"}),
-				slog.Any("error", err),
+				"udpAddr", addr,
+				"initiatorIndex", uint64(hostinfo.localIndexId),
+				"handshake", m{"stage": 1, "style": "ix_psk0"},
+				"error", err,
 			)
 
 		} else {
@@ -258,20 +258,20 @@ func (hm *HandshakeManager) handleOutbound(vpnIp netip.Addr, lighthouseTriggered
 	// so only log when the list of remotes has changed
 	if remotesHaveChanged {
 		hostinfo.logger(hm.l).Info("Handshake message sent",
-			slog.Any("udpAddrs", sentTo),
-			slog.Uint64("initiatorIndex", uint64(hostinfo.localIndexId)),
-			slog.Any("handshake", m{"stage": 1, "style": "ix_psk0"}),
+			"udpAddrs", sentTo,
+			"initiatorIndex", uint64(hostinfo.localIndexId),
+			"handshake", m{"stage": 1, "style": "ix_psk0"},
 		)
 	} else if hm.l.Enabled(context.Background(), slog.LevelDebug) {
 		hostinfo.logger(hm.l).Debug("Handshake message sent",
-			slog.Any("udpAddrs", sentTo),
-			slog.Uint64("initiatorIndex", uint64(hostinfo.localIndexId)),
-			slog.Any("handshake", m{"stage": 1, "style": "ix_psk0"}),
+			"udpAddrs", sentTo,
+			"initiatorIndex", uint64(hostinfo.localIndexId),
+			"handshake", m{"stage": 1, "style": "ix_psk0"},
 		)
 	}
 
 	if hm.config.useRelays && len(hostinfo.remotes.relays) > 0 {
-		hostinfo.logger(hm.l).Info("Attempt to relay through hosts", slog.Any("relays", hostinfo.remotes.relays))
+		hostinfo.logger(hm.l).Info("Attempt to relay through hosts", "relays", hostinfo.remotes.relays)
 		// Send a RelayRequest to all known Relay IP's
 		for _, relay := range hostinfo.remotes.relays {
 			// Don't relay through the host I'm trying to connect to
@@ -286,7 +286,7 @@ func (hm *HandshakeManager) handleOutbound(vpnIp netip.Addr, lighthouseTriggered
 
 			relayHostInfo := hm.mainHostMap.QueryVpnAddr(relay)
 			if relayHostInfo == nil || !relayHostInfo.remote.IsValid() {
-				hostinfo.logger(hm.l).Info("Establish tunnel to relay target", slog.String("relay", relay.String()))
+				hostinfo.logger(hm.l).Info("Establish tunnel to relay target", "relay", relay.String())
 				hm.f.Handshake(relay)
 				continue
 			}
@@ -297,7 +297,7 @@ func (hm *HandshakeManager) handleOutbound(vpnIp netip.Addr, lighthouseTriggered
 				if relayHostInfo.remote.IsValid() {
 					idx, err := AddRelay(hm.l, relayHostInfo, hm.mainHostMap, vpnIp, nil, TerminalType, Requested)
 					if err != nil {
-						hostinfo.logger(hm.l).Info("Failed to add relay to hostmap", slog.String("relay", relay.String()), slog.Any("error", err))
+						hostinfo.logger(hm.l).Info("Failed to add relay to hostmap", "relay", relay.String(), "error", err)
 					}
 
 					m := NebulaControl{
@@ -331,14 +331,14 @@ func (hm *HandshakeManager) handleOutbound(vpnIp netip.Addr, lighthouseTriggered
 
 					msg, err := m.Marshal()
 					if err != nil {
-						hostinfo.logger(hm.l).Error("Failed to marshal Control message to create relay", slog.Any("error", err))
+						hostinfo.logger(hm.l).Error("Failed to marshal Control message to create relay", "error", err)
 					} else {
 						hm.f.SendMessageToHostInfo(header.Control, 0, relayHostInfo, msg, make([]byte, 12), make([]byte, mtu))
 						hm.l.Info("send CreateRelayRequest",
-							slog.Any("relayFrom", hm.f.myVpnAddrs[0]),
-							slog.Any("relayTo", vpnIp),
-							slog.Uint64("initiatorRelayIndex", uint64(idx)),
-							slog.Any("relay", relay),
+							"relayFrom", hm.f.myVpnAddrs[0],
+							"relayTo", vpnIp,
+							"initiatorRelayIndex", uint64(idx),
+							"relay", relay,
 						)
 					}
 				}
@@ -347,14 +347,14 @@ func (hm *HandshakeManager) handleOutbound(vpnIp netip.Addr, lighthouseTriggered
 
 			switch existingRelay.State {
 			case Established:
-				hostinfo.logger(hm.l).Info("Send handshake via relay", slog.String("relay", relay.String()))
+				hostinfo.logger(hm.l).Info("Send handshake via relay", "relay", relay.String())
 				hm.f.SendVia(relayHostInfo, existingRelay, hostinfo.HandshakePacket[0], make([]byte, 12), make([]byte, mtu), false)
 			case Disestablished:
 				// Mark this relay as 'requested'
 				relayHostInfo.relayState.UpdateRelayForByIpState(vpnIp, Requested)
 				fallthrough
 			case Requested:
-				hostinfo.logger(hm.l).Info("Re-send CreateRelay request", slog.String("relay", relay.String()))
+				hostinfo.logger(hm.l).Info("Re-send CreateRelay request", "relay", relay.String())
 				// Re-send the CreateRelay request, in case the previous one was lost.
 				m := NebulaControl{
 					Type:                NebulaControl_CreateRelayRequest,
@@ -386,15 +386,15 @@ func (hm *HandshakeManager) handleOutbound(vpnIp netip.Addr, lighthouseTriggered
 				}
 				msg, err := m.Marshal()
 				if err != nil {
-					hostinfo.logger(hm.l).Error("Failed to marshal Control message to create relay", slog.Any("error", err))
+					hostinfo.logger(hm.l).Error("Failed to marshal Control message to create relay", "error", err)
 				} else {
 					// This must send over the hostinfo, not over hm.Hosts[ip]
 					hm.f.SendMessageToHostInfo(header.Control, 0, relayHostInfo, msg, make([]byte, 12), make([]byte, mtu))
 					hm.l.Info("send CreateRelayRequest",
-						slog.Any("relayFrom", hm.f.myVpnAddrs[0]),
-						slog.Any("relayTo", vpnIp),
-						slog.Uint64("initiatorRelayIndex", uint64(existingRelay.LocalIndex)),
-						slog.Any("relay", relay),
+						"relayFrom", hm.f.myVpnAddrs[0],
+						"relayTo", vpnIp,
+						"initiatorRelayIndex", uint64(existingRelay.LocalIndex),
+						"relay", relay,
 					)
 				}
 			case PeerRequested:
@@ -402,9 +402,9 @@ func (hm *HandshakeManager) handleOutbound(vpnIp netip.Addr, lighthouseTriggered
 				fallthrough
 			default:
 				hostinfo.logger(hm.l).Error("Relay unexpected state",
-					slog.Any("vpnIp", vpnIp),
-					slog.Any("state", existingRelay.State),
-					slog.Any("relay", relay),
+					"vpnIp", vpnIp,
+					"state", existingRelay.State,
+					"relay", relay,
 				)
 
 			}
@@ -551,8 +551,8 @@ func (hm *HandshakeManager) CheckAndComplete(hostinfo *HostInfo, handshakePacket
 		// We have a collision, but this can happen since we can't control
 		// the remote ID. Just log about the situation as a note.
 		hostinfo.logger(hm.l).Info("New host shadows existing host remoteIndex",
-			slog.Uint64("remoteIndex", uint64(hostinfo.remoteIndexId)),
-			slog.Any("collision", existingRemoteIndex.vpnAddrs),
+			"remoteIndex", uint64(hostinfo.remoteIndexId),
+			"collision", existingRemoteIndex.vpnAddrs,
 		)
 	}
 
@@ -574,8 +574,8 @@ func (hm *HandshakeManager) Complete(hostinfo *HostInfo, f *Interface) {
 		// We have a collision, but this can happen since we can't control
 		// the remote ID. Just log about the situation as a note.
 		hostinfo.logger(hm.l).Info("New host shadows existing host remoteIndex",
-			slog.Uint64("remoteIndex", uint64(hostinfo.remoteIndexId)),
-			slog.Any("collision", existingRemoteIndex.vpnAddrs),
+			"remoteIndex", uint64(hostinfo.remoteIndexId),
+			"collision", existingRemoteIndex.vpnAddrs,
 		)
 	}
 
@@ -634,8 +634,8 @@ func (hm *HandshakeManager) unlockedDeleteHostInfo(hostinfo *HostInfo) {
 
 	if hm.l.Enabled(context.Background(), slog.LevelDebug) {
 		hm.l.Debug("Pending hostmap hostInfo deleted",
-			slog.Any("hostMap", m{"mapTotalSize": len(hm.vpnIps),
-				"vpnAddrs": hostinfo.vpnAddrs, "indexNumber": hostinfo.localIndexId, "remoteIndexNumber": hostinfo.remoteIndexId}),
+			"hostMap", m{"mapTotalSize": len(hm.vpnIps),
+				"vpnAddrs": hostinfo.vpnAddrs, "indexNumber": hostinfo.localIndexId, "remoteIndexNumber": hostinfo.remoteIndexId},
 		)
 	}
 }
@@ -712,7 +712,7 @@ func generateIndex(l *slog.Logger) (uint32, error) {
 	for index == 0 {
 		_, err := rand.Read(b)
 		if err != nil {
-			l.Error("Failed to generate index", slog.Any("error", err))
+			l.Error("Failed to generate index", "error", err)
 			return 0, err
 		}
 
@@ -720,7 +720,7 @@ func generateIndex(l *slog.Logger) (uint32, error) {
 	}
 
 	if l.Enabled(context.Background(), slog.LevelDebug) {
-		l.Debug("Generated index", slog.Any("index", index))
+		l.Debug("Generated index", "index", index)
 	}
 	return index, nil
 }

--- a/hostmap.go
+++ b/hostmap.go
@@ -322,7 +322,7 @@ func NewHostMapFromConfig(l *slog.Logger, c *config.C) *HostMap {
 		hm.reload(c, false)
 	})
 
-	l.Info("Main HostMap created", slog.Any("preferredRanges", hm.GetPreferredRanges()))
+	l.Info("Main HostMap created", "preferredRanges", hm.GetPreferredRanges())
 
 	return hm
 }
@@ -347,8 +347,8 @@ func (hm *HostMap) reload(c *config.C, initial bool) {
 
 			if err != nil {
 				hm.l.Warn("Failed to parse preferred ranges, ignoring",
-					slog.Any("error", err),
-					slog.Any("range", rawPreferredRanges),
+					"error", err,
+					"range", rawPreferredRanges,
 				)
 				continue
 			}
@@ -359,8 +359,8 @@ func (hm *HostMap) reload(c *config.C, initial bool) {
 		oldRanges := hm.preferredRanges.Swap(&preferredRanges)
 		if !initial {
 			hm.l.Info("preferred_ranges changed",
-				slog.Any("oldPreferredRanges", *oldRanges),
-				slog.Any("newPreferredRanges", preferredRanges),
+				"oldPreferredRanges", *oldRanges,
+				"newPreferredRanges", preferredRanges,
 			)
 		}
 	}
@@ -496,8 +496,8 @@ func (hm *HostMap) unlockedInnerDeleteHostInfo(hostinfo *HostInfo, addr netip.Ad
 
 	if hm.l.Enabled(context.Background(), slog.LevelDebug) {
 		hm.l.Debug("Hostmap hostInfo deleted",
-			slog.Any("hostMap", m{"mapTotalSize": len(hm.Hosts),
-				"vpnAddrs": hostinfo.vpnAddrs, "indexNumber": hostinfo.localIndexId, "remoteIndexNumber": hostinfo.remoteIndexId}),
+			"hostMap", m{"mapTotalSize": len(hm.Hosts),
+				"vpnAddrs": hostinfo.vpnAddrs, "indexNumber": hostinfo.localIndexId, "remoteIndexNumber": hostinfo.remoteIndexId},
 		)
 	}
 
@@ -624,8 +624,8 @@ func (hm *HostMap) unlockedAddHostInfo(hostinfo *HostInfo, f *Interface) {
 
 	if hm.l.Enabled(context.Background(), slog.LevelDebug) {
 		hm.l.Debug("Hostmap vpnIp added",
-			slog.Any("hostMap", m{"vpnAddrs": hostinfo.vpnAddrs, "mapTotalSize": len(hm.Hosts),
-				"hostinfo": m{"existing": true, "localIndexId": hostinfo.localIndexId, "vpnAddrs": hostinfo.vpnAddrs}}),
+			"hostMap", m{"vpnAddrs": hostinfo.vpnAddrs, "mapTotalSize": len(hm.Hosts),
+				"hostinfo": m{"existing": true, "localIndexId": hostinfo.localIndexId, "vpnAddrs": hostinfo.vpnAddrs}},
 		)
 	}
 }
@@ -799,14 +799,14 @@ func (i *HostInfo) logger(l *slog.Logger) *slog.Logger {
 	}
 
 	li := l.With(
-		slog.Any("vpnAddrs", i.vpnAddrs),
-		slog.Uint64("localIndex", uint64(i.localIndexId)),
-		slog.Uint64("remoteIndex", uint64(i.remoteIndexId)),
+		"vpnAddrs", i.vpnAddrs,
+		"localIndex", uint64(i.localIndexId),
+		"remoteIndex", uint64(i.remoteIndexId),
 	)
 
 	if connState := i.ConnectionState; connState != nil {
 		if peerCert := connState.peerCert; peerCert != nil {
-			li = li.With(slog.String("certName", peerCert.Certificate.Name()))
+			li = li.With("certName", peerCert.Certificate.Name())
 		}
 	}
 
@@ -822,9 +822,9 @@ func localAddrs(l *slog.Logger, allowList *LocalAllowList) []netip.Addr {
 	for _, i := range ifaces {
 		allow := allowList.AllowName(i.Name)
 		if l.Enabled(context.Background(), LogLevelTrace) {
-			l.LogAttrs(context.Background(), LogLevelTrace, "localAllowList.AllowName",
-				slog.String("interfaceName", i.Name),
-				slog.Bool("allow", allow),
+			l.Log(context.Background(), LogLevelTrace, "localAllowList.AllowName",
+				"interfaceName", i.Name,
+				"allow", allow,
 			)
 		}
 
@@ -844,7 +844,7 @@ func localAddrs(l *slog.Logger, allowList *LocalAllowList) []netip.Addr {
 
 			if !addr.IsValid() {
 				if l.Enabled(context.Background(), slog.LevelDebug) {
-					l.Debug("addr was invalid", slog.Any("localAddr", rawAddr))
+					l.Debug("addr was invalid", "localAddr", rawAddr)
 				}
 				continue
 			}
@@ -853,9 +853,9 @@ func localAddrs(l *slog.Logger, allowList *LocalAllowList) []netip.Addr {
 			if addr.IsLoopback() == false && addr.IsLinkLocalUnicast() == false {
 				isAllowed := allowList.Allow(addr)
 				if l.Enabled(context.Background(), LogLevelTrace) {
-					l.LogAttrs(context.Background(), LogLevelTrace, "localAllowList.Allow",
-						slog.Any("localAddr", addr),
-						slog.Bool("allowed", isAllowed),
+					l.Log(context.Background(), LogLevelTrace, "localAllowList.Allow",
+						"localAddr", addr,
+						"allowed", isAllowed,
 					)
 				}
 				if !isAllowed {

--- a/inside.go
+++ b/inside.go
@@ -17,8 +17,8 @@ func (f *Interface) consumeInsidePacket(packet []byte, fwPacket *firewall.Packet
 	if err != nil {
 		if f.l.Enabled(context.Background(), slog.LevelDebug) {
 			f.l.Debug("Error while validating outbound packet",
-				slog.Any("packet", packet),
-				slog.Any("error", err),
+				"packet", packet,
+				"error", err,
 			)
 		}
 		return
@@ -39,7 +39,7 @@ func (f *Interface) consumeInsidePacket(packet []byte, fwPacket *firewall.Packet
 		if immediatelyForwardToSelf {
 			_, err := f.readers[q].Write(packet)
 			if err != nil {
-				f.l.Error("Failed to forward to tun", slog.Any("error", err))
+				f.l.Error("Failed to forward to tun", "error", err)
 			}
 		}
 		// Otherwise, drop. On linux, we should never see these packets - Linux
@@ -60,8 +60,8 @@ func (f *Interface) consumeInsidePacket(packet []byte, fwPacket *firewall.Packet
 		f.rejectInside(packet, out, q)
 		if f.l.Enabled(context.Background(), slog.LevelDebug) {
 			f.l.Debug("dropping outbound packet, vpnAddr not in our vpn networks or in unsafe networks",
-				slog.Any("vpnAddr", fwPacket.RemoteAddr),
-				slog.Any("fwPacket", fwPacket),
+				"vpnAddr", fwPacket.RemoteAddr,
+				"fwPacket", fwPacket,
 			)
 		}
 		return
@@ -79,8 +79,8 @@ func (f *Interface) consumeInsidePacket(packet []byte, fwPacket *firewall.Packet
 		f.rejectInside(packet, out, q)
 		if f.l.Enabled(context.Background(), slog.LevelDebug) {
 			hostinfo.logger(f.l).Debug("dropping outbound packet",
-				slog.Any("fwPacket", fwPacket),
-				slog.Any("reason", dropReason),
+				"fwPacket", fwPacket,
+				"reason", dropReason,
 			)
 		}
 	}
@@ -98,7 +98,7 @@ func (f *Interface) rejectInside(packet []byte, out []byte, q int) {
 
 	_, err := f.readers[q].Write(out)
 	if err != nil {
-		f.l.Error("Failed to write to tun", slog.Any("error", err))
+		f.l.Error("Failed to write to tun", "error", err)
 	}
 }
 
@@ -115,8 +115,8 @@ func (f *Interface) rejectOutside(packet []byte, ci *ConnectionState, hostinfo *
 	if len(out) > iputil.MaxRejectPacketSize {
 		if f.l.Enabled(context.Background(), slog.LevelInfo) {
 			f.l.Info("rejectOutside: packet too big, not sending",
-				slog.Any("packet", packet),
-				slog.Any("outPacket", out),
+				"packet", packet,
+				"outPacket", out,
 			)
 		}
 		return
@@ -191,8 +191,8 @@ func (f *Interface) getOrHandshakeConsiderRouting(fwPacket *firewall.Packet, cac
 
 		if f.l.Enabled(context.Background(), slog.LevelDebug) {
 			f.l.Debug("Calculated gateway for ECMP not available, attempting other gateways",
-				slog.Any("destination", destinationAddr),
-				slog.Any("originalGateway", gatewayAddr),
+				"destination", destinationAddr,
+				"originalGateway", gatewayAddr,
 			)
 		}
 
@@ -219,7 +219,7 @@ func (f *Interface) sendMessageNow(t header.MessageType, st header.MessageSubTyp
 	fp := &firewall.Packet{}
 	err := newPacket(p, false, fp)
 	if err != nil {
-		f.l.Warn("error while parsing outgoing packet for firewall check", slog.Any("error", err))
+		f.l.Warn("error while parsing outgoing packet for firewall check", "error", err)
 		return
 	}
 
@@ -228,8 +228,8 @@ func (f *Interface) sendMessageNow(t header.MessageType, st header.MessageSubTyp
 	if dropReason != nil {
 		if f.l.Enabled(context.Background(), slog.LevelDebug) {
 			f.l.Debug("dropping cached packet",
-				slog.Any("fwPacket", fp),
-				slog.Any("reason", dropReason),
+				"fwPacket", fp,
+				"reason", dropReason,
 			)
 		}
 		return
@@ -248,7 +248,7 @@ func (f *Interface) SendMessageToVpnAddr(t header.MessageType, st header.Message
 	if hostInfo == nil {
 		if f.l.Enabled(context.Background(), slog.LevelDebug) {
 			f.l.Debug("dropping SendMessageToVpnAddr, vpnAddr not in our vpn networks or in unsafe routes",
-				slog.Any("vpnAddr", vpnAddr),
+				"vpnAddr", vpnAddr,
 			)
 		}
 		return
@@ -306,10 +306,10 @@ func (f *Interface) SendVia(via *HostInfo,
 			via.ConnectionState.writeLock.Unlock()
 		}
 		via.logger(f.l).Error("SendVia out buffer not large enough for relay",
-			slog.Int("outCap", cap(out)),
-			slog.Int("payloadLen", len(ad)),
-			slog.Int("headerLen", len(out)),
-			slog.Int("cipherOverhead", via.ConnectionState.eKey.Overhead()),
+			"outCap", cap(out),
+			"payloadLen", len(ad),
+			"headerLen", len(out),
+			"cipherOverhead", via.ConnectionState.eKey.Overhead(),
 		)
 		return
 	}
@@ -330,12 +330,12 @@ func (f *Interface) SendVia(via *HostInfo,
 		via.ConnectionState.writeLock.Unlock()
 	}
 	if err != nil {
-		via.logger(f.l).Info("Failed to EncryptDanger in sendVia", slog.Any("error", err))
+		via.logger(f.l).Info("Failed to EncryptDanger in sendVia", "error", err)
 		return
 	}
 	err = f.writers[0].WriteTo(out, via.remote)
 	if err != nil {
-		via.logger(f.l).Info("Failed to WriteTo in sendVia", slog.Any("error", err))
+		via.logger(f.l).Info("Failed to WriteTo in sendVia", "error", err)
 	}
 	f.connectionManager.RelayUsed(relay.LocalIndex)
 }
@@ -376,7 +376,7 @@ func (f *Interface) sendNoMetrics(t header.MessageType, st header.MessageSubType
 		hostinfo.lastRebindCount = f.rebindCount
 		if f.l.Enabled(context.Background(), slog.LevelDebug) {
 			f.l.Debug("Lighthouse update triggered for punch due to rebind counter",
-				slog.Any("vpnAddrs", hostinfo.vpnAddrs),
+				"vpnAddrs", hostinfo.vpnAddrs,
 			)
 		}
 	}
@@ -388,10 +388,10 @@ func (f *Interface) sendNoMetrics(t header.MessageType, st header.MessageSubType
 	}
 	if err != nil {
 		hostinfo.logger(f.l).Error("Failed to encrypt outgoing packet",
-			slog.Any("error", err),
-			slog.Any("udpAddr", remote),
-			slog.Uint64("counter", c),
-			slog.Uint64("attemptedCounter", c),
+			"error", err,
+			"udpAddr", remote,
+			"counter", c,
+			"attemptedCounter", c,
 		)
 		return
 	}
@@ -400,16 +400,16 @@ func (f *Interface) sendNoMetrics(t header.MessageType, st header.MessageSubType
 		err = f.writers[q].WriteTo(out, remote)
 		if err != nil {
 			hostinfo.logger(f.l).Error("Failed to write outgoing packet",
-				slog.Any("error", err),
-				slog.Any("udpAddr", remote),
+				"error", err,
+				"udpAddr", remote,
 			)
 		}
 	} else if hostinfo.remote.IsValid() {
 		err = f.writers[q].WriteTo(out, hostinfo.remote)
 		if err != nil {
 			hostinfo.logger(f.l).Error("Failed to write outgoing packet",
-				slog.Any("error", err),
-				slog.Any("udpAddr", remote),
+				"error", err,
+				"udpAddr", remote,
 			)
 		}
 	} else {
@@ -419,8 +419,8 @@ func (f *Interface) sendNoMetrics(t header.MessageType, st header.MessageSubType
 			if err != nil {
 				hostinfo.relayState.DeleteRelay(relayIP)
 				hostinfo.logger(f.l).Info("sendNoMetrics failed to find HostInfo",
-					slog.Any("relay", relayIP),
-					slog.Any("error", err),
+					"relay", relayIP,
+					"error", err,
 				)
 				continue
 			}

--- a/interface.go
+++ b/interface.go
@@ -224,15 +224,15 @@ func (f *Interface) activate() error {
 
 	addr, err := f.outside.LocalAddr()
 	if err != nil {
-		f.l.Error("Failed to get udp listen address", slog.Any("error", err))
+		f.l.Error("Failed to get udp listen address", "error", err)
 	}
 
 	f.l.Info("Nebula interface is active",
-		slog.String("interface", f.inside.Name()),
-		slog.Any("networks", f.myVpnNetworks),
-		slog.String("build", f.version),
-		slog.Any("udpAddr", addr),
-		slog.Bool("boringcrypto", boringEnabled()),
+		"interface", f.inside.Name(),
+		"networks", f.myVpnNetworks,
+		"build", f.version,
+		"udpAddr", addr,
+		"boringcrypto", boringEnabled(),
 	)
 
 	if f.routines > 1 {
@@ -321,11 +321,11 @@ func (f *Interface) listenOut(i int) {
 	})
 
 	if err != nil && !f.closed.Load() {
-		f.l.Error("Error while reading inbound packet, closing", slog.Any("error", err))
+		f.l.Error("Error while reading inbound packet, closing", "error", err)
 		f.onFatal(err)
 	}
 
-	f.l.Debug("underlay reader is done", slog.Int("reader", i))
+	f.l.Debug("underlay reader is done", "reader", i)
 }
 
 func (f *Interface) listenIn(reader io.ReadWriteCloser, i int) {
@@ -340,7 +340,7 @@ func (f *Interface) listenIn(reader io.ReadWriteCloser, i int) {
 		n, err := reader.Read(packet)
 		if err != nil {
 			if !f.closed.Load() {
-				f.l.Error("Error while reading outbound packet, closing", slog.Any("error", err), slog.Int("reader", i))
+				f.l.Error("Error while reading outbound packet, closing", "error", err, "reader", i)
 				f.onFatal(err)
 			}
 			break
@@ -349,7 +349,7 @@ func (f *Interface) listenIn(reader io.ReadWriteCloser, i int) {
 		f.consumeInsidePacket(packet[:n], fwPacket, nb, out, i, conntrackCache.Get())
 	}
 
-	f.l.Debug("overlay reader is done", slog.Int("reader", i))
+	f.l.Debug("overlay reader is done", "reader", i)
 }
 
 func (f *Interface) RegisterConfigChangeCallbacks(c *config.C) {
@@ -369,7 +369,7 @@ func (f *Interface) reloadDisconnectInvalid(c *config.C) {
 	if initial || c.HasChanged("pki.disconnect_invalid") {
 		f.disconnectInvalid.Store(c.GetBool("pki.disconnect_invalid", true))
 		if !initial {
-			f.l.Info("pki.disconnect_invalid changed", slog.Bool("value", f.disconnectInvalid.Load()))
+			f.l.Info("pki.disconnect_invalid changed", "value", f.disconnectInvalid.Load())
 		}
 	}
 }
@@ -383,7 +383,7 @@ func (f *Interface) reloadFirewall(c *config.C) {
 
 	fw, err := NewFirewallFromConfig(f.l, f.pki.getCertState(), c)
 	if err != nil {
-		f.l.Error("Error while creating firewall during reload", slog.Any("error", err))
+		f.l.Error("Error while creating firewall during reload", "error", err)
 		return
 	}
 
@@ -397,9 +397,9 @@ func (f *Interface) reloadFirewall(c *config.C) {
 	// safe and just reset conntrack in this case.
 	if fw.rulesVersion == 0 {
 		f.l.Warn("firewall rulesVersion has overflowed, resetting conntrack",
-			slog.Any("firewallHashes", fw.GetRuleHashes()),
-			slog.Any("oldFirewallHashes", oldFw.GetRuleHashes()),
-			slog.Any("rulesVersion", fw.rulesVersion),
+			"firewallHashes", fw.GetRuleHashes(),
+			"oldFirewallHashes", oldFw.GetRuleHashes(),
+			"rulesVersion", fw.rulesVersion,
 		)
 	} else {
 		fw.Conntrack = conntrack
@@ -409,9 +409,9 @@ func (f *Interface) reloadFirewall(c *config.C) {
 
 	oldFw.Destroy()
 	f.l.Info("New firewall has been installed",
-		slog.Any("firewallHashes", fw.GetRuleHashes()),
-		slog.Any("oldFirewallHashes", oldFw.GetRuleHashes()),
-		slog.Any("rulesVersion", fw.rulesVersion),
+		"firewallHashes", fw.GetRuleHashes(),
+		"oldFirewallHashes", oldFw.GetRuleHashes(),
+		"rulesVersion", fw.rulesVersion,
 	)
 }
 
@@ -434,7 +434,7 @@ func (f *Interface) reloadSendRecvError(c *config.C) {
 			}
 		}
 
-		f.l.Info("Loaded send_recv_error config", slog.String("sendRecvError", f.sendRecvErrorConfig.String()))
+		f.l.Info("Loaded send_recv_error config", "sendRecvError", f.sendRecvErrorConfig.String())
 	}
 }
 
@@ -457,7 +457,7 @@ func (f *Interface) reloadAcceptRecvError(c *config.C) {
 			}
 		}
 
-		f.l.Info("Loaded accept_recv_error config", slog.String("acceptRecvError", f.acceptRecvErrorConfig.String()))
+		f.l.Info("Loaded accept_recv_error config", "acceptRecvError", f.acceptRecvErrorConfig.String())
 	}
 }
 
@@ -531,7 +531,7 @@ func (f *Interface) Close() error {
 	for i, u := range f.writers {
 		err := u.Close()
 		if err != nil {
-			f.l.Error("Error while closing udp socket", slog.Any("error", err), slog.Int("writer", i))
+			f.l.Error("Error while closing udp socket", "error", err, "writer", i)
 			errs = append(errs, err)
 		}
 	}

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -133,7 +133,7 @@ func NewLightHouseFromConfig(ctx context.Context, l *slog.Logger, c *config.C, c
 		case *util.ContextualError:
 			v.Log(l)
 		case error:
-			l.Error("failed to reload lighthouse", slog.Any("error", err))
+			l.Error("failed to reload lighthouse", "error", err)
 		}
 	})
 
@@ -206,8 +206,8 @@ func (lh *LightHouse) reload(c *config.C, initial bool) error {
 			addr := addrs[0].Unmap()
 			if lh.myVpnNetworksTable.Contains(addr) {
 				lh.l.Warn("Ignoring lighthouse.advertise_addrs report because it is within the nebula network range",
-					slog.String("addr", rawAddr),
-					slog.Int("entry", i+1),
+					"addr", rawAddr,
+					"entry", i+1,
 				)
 				continue
 			}
@@ -227,7 +227,7 @@ func (lh *LightHouse) reload(c *config.C, initial bool) error {
 
 		if !initial {
 			lh.l.Info("lighthouse.interval changed",
-				slog.Int64("interval", lh.interval.Load()),
+				"interval", lh.interval.Load(),
 			)
 
 			if lh.updateCancel != nil {
@@ -341,11 +341,11 @@ func (lh *LightHouse) reload(c *config.C, initial bool) error {
 				configRIP, err := netip.ParseAddr(v)
 				if err != nil {
 					lh.l.Warn("Parse relay from config failed",
-						slog.String("relay", v),
-						slog.Any("error", err),
+						"relay", v,
+						"error", err,
 					)
 				} else {
-					lh.l.Info("Read relay from config", slog.String("relay", v))
+					lh.l.Info("Read relay from config", "relay", v)
 					relaysForMe = append(relaysForMe, configRIP)
 				}
 			}
@@ -371,8 +371,8 @@ func (lh *LightHouse) parseLighthouses(c *config.C) ([]netip.Addr, error) {
 
 		if !lh.myVpnNetworksTable.Contains(addr) {
 			lh.l.Warn("lighthouse host is not within our networks, lighthouse functionality will work but layer 3 network traffic to the lighthouse will not",
-				slog.Any("vpnAddr", addr),
-				slog.Any("networks", lh.myVpnNetworks),
+				"vpnAddr", addr,
+				"networks", lh.myVpnNetworks,
 			)
 		}
 		out[i] = addr
@@ -445,9 +445,9 @@ func (lh *LightHouse) loadStaticMap(c *config.C, staticList map[netip.Addr]struc
 
 		if !lh.myVpnNetworksTable.Contains(vpnAddr) {
 			lh.l.Warn("static_host_map key is not within our networks, layer 3 network traffic to this host will not work",
-				slog.Any("vpnAddr", vpnAddr),
-				slog.Any("networks", lh.myVpnNetworks),
-				slog.Int("entry", i+1),
+				"vpnAddr", vpnAddr,
+				"networks", lh.myVpnNetworks,
+				"entry", i+1,
 			)
 		}
 
@@ -555,7 +555,7 @@ func (lh *LightHouse) DeleteVpnAddrs(allVpnAddrs []netip.Addr) {
 			if srm == rm {
 				delete(lh.addrMap, addr)
 				if debugEnabled {
-					lh.l.Debug("deleting from lighthouse", slog.Any("vpnAddr", addr))
+					lh.l.Debug("deleting from lighthouse", "vpnAddr", addr)
 				}
 			}
 		}
@@ -673,10 +673,10 @@ func (lh *LightHouse) unlockedGetRemoteList(allAddrs []netip.Addr) *RemoteList {
 func (lh *LightHouse) shouldAdd(vpnAddrs []netip.Addr, to netip.Addr) bool {
 	allow := lh.GetRemoteAllowList().AllowAll(vpnAddrs, to)
 	if lh.l.Enabled(context.Background(), LogLevelTrace) {
-		lh.l.LogAttrs(context.Background(), LogLevelTrace, "remoteAllowList.Allow",
-			slog.Any("vpnAddrs", vpnAddrs),
-			slog.Any("udpAddr", to),
-			slog.Bool("allow", allow),
+		lh.l.Log(context.Background(), LogLevelTrace, "remoteAllowList.Allow",
+			"vpnAddrs", vpnAddrs,
+			"udpAddr", to,
+			"allow", allow,
 		)
 	}
 	if !allow {
@@ -695,10 +695,10 @@ func (lh *LightHouse) unlockedShouldAddV4(vpnAddr netip.Addr, to *V4AddrPort) bo
 	udpAddr := protoV4AddrPortToNetAddrPort(to)
 	allow := lh.GetRemoteAllowList().Allow(vpnAddr, udpAddr.Addr())
 	if lh.l.Enabled(context.Background(), LogLevelTrace) {
-		lh.l.LogAttrs(context.Background(), LogLevelTrace, "remoteAllowList.Allow",
-			slog.Any("vpnAddr", vpnAddr),
-			slog.Any("udpAddr", udpAddr),
-			slog.Bool("allow", allow),
+		lh.l.Log(context.Background(), LogLevelTrace, "remoteAllowList.Allow",
+			"vpnAddr", vpnAddr,
+			"udpAddr", udpAddr,
+			"allow", allow,
 		)
 	}
 
@@ -718,10 +718,10 @@ func (lh *LightHouse) unlockedShouldAddV6(vpnAddr netip.Addr, to *V6AddrPort) bo
 	udpAddr := protoV6AddrPortToNetAddrPort(to)
 	allow := lh.GetRemoteAllowList().Allow(vpnAddr, udpAddr.Addr())
 	if lh.l.Enabled(context.Background(), LogLevelTrace) {
-		lh.l.LogAttrs(context.Background(), LogLevelTrace, "remoteAllowList.Allow",
-			slog.Any("vpnAddr", vpnAddr),
-			slog.Any("udpAddr", udpAddr),
-			slog.Bool("allow", allow),
+		lh.l.Log(context.Background(), LogLevelTrace, "remoteAllowList.Allow",
+			"vpnAddr", vpnAddr,
+			"udpAddr", udpAddr,
+			"allow", allow,
 		)
 	}
 
@@ -798,8 +798,8 @@ func (lh *LightHouse) innerQueryServer(addr netip.Addr, nb, out []byte) {
 		if v == cert.Version1 {
 			if !addr.Is4() {
 				lh.l.Error("Can't query lighthouse for v6 address using a v1 protocol",
-					slog.Any("queryVpnAddr", addr),
-					slog.Any("lighthouseAddr", lhVpnAddr),
+					"queryVpnAddr", addr,
+					"lighthouseAddr", lhVpnAddr,
 				)
 				continue
 			}
@@ -812,9 +812,9 @@ func (lh *LightHouse) innerQueryServer(addr netip.Addr, nb, out []byte) {
 				v1Query, err = msg.Marshal()
 				if err != nil {
 					lh.l.Error("Failed to marshal lighthouse v1 query payload",
-						slog.Any("error", err),
-						slog.Any("queryVpnAddr", addr),
-						slog.Any("lighthouseAddr", lhVpnAddr),
+						"error", err,
+						"queryVpnAddr", addr,
+						"lighthouseAddr", lhVpnAddr,
 					)
 					continue
 				}
@@ -831,9 +831,9 @@ func (lh *LightHouse) innerQueryServer(addr netip.Addr, nb, out []byte) {
 				v2Query, err = msg.Marshal()
 				if err != nil {
 					lh.l.Error("Failed to marshal lighthouse v2 query payload",
-						slog.Any("error", err),
-						slog.Any("queryVpnAddr", addr),
-						slog.Any("lighthouseAddr", lhVpnAddr),
+						"error", err,
+						"queryVpnAddr", addr,
+						"lighthouseAddr", lhVpnAddr,
 					)
 					continue
 				}
@@ -844,9 +844,9 @@ func (lh *LightHouse) innerQueryServer(addr netip.Addr, nb, out []byte) {
 
 		} else {
 			lh.l.Debug("unsupported protocol version",
-				slog.String("op", "query"),
-				slog.Any("queryVpnAddr", addr),
-				slog.Any("version", v),
+				"op", "query",
+				"queryVpnAddr", addr,
+				"version", v,
 			)
 			continue
 		}
@@ -940,7 +940,7 @@ func (lh *LightHouse) SendUpdate() {
 			if v1Update == nil {
 				if !lh.myVpnNetworks[0].Addr().Is4() {
 					lh.l.Warn("cannot update lighthouse using v1 protocol without an IPv4 address",
-						slog.Any("lighthouseAddr", lhVpnAddr),
+						"lighthouseAddr", lhVpnAddr,
 					)
 					continue
 				}
@@ -966,8 +966,8 @@ func (lh *LightHouse) SendUpdate() {
 				v1Update, err = msg.Marshal()
 				if err != nil {
 					lh.l.Error("Error while marshaling for lighthouse v1 update",
-						slog.Any("error", err),
-						slog.Any("lighthouseAddr", lhVpnAddr),
+						"error", err,
+						"lighthouseAddr", lhVpnAddr,
 					)
 					continue
 				}
@@ -995,8 +995,8 @@ func (lh *LightHouse) SendUpdate() {
 				v2Update, err = msg.Marshal()
 				if err != nil {
 					lh.l.Error("Error while marshaling for lighthouse v2 update",
-						slog.Any("error", err),
-						slog.Any("lighthouseAddr", lhVpnAddr),
+						"error", err,
+						"lighthouseAddr", lhVpnAddr,
 					)
 					continue
 				}
@@ -1007,8 +1007,8 @@ func (lh *LightHouse) SendUpdate() {
 
 		} else {
 			lh.l.Debug("unsupported protocol version",
-				slog.String("op", "update"),
-				slog.Any("version", v),
+				"op", "update",
+				"version", v,
 			)
 			continue
 		}
@@ -1073,17 +1073,17 @@ func (lhh *LightHouseHandler) HandleRequest(rAddr netip.AddrPort, fromVpnAddrs [
 	err := n.Unmarshal(p)
 	if err != nil {
 		lhh.l.Error("Failed to unmarshal lighthouse packet",
-			slog.Any("error", err),
-			slog.Any("vpnAddrs", fromVpnAddrs),
-			slog.Any("udpAddr", rAddr),
+			"error", err,
+			"vpnAddrs", fromVpnAddrs,
+			"udpAddr", rAddr,
 		)
 		return
 	}
 
 	if n.Details == nil {
 		lhh.l.Error("Invalid lighthouse update",
-			slog.Any("vpnAddrs", fromVpnAddrs),
-			slog.Any("udpAddr", rAddr),
+			"vpnAddrs", fromVpnAddrs,
+			"udpAddr", rAddr,
 		)
 		return
 	}
@@ -1113,7 +1113,7 @@ func (lhh *LightHouseHandler) handleHostQuery(n *NebulaMeta, fromVpnAddrs []neti
 	// Exit if we don't answer queries
 	if !lhh.lh.amLighthouse {
 		if lhh.l.Enabled(context.Background(), slog.LevelDebug) {
-			lhh.l.Debug("I don't answer queries, but received one", slog.Any("from", addr))
+			lhh.l.Debug("I don't answer queries, but received one", "from", addr)
 		}
 		return
 	}
@@ -1122,8 +1122,8 @@ func (lhh *LightHouseHandler) handleHostQuery(n *NebulaMeta, fromVpnAddrs []neti
 	if err != nil {
 		if lhh.l.Enabled(context.Background(), slog.LevelDebug) {
 			lhh.l.Debug("Dropping malformed HostQuery",
-				slog.Any("from", fromVpnAddrs),
-				slog.Any("details", n.Details),
+				"from", fromVpnAddrs,
+				"details", n.Details,
 			)
 		}
 		return
@@ -1132,8 +1132,8 @@ func (lhh *LightHouseHandler) handleHostQuery(n *NebulaMeta, fromVpnAddrs []neti
 		// this case really shouldn't be possible to represent, but reject it anyway.
 		if lhh.l.Enabled(context.Background(), slog.LevelDebug) {
 			lhh.l.Debug("invalid vpn addr for v1 handleHostQuery",
-				slog.Any("vpnAddrs", fromVpnAddrs),
-				slog.Any("queryVpnAddr", queryVpnAddr),
+				"vpnAddrs", fromVpnAddrs,
+				"queryVpnAddr", queryVpnAddr,
 			)
 		}
 		return
@@ -1160,8 +1160,8 @@ func (lhh *LightHouseHandler) handleHostQuery(n *NebulaMeta, fromVpnAddrs []neti
 
 	if err != nil {
 		lhh.l.Error("Failed to marshal lighthouse host query reply",
-			slog.Any("error", err),
-			slog.Any("vpnAddrs", fromVpnAddrs),
+			"error", err,
+			"vpnAddrs", fromVpnAddrs,
 		)
 		return
 	}
@@ -1192,7 +1192,7 @@ func (lhh *LightHouseHandler) sendHostPunchNotification(n *NebulaMeta, fromVpnAd
 			} else {
 				if lhh.l.Enabled(context.Background(), slog.LevelDebug) {
 					lhh.l.Debug("unable to punch to host, no addresses in common",
-						slog.Any("to", crt.Networks()),
+						"to", crt.Networks(),
 					)
 				}
 			}
@@ -1220,8 +1220,8 @@ func (lhh *LightHouseHandler) sendHostPunchNotification(n *NebulaMeta, fromVpnAd
 
 	if err != nil {
 		lhh.l.Error("Failed to marshal lighthouse host was queried for",
-			slog.Any("error", err),
-			slog.Any("vpnAddrs", fromVpnAddrs),
+			"error", err,
+			"vpnAddrs", fromVpnAddrs,
 		)
 		return
 	}
@@ -1266,8 +1266,8 @@ func (lhh *LightHouseHandler) coalesceAnswers(v cert.Version, c *cache, n *Nebul
 		} else {
 			if lhh.l.Enabled(context.Background(), slog.LevelDebug) {
 				lhh.l.Debug("unsupported protocol version",
-					slog.String("op", "coalesceAnswers"),
-					slog.Any("version", v),
+					"op", "coalesceAnswers",
+					"version", v,
 				)
 			}
 		}
@@ -1283,8 +1283,8 @@ func (lhh *LightHouseHandler) handleHostQueryReply(n *NebulaMeta, fromVpnAddrs [
 	if err != nil {
 		if lhh.l.Enabled(context.Background(), slog.LevelDebug) {
 			lhh.l.Error("dropping malformed HostQueryReply",
-				slog.Any("error", err),
-				slog.Any("vpnAddrs", fromVpnAddrs),
+				"error", err,
+				"vpnAddrs", fromVpnAddrs,
 			)
 		}
 		return
@@ -1311,7 +1311,7 @@ func (lhh *LightHouseHandler) handleHostQueryReply(n *NebulaMeta, fromVpnAddrs [
 func (lhh *LightHouseHandler) handleHostUpdateNotification(n *NebulaMeta, fromVpnAddrs []netip.Addr, w EncWriter) {
 	if !lhh.lh.amLighthouse {
 		if lhh.l.Enabled(context.Background(), slog.LevelDebug) {
-			lhh.l.Debug("I am not a lighthouse, do not take host updates", slog.Any("from", fromVpnAddrs))
+			lhh.l.Debug("I am not a lighthouse, do not take host updates", "from", fromVpnAddrs)
 		}
 		return
 	}
@@ -1336,8 +1336,8 @@ func (lhh *LightHouseHandler) handleHostUpdateNotification(n *NebulaMeta, fromVp
 	if detailsVpnAddr.IsValid() && !slices.Contains(fromVpnAddrs, detailsVpnAddr) {
 		if lhh.l.Enabled(context.Background(), slog.LevelDebug) {
 			lhh.l.Debug("Host sent invalid update",
-				slog.Any("vpnAddrs", fromVpnAddrs),
-				slog.Any("answer", detailsVpnAddr),
+				"vpnAddrs", fromVpnAddrs,
+				"answer", detailsVpnAddr,
 			)
 		}
 		return
@@ -1361,7 +1361,7 @@ func (lhh *LightHouseHandler) handleHostUpdateNotification(n *NebulaMeta, fromVp
 	case cert.Version1:
 		if !fromVpnAddrs[0].Is4() {
 			lhh.l.Error("Can not send HostUpdateNotificationAck for a ipv6 vpn ip in a v1 message",
-				slog.Any("vpnAddrs", fromVpnAddrs),
+				"vpnAddrs", fromVpnAddrs,
 			)
 			return
 		}
@@ -1370,15 +1370,15 @@ func (lhh *LightHouseHandler) handleHostUpdateNotification(n *NebulaMeta, fromVp
 	case cert.Version2:
 		// do nothing, we want to send a blank message
 	default:
-		lhh.l.Error("invalid protocol version", slog.Any("useVersion", useVersion))
+		lhh.l.Error("invalid protocol version", "useVersion", useVersion)
 		return
 	}
 
 	ln, err := n.MarshalTo(lhh.pb)
 	if err != nil {
 		lhh.l.Error("Failed to marshal lighthouse host update ack",
-			slog.Any("error", err),
-			slog.Any("vpnAddrs", fromVpnAddrs),
+			"error", err,
+			"vpnAddrs", fromVpnAddrs,
 		)
 		return
 	}
@@ -1398,8 +1398,8 @@ func (lhh *LightHouseHandler) handleHostPunchNotification(n *NebulaMeta, fromVpn
 	if err != nil {
 		if lhh.l.Enabled(context.Background(), slog.LevelDebug) {
 			lhh.l.Debug("dropping invalid HostPunchNotification",
-				slog.Any("details", n.Details),
-				slog.Any("error", err),
+				"details", n.Details,
+				"error", err,
 			)
 		}
 		return
@@ -1419,8 +1419,8 @@ func (lhh *LightHouseHandler) handleHostPunchNotification(n *NebulaMeta, fromVpn
 
 		if lhh.l.Enabled(context.Background(), slog.LevelDebug) {
 			lhh.l.Debug("Punching",
-				slog.Any("vpnPeer", vpnPeer),
-				slog.Any("logVpnAddr", logVpnAddr),
+				"vpnPeer", vpnPeer,
+				"logVpnAddr", logVpnAddr,
 			)
 		}
 	}
@@ -1448,7 +1448,7 @@ func (lhh *LightHouseHandler) handleHostPunchNotification(n *NebulaMeta, fromVpn
 			time.Sleep(lhh.lh.punchy.GetRespondDelay())
 			if lhh.l.Enabled(context.Background(), slog.LevelDebug) {
 				lhh.l.Debug("Sending a nebula test packet",
-					slog.Any("vpnAddr", detailsVpnAddr),
+					"vpnAddr", detailsVpnAddr,
 				)
 			}
 			//NOTE: we have to allocate a new output buffer here since we are spawning a new goroutine

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -14,11 +14,11 @@ import (
 // lh.l.With("subsystem", ...), etc.) and call from hot paths.
 
 func BenchmarkLogger_Stock_RootInfo(b *testing.B) {
-	l := slog.New(slog.NewTextHandler(io.Discard, nil))
+	l := slog.New(slog.DiscardHandler)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		l.Info("hello", slog.Int("i", i))
+		l.Info("hello", "i", i)
 	}
 }
 
@@ -27,31 +27,31 @@ func BenchmarkLogger_Nebula_RootInfo(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		l.Info("hello", slog.Int("i", i))
+		l.Info("hello", "i", i)
 	}
 }
 
 func BenchmarkLogger_Stock_DerivedInfo(b *testing.B) {
-	l := slog.New(slog.NewTextHandler(io.Discard, nil)).With(
-		slog.String("subsystem", "bench"),
-		slog.Int("localIndex", 1234),
+	l := slog.New(slog.DiscardHandler).With(
+		"subsystem", "bench",
+		"localIndex", 1234,
 	)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		l.Info("hello", slog.Int("i", i))
+		l.Info("hello", "i", i)
 	}
 }
 
 func BenchmarkLogger_Nebula_DerivedInfo(b *testing.B) {
 	l := NewLogger(io.Discard).With(
-		slog.String("subsystem", "bench"),
-		slog.Int("localIndex", 1234),
+		"subsystem", "bench",
+		"localIndex", 1234,
 	)
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		l.Info("hello", slog.Int("i", i))
+		l.Info("hello", "i", i)
 	}
 }
 
@@ -60,31 +60,31 @@ func BenchmarkLogger_Nebula_DerivedInfo(b *testing.B) {
 // the active level. This is the dominant pattern in inside.go/outside.go and
 // what we pay on every packet.
 func BenchmarkLogger_Stock_DerivedEnabledGateMiss(b *testing.B) {
-	l := slog.New(slog.NewTextHandler(io.Discard, nil)).With(
-		slog.String("subsystem", "bench"),
-		slog.Int("localIndex", 1234),
+	l := slog.New(slog.DiscardHandler).With(
+		"subsystem", "bench",
+		"localIndex", 1234,
 	)
 	ctx := context.Background()
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if l.Enabled(ctx, slog.LevelDebug) {
-			l.Debug("hello", slog.Int("i", i))
+			l.Debug("hello", "i", i)
 		}
 	}
 }
 
 func BenchmarkLogger_Nebula_DerivedEnabledGateMiss(b *testing.B) {
 	l := NewLogger(io.Discard).With(
-		slog.String("subsystem", "bench"),
-		slog.Int("localIndex", 1234),
+		"subsystem", "bench",
+		"localIndex", 1234,
 	)
 	ctx := context.Background()
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if l.Enabled(ctx, slog.LevelDebug) {
-			l.Debug("hello", slog.Int("i", i))
+			l.Debug("hello", "i", i)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func Main(c *config.C, configTest bool, buildVersion string, l *slog.Logger, dev
 	c.RegisterReloadCallback(func(c *config.C) {
 		err := configLogger(l, c)
 		if err != nil {
-			l.Error("Failed to configure the logger", slog.Any("error", err))
+			l.Error("Failed to configure the logger", "error", err)
 		}
 	})
 
@@ -65,7 +65,7 @@ func Main(c *config.C, configTest bool, buildVersion string, l *slog.Logger, dev
 	if err != nil {
 		return nil, util.ContextualizeIfNeeded("Error while loading firewall rules", err)
 	}
-	l.Info("Firewall started", slog.Any("firewallHashes", fw.GetRuleHashes()))
+	l.Info("Firewall started", "firewallHashes", fw.GetRuleHashes())
 
 	ssh, err := sshd.NewSSHServer(l.With("subsystem", "sshd"))
 	if err != nil {
@@ -76,7 +76,7 @@ func Main(c *config.C, configTest bool, buildVersion string, l *slog.Logger, dev
 	if c.GetBool("sshd.enabled", false) {
 		sshStart, err = configSSH(l, ssh, c)
 		if err != nil {
-			l.Warn("Failed to configure sshd, ssh debugging will not be available", slog.Any("error", err))
+			l.Warn("Failed to configure sshd, ssh debugging will not be available", "error", err)
 			sshStart = nil
 		}
 	}
@@ -94,7 +94,7 @@ func Main(c *config.C, configTest bool, buildVersion string, l *slog.Logger, dev
 			routines = 1
 		}
 		if routines > 1 {
-			l.Info("Using multiple routines", slog.Int("routines", routines))
+			l.Info("Using multiple routines", "routines", routines)
 		}
 	} else {
 		// deprecated and undocumented
@@ -102,7 +102,7 @@ func Main(c *config.C, configTest bool, buildVersion string, l *slog.Logger, dev
 		udpQueues := c.GetInt("listen.routines", 1)
 		routines = max(tunQueues, udpQueues)
 		if routines != 1 {
-			l.Warn("Setting tun.routines and listen.routines is deprecated. Use `routines` instead", slog.Int("routines", routines))
+			l.Warn("Setting tun.routines and listen.routines is deprecated. Use `routines` instead", "routines", routines)
 		}
 	}
 
@@ -115,7 +115,7 @@ func Main(c *config.C, configTest bool, buildVersion string, l *slog.Logger, dev
 		conntrackCacheTimeout = 1 * time.Second
 	}
 	if conntrackCacheTimeout > 0 {
-		l.Info("Using routine-local conntrack cache", slog.Duration("duration", conntrackCacheTimeout))
+		l.Info("Using routine-local conntrack cache", "duration", conntrackCacheTimeout)
 	}
 
 	var tun overlay.Device
@@ -161,7 +161,7 @@ func Main(c *config.C, configTest bool, buildVersion string, l *slog.Logger, dev
 		}
 
 		for i := 0; i < routines; i++ {
-			l.Info("listening", slog.Any("addr", netip.AddrPortFrom(listenHost, uint16(port))))
+			l.Info("listening", "addr", netip.AddrPortFrom(listenHost, uint16(port)))
 			udpServer, err := udp.NewListener(l, listenHost, port, routines > 1, c.GetInt("listen.batch", 64))
 			if err != nil {
 				return nil, util.NewContextualError("Failed to open udp listener", m{"queue": i}, err)
@@ -212,7 +212,7 @@ func Main(c *config.C, configTest bool, buildVersion string, l *slog.Logger, dev
 
 	ds, err := newDnsServerFromConfig(ctx, l, pki.getCertState(), hostMap, c)
 	if err != nil {
-		l.Warn("Failed to start DNS responder", slog.Any("error", err))
+		l.Warn("Failed to start DNS responder", "error", err)
 	}
 
 	ifConfig := &InterfaceConfig{

--- a/outside.go
+++ b/outside.go
@@ -26,9 +26,9 @@ func (f *Interface) readOutsidePackets(via ViaSender, out []byte, packet []byte,
 		// Hole punch packets are 0 or 1 byte big, so lets ignore printing those errors
 		if len(packet) > 1 {
 			f.l.Info("Error while parsing inbound packet",
-				slog.Any("from", via),
-				slog.Any("error", err),
-				slog.Any("packet", packet),
+				"from", via,
+				"error", err,
+				"packet", packet,
 			)
 		}
 		return
@@ -38,7 +38,7 @@ func (f *Interface) readOutsidePackets(via ViaSender, out []byte, packet []byte,
 	if !via.IsRelayed {
 		if f.myVpnNetworksTable.Contains(via.UdpAddr.Addr()) {
 			if f.l.Enabled(context.Background(), slog.LevelDebug) {
-				f.l.Debug("Refusing to process double encrypted packet", slog.Any("from", via))
+				f.l.Debug("Refusing to process double encrypted packet", "from", via)
 			}
 			return
 		}
@@ -93,8 +93,8 @@ func (f *Interface) readOutsidePackets(via ViaSender, out []byte, packet []byte,
 				// The only way this happens is if hostmap has an index to the correct HostInfo, but the HostInfo is missing
 				// its internal mapping. This should never happen.
 				hostinfo.logger(f.l).Error("HostInfo missing remote relay index",
-					slog.Any("vpnAddrs", hostinfo.vpnAddrs),
-					slog.Uint64("remoteIndex", uint64(h.RemoteIndex)),
+					"vpnAddrs", hostinfo.vpnAddrs,
+					"remoteIndex", uint64(h.RemoteIndex),
 				)
 				return
 			}
@@ -117,9 +117,9 @@ func (f *Interface) readOutsidePackets(via ViaSender, out []byte, packet []byte,
 				targetHI, targetRelay, err := f.hostMap.QueryVpnAddrsRelayFor(hostinfo.vpnAddrs, relay.PeerAddr)
 				if err != nil {
 					hostinfo.logger(f.l).Info("Failed to find target host info by ip",
-						slog.Any("relayTo", relay.PeerAddr),
-						slog.Any("error", err),
-						slog.Any("hostinfo.vpnAddrs", hostinfo.vpnAddrs),
+						"relayTo", relay.PeerAddr,
+						"error", err,
+						"hostinfo.vpnAddrs", hostinfo.vpnAddrs,
 					)
 					return
 				}
@@ -137,9 +137,9 @@ func (f *Interface) readOutsidePackets(via ViaSender, out []byte, packet []byte,
 					}
 				} else {
 					hostinfo.logger(f.l).Info("Unexpected target relay state",
-						slog.Any("relayTo", relay.PeerAddr),
-						slog.Any("relayFrom", hostinfo.vpnAddrs[0]),
-						slog.Any("targetRelayState", targetRelay.State),
+						"relayTo", relay.PeerAddr,
+						"relayFrom", hostinfo.vpnAddrs[0],
+						"targetRelayState", targetRelay.State,
 					)
 					return
 				}
@@ -155,9 +155,9 @@ func (f *Interface) readOutsidePackets(via ViaSender, out []byte, packet []byte,
 		d, err := f.decrypt(hostinfo, h.MessageCounter, out, packet, h, nb)
 		if err != nil {
 			hostinfo.logger(f.l).Error("Failed to decrypt lighthouse packet",
-				slog.Any("error", err),
-				slog.Any("from", via),
-				slog.Any("packet", packet),
+				"error", err,
+				"from", via,
+				"packet", packet,
 			)
 			return
 		}
@@ -176,9 +176,9 @@ func (f *Interface) readOutsidePackets(via ViaSender, out []byte, packet []byte,
 		d, err := f.decrypt(hostinfo, h.MessageCounter, out, packet, h, nb)
 		if err != nil {
 			hostinfo.logger(f.l).Error("Failed to decrypt test packet",
-				slog.Any("error", err),
-				slog.Any("from", via),
-				slog.Any("packet", packet),
+				"error", err,
+				"from", via,
+				"packet", packet,
 			)
 			return
 		}
@@ -213,14 +213,14 @@ func (f *Interface) readOutsidePackets(via ViaSender, out []byte, packet []byte,
 		_, err = f.decrypt(hostinfo, h.MessageCounter, out, packet, h, nb)
 		if err != nil {
 			hostinfo.logger(f.l).Error("Failed to decrypt CloseTunnel packet",
-				slog.Any("error", err),
-				slog.Any("from", via),
-				slog.Any("packet", packet),
+				"error", err,
+				"from", via,
+				"packet", packet,
 			)
 			return
 		}
 
-		hostinfo.logger(f.l).Info("Close tunnel received, tearing down.", slog.Any("from", via))
+		hostinfo.logger(f.l).Info("Close tunnel received, tearing down.", "from", via)
 
 		f.closeTunnel(hostinfo)
 		return
@@ -233,9 +233,9 @@ func (f *Interface) readOutsidePackets(via ViaSender, out []byte, packet []byte,
 		d, err := f.decrypt(hostinfo, h.MessageCounter, out, packet, h, nb)
 		if err != nil {
 			hostinfo.logger(f.l).Error("Failed to decrypt Control packet",
-				slog.Any("error", err),
-				slog.Any("from", via),
-				slog.Any("packet", packet),
+				"error", err,
+				"from", via,
+				"packet", packet,
 			)
 			return
 		}
@@ -245,7 +245,7 @@ func (f *Interface) readOutsidePackets(via ViaSender, out []byte, packet []byte,
 	default:
 		f.messageMetrics.Rx(h.Type, h.Subtype, 1)
 		if f.l.Enabled(context.Background(), slog.LevelDebug) {
-			hostinfo.logger(f.l).Debug("Unexpected packet received", slog.Any("from", via))
+			hostinfo.logger(f.l).Debug("Unexpected packet received", "from", via)
 		}
 		return
 	}
@@ -273,7 +273,7 @@ func (f *Interface) handleHostRoaming(hostinfo *HostInfo, via ViaSender) {
 	if !via.IsRelayed && hostinfo.remote != via.UdpAddr {
 		if !f.lightHouse.GetRemoteAllowList().AllowAll(hostinfo.vpnAddrs, via.UdpAddr.Addr()) {
 			if f.l.Enabled(context.Background(), slog.LevelDebug) {
-				hostinfo.logger(f.l).Debug("lighthouse.remote_allow_list denied roaming", slog.Any("newAddr", via.UdpAddr))
+				hostinfo.logger(f.l).Debug("lighthouse.remote_allow_list denied roaming", "newAddr", via.UdpAddr)
 			}
 			return
 		}
@@ -281,17 +281,17 @@ func (f *Interface) handleHostRoaming(hostinfo *HostInfo, via ViaSender) {
 		if !hostinfo.lastRoam.IsZero() && via.UdpAddr == hostinfo.lastRoamRemote && time.Since(hostinfo.lastRoam) < RoamingSuppressSeconds*time.Second {
 			if f.l.Enabled(context.Background(), slog.LevelDebug) {
 				hostinfo.logger(f.l).Debug("Suppressing roam back to previous remote",
-					slog.Int("suppressSeconds", RoamingSuppressSeconds),
-					slog.Any("udpAddr", hostinfo.remote),
-					slog.Any("newAddr", via.UdpAddr),
+					"suppressSeconds", RoamingSuppressSeconds,
+					"udpAddr", hostinfo.remote,
+					"newAddr", via.UdpAddr,
 				)
 			}
 			return
 		}
 
 		hostinfo.logger(f.l).Info("Host roamed to new udp ip/port.",
-			slog.Any("udpAddr", hostinfo.remote),
-			slog.Any("newAddr", via.UdpAddr),
+			"udpAddr", hostinfo.remote,
+			"newAddr", via.UdpAddr,
 		)
 		hostinfo.lastRoam = time.Now()
 		hostinfo.lastRoamRemote = hostinfo.remote
@@ -524,7 +524,7 @@ func (f *Interface) decrypt(hostinfo *HostInfo, mc uint64, out []byte, packet []
 
 	if !hostinfo.ConnectionState.window.Update(f.l, mc) {
 		if f.l.Enabled(context.Background(), slog.LevelDebug) {
-			hostinfo.logger(f.l).Debug("dropping out of window packet", slog.Any("header", h))
+			hostinfo.logger(f.l).Debug("dropping out of window packet", "header", h)
 		}
 		return nil, errors.New("out of window packet")
 	}
@@ -537,22 +537,22 @@ func (f *Interface) decryptToTun(hostinfo *HostInfo, messageCounter uint64, out 
 
 	out, err = hostinfo.ConnectionState.dKey.DecryptDanger(out, packet[:header.Len], packet[header.Len:], messageCounter, nb)
 	if err != nil {
-		hostinfo.logger(f.l).Error("Failed to decrypt packet", slog.Any("error", err))
+		hostinfo.logger(f.l).Error("Failed to decrypt packet", "error", err)
 		return false
 	}
 
 	err = newPacket(out, true, fwPacket)
 	if err != nil {
 		hostinfo.logger(f.l).Warn("Error while validating inbound packet",
-			slog.Any("error", err),
-			slog.Any("packet", out),
+			"error", err,
+			"packet", out,
 		)
 		return false
 	}
 
 	if !hostinfo.ConnectionState.window.Update(f.l, messageCounter) {
 		if f.l.Enabled(context.Background(), slog.LevelDebug) {
-			hostinfo.logger(f.l).Debug("dropping out of window packet", slog.Any("fwPacket", fwPacket))
+			hostinfo.logger(f.l).Debug("dropping out of window packet", "fwPacket", fwPacket)
 		}
 		return false
 	}
@@ -564,8 +564,8 @@ func (f *Interface) decryptToTun(hostinfo *HostInfo, messageCounter uint64, out 
 		f.rejectOutside(out, hostinfo.ConnectionState, hostinfo, nb, packet, q)
 		if f.l.Enabled(context.Background(), slog.LevelDebug) {
 			hostinfo.logger(f.l).Debug("dropping inbound packet",
-				slog.Any("fwPacket", fwPacket),
-				slog.Any("reason", dropReason),
+				"fwPacket", fwPacket,
+				"reason", dropReason,
 			)
 		}
 		return false
@@ -574,7 +574,7 @@ func (f *Interface) decryptToTun(hostinfo *HostInfo, messageCounter uint64, out 
 	f.connectionManager.In(hostinfo)
 	_, err = f.readers[q].Write(out)
 	if err != nil {
-		f.l.Error("Failed to write to tun", slog.Any("error", err))
+		f.l.Error("Failed to write to tun", "error", err)
 	}
 	return true
 }
@@ -592,8 +592,8 @@ func (f *Interface) sendRecvError(endpoint netip.AddrPort, index uint32) {
 	_ = f.outside.WriteTo(b, endpoint)
 	if f.l.Enabled(context.Background(), slog.LevelDebug) {
 		f.l.Debug("Recv error sent",
-			slog.Uint64("index", uint64(index)),
-			slog.Any("udpAddr", endpoint),
+			"index", uint64(index),
+			"udpAddr", endpoint,
 		)
 	}
 }
@@ -601,29 +601,29 @@ func (f *Interface) sendRecvError(endpoint netip.AddrPort, index uint32) {
 func (f *Interface) handleRecvError(addr netip.AddrPort, h *header.H) {
 	if !f.acceptRecvErrorConfig.ShouldRecvError(addr) {
 		f.l.Debug("Recv error received, ignoring",
-			slog.Uint64("index", uint64(h.RemoteIndex)),
-			slog.Any("udpAddr", addr),
+			"index", uint64(h.RemoteIndex),
+			"udpAddr", addr,
 		)
 		return
 	}
 
 	if f.l.Enabled(context.Background(), slog.LevelDebug) {
 		f.l.Debug("Recv error received",
-			slog.Uint64("index", uint64(h.RemoteIndex)),
-			slog.Any("udpAddr", addr),
+			"index", uint64(h.RemoteIndex),
+			"udpAddr", addr,
 		)
 	}
 
 	hostinfo := f.hostMap.QueryReverseIndex(h.RemoteIndex)
 	if hostinfo == nil {
-		f.l.Debug("Did not find remote index in main hostmap", slog.Uint64("remoteIndex", uint64(h.RemoteIndex)))
+		f.l.Debug("Did not find remote index in main hostmap", "remoteIndex", uint64(h.RemoteIndex))
 		return
 	}
 
 	if hostinfo.remote.IsValid() && hostinfo.remote != addr {
 		f.l.Info("Someone spoofing recv_errors?",
-			slog.Any("addr", addr),
-			slog.Any("hostinfoRemote", hostinfo.remote),
+			"addr", addr,
+			"hostinfoRemote", hostinfo.remote,
 		)
 		return
 	}

--- a/overlay/route.go
+++ b/overlay/route.go
@@ -53,8 +53,8 @@ func makeRouteTree(l *slog.Logger, routes []Route, allowMTU bool) (*bart.Table[r
 	for _, r := range routes {
 		if !allowMTU && r.MTU > 0 {
 			l.Warn("route MTU is not supported on this platform",
-				slog.String("goos", runtime.GOOS),
-				slog.Any("route", r),
+				"goos", runtime.GOOS,
+				"route", r,
 			)
 		}
 

--- a/overlay/tun_darwin.go
+++ b/overlay/tun_darwin.go
@@ -389,7 +389,7 @@ func (t *tun) addRoutes(logErrors bool) error {
 		err := addRoute(r.Cidr, t.linkAddr)
 		if err != nil {
 			if errors.Is(err, unix.EEXIST) {
-				t.l.Warn("unable to add unsafe_route, identical route already exists", slog.Any("route", r.Cidr))
+				t.l.Warn("unable to add unsafe_route, identical route already exists", "route", r.Cidr)
 			} else {
 				retErr := util.NewContextualError("Failed to add route", map[string]any{"route": r}, err)
 				if logErrors {
@@ -399,7 +399,7 @@ func (t *tun) addRoutes(logErrors bool) error {
 				}
 			}
 		} else {
-			t.l.Info("Added route", slog.Any("route", r))
+			t.l.Info("Added route", "route", r)
 		}
 	}
 
@@ -414,9 +414,9 @@ func (t *tun) removeRoutes(routes []Route) error {
 
 		err := delRoute(r.Cidr, t.linkAddr)
 		if err != nil {
-			t.l.Error("Failed to remove route", slog.Any("error", err), slog.Any("route", r))
+			t.l.Error("Failed to remove route", "error", err, "route", r)
 		} else {
-			t.l.Info("Removed route", slog.Any("route", r))
+			t.l.Info("Removed route", "route", r)
 		}
 	}
 	return nil

--- a/overlay/tun_disabled.go
+++ b/overlay/tun_disabled.go
@@ -69,7 +69,7 @@ func (t *disabledTun) Read(b []byte) (int, error) {
 
 	t.tx.Inc(1)
 	if t.l.Enabled(context.Background(), slog.LevelDebug) {
-		t.l.Debug("Write payload", slog.Any("raw", prettyPacket(r)))
+		t.l.Debug("Write payload", "raw", prettyPacket(r))
 	}
 
 	return copy(b, r), nil
@@ -98,10 +98,10 @@ func (t *disabledTun) Write(b []byte) (int, error) {
 	// Check for ICMP Echo Request before spending time doing the full parsing
 	if t.handleICMPEchoRequest(b) {
 		if t.l.Enabled(context.Background(), slog.LevelDebug) {
-			t.l.Debug("Disabled tun responded to ICMP Echo Request", slog.Any("raw", prettyPacket(b)))
+			t.l.Debug("Disabled tun responded to ICMP Echo Request", "raw", prettyPacket(b))
 		}
 	} else if t.l.Enabled(context.Background(), slog.LevelDebug) {
-		t.l.Debug("Disabled tun received unexpected payload", slog.Any("raw", prettyPacket(b)))
+		t.l.Debug("Disabled tun received unexpected payload", "raw", prettyPacket(b))
 	}
 	return len(b), nil
 }

--- a/overlay/tun_freebsd.go
+++ b/overlay/tun_freebsd.go
@@ -245,7 +245,7 @@ func (t *tun) Close() error {
 
 	if t.fd >= 0 {
 		if err := unix.Close(t.fd); err != nil {
-			t.l.Error("Error closing device", slog.Any("error", err))
+			t.l.Error("Error closing device", "error", err)
 		}
 		t.fd = -1
 	}
@@ -266,7 +266,7 @@ func (t *tun) Close() error {
 			err = ioctl(uintptr(s), syscall.SIOCIFDESTROY, uintptr(unsafe.Pointer(&ifreq)))
 		}
 		if err != nil {
-			t.l.Error("Error destroying tunnel", slog.Any("error", err))
+			t.l.Error("Error destroying tunnel", "error", err)
 		}
 	}()
 
@@ -586,7 +586,7 @@ func (t *tun) addRoutes(logErrors bool) error {
 				return retErr
 			}
 		} else {
-			t.l.Info("Added route", slog.Any("route", r))
+			t.l.Info("Added route", "route", r)
 		}
 	}
 
@@ -601,9 +601,9 @@ func (t *tun) removeRoutes(routes []Route) error {
 
 		err := delRoute(r.Cidr, t.linkAddr)
 		if err != nil {
-			t.l.Error("Failed to remove route", slog.Any("error", err), slog.Any("route", r))
+			t.l.Error("Failed to remove route", "error", err, "route", r)
 		} else {
-			t.l.Info("Removed route", slog.Any("route", r))
+			t.l.Info("Removed route", "route", r)
 		}
 	}
 	return nil

--- a/overlay/tun_linux.go
+++ b/overlay/tun_linux.go
@@ -378,7 +378,7 @@ func (t *tun) reload(c *config.C, initial bool) error {
 	if !initial {
 		if oldMaxMTU != newMaxMTU {
 			t.setMTU()
-			t.l.Info("Set max MTU", slog.Int("mtu", t.MaxMTU), slog.Int("oldMTU", oldMaxMTU))
+			t.l.Info("Set max MTU", "mtu", t.MaxMTU, "oldMTU", oldMaxMTU)
 		}
 
 		if oldDefaultMTU != newDefaultMTU {
@@ -387,7 +387,7 @@ func (t *tun) reload(c *config.C, initial bool) error {
 				if err != nil {
 					t.l.Warn(err.Error())
 				} else {
-					t.l.Info("Set default MTU", slog.Int("mtu", t.DefaultMTU), slog.Int("oldMTU", oldDefaultMTU))
+					t.l.Info("Set default MTU", "mtu", t.DefaultMTU, "oldMTU", oldDefaultMTU)
 				}
 			}
 		}
@@ -492,9 +492,9 @@ func (t *tun) addIPs(link netlink.Link) error {
 		}
 		err = netlink.AddrDel(link, &al[i])
 		if err != nil {
-			t.l.Error("failed to remove address from tun address list", slog.Any("error", err))
+			t.l.Error("failed to remove address from tun address list", "error", err)
 		} else {
-			t.l.Info("removed address not listed in cert(s)", slog.String("removed", al[i].String()))
+			t.l.Info("removed address not listed in cert(s)", "removed", al[i].String())
 		}
 	}
 
@@ -538,12 +538,12 @@ func (t *tun) Activate() error {
 	ifrq := ifreqQLEN{Name: devName, Value: int32(t.TXQueueLen)}
 	if err = ioctl(t.ioctlFd, unix.SIOCSIFTXQLEN, uintptr(unsafe.Pointer(&ifrq))); err != nil {
 		// If we can't set the queue length nebula will still work but it may lead to packet loss
-		t.l.Error("Failed to set tun tx queue length", slog.Any("error", err))
+		t.l.Error("Failed to set tun tx queue length", "error", err)
 	}
 
 	const modeNone = 1
 	if err = netlink.LinkSetIP6AddrGenMode(link, modeNone); err != nil {
-		t.l.Warn("Failed to disable link local address generation", slog.Any("error", err))
+		t.l.Warn("Failed to disable link local address generation", "error", err)
 	}
 
 	if err = t.addIPs(link); err != nil {
@@ -582,7 +582,7 @@ func (t *tun) setMTU() {
 	ifm := ifreqMTU{Name: t.deviceBytes(), MTU: int32(t.MaxMTU)}
 	if err := ioctl(t.ioctlFd, unix.SIOCSIFMTU, uintptr(unsafe.Pointer(&ifm))); err != nil {
 		// This is currently a non fatal condition because the route table must have the MTU set appropriately as well
-		t.l.Error("Failed to set tun mtu", slog.Any("error", err))
+		t.l.Error("Failed to set tun mtu", "error", err)
 	}
 }
 
@@ -605,7 +605,7 @@ func (t *tun) setDefaultRoute(cidr netip.Prefix) error {
 	}
 	err := netlink.RouteReplace(&nr)
 	if err != nil {
-		t.l.Warn("Failed to set default route MTU, retrying", slog.Any("error", err), slog.Any("cidr", cidr))
+		t.l.Warn("Failed to set default route MTU, retrying", "error", err, "cidr", cidr)
 		//retry twice more -- on some systems there appears to be a race condition where if we set routes too soon, netlink says `invalid argument`
 		for i := 0; i < 2; i++ {
 			time.Sleep(100 * time.Millisecond)
@@ -614,9 +614,9 @@ func (t *tun) setDefaultRoute(cidr netip.Prefix) error {
 				break
 			} else {
 				t.l.Warn("Failed to set default route MTU, retrying",
-					slog.Any("error", err),
-					slog.Any("cidr", cidr),
-					slog.Int("mtu", t.DefaultMTU),
+					"error", err,
+					"cidr", cidr,
+					"mtu", t.DefaultMTU,
 				)
 			}
 		}
@@ -662,7 +662,7 @@ func (t *tun) addRoutes(logErrors bool) error {
 				return retErr
 			}
 		} else {
-			t.l.Info("Added route", slog.Any("route", r))
+			t.l.Info("Added route", "route", r)
 		}
 	}
 
@@ -694,9 +694,9 @@ func (t *tun) removeRoutes(routes []Route) {
 
 		err := netlink.RouteDel(&nr)
 		if err != nil {
-			t.l.Error("Failed to remove route", slog.Any("error", err), slog.Any("route", r))
+			t.l.Error("Failed to remove route", "error", err, "route", r)
 		} else {
-			t.l.Info("Removed route", slog.Any("route", r))
+			t.l.Info("Removed route", "route", r)
 		}
 	}
 }
@@ -725,11 +725,11 @@ func (t *tun) watchRoutes() {
 	netlinkOptions := netlink.RouteSubscribeOptions{
 		ReceiveBufferSize:      t.useSystemRoutesBufferSize,
 		ReceiveBufferForceSize: t.useSystemRoutesBufferSize != 0,
-		ErrorCallback:          func(e error) { t.l.Error("netlink error", slog.Any("error", e)) },
+		ErrorCallback:          func(e error) { t.l.Error("netlink error", "error", e) },
 	}
 
 	if err := netlink.RouteSubscribeWithOptions(rch, doneChan, netlinkOptions); err != nil {
-		t.l.Error("failed to subscribe to system route changes", slog.Any("error", err))
+		t.l.Error("failed to subscribe to system route changes", "error", err)
 		return
 	}
 
@@ -771,7 +771,7 @@ func (t *tun) getGatewaysFromRoute(r *netlink.Route) routing.Gateways {
 
 	link, err := netlink.LinkByName(t.Device)
 	if err != nil {
-		t.l.Error("Ignoring route update: failed to get link by name", slog.String("deviceName", t.Device))
+		t.l.Error("Ignoring route update: failed to get link by name", "deviceName", t.Device)
 		return gateways
 	}
 
@@ -783,10 +783,10 @@ func (t *tun) getGatewaysFromRoute(r *netlink.Route) routing.Gateways {
 				gateways = append(gateways, routing.NewGateway(gwAddr, 1))
 			} else {
 				// Gateway isn't in our overlay network, ignore
-				t.l.Debug("Ignoring route update, gateway is not in our network", slog.Any("route", r))
+				t.l.Debug("Ignoring route update, gateway is not in our network", "route", r)
 			}
 		} else {
-			t.l.Debug("Ignoring route update, invalid gateway or via address", slog.Any("route", r))
+			t.l.Debug("Ignoring route update, invalid gateway or via address", "route", r)
 		}
 	}
 
@@ -799,10 +799,10 @@ func (t *tun) getGatewaysFromRoute(r *netlink.Route) routing.Gateways {
 					gateways = append(gateways, routing.NewGateway(gwAddr, p.Hops+1))
 				} else {
 					// Gateway isn't in our overlay network, ignore
-					t.l.Debug("Ignoring route update, gateway is not in our network", slog.Any("route", r))
+					t.l.Debug("Ignoring route update, gateway is not in our network", "route", r)
 				}
 			} else {
-				t.l.Debug("Ignoring route update, invalid gateway or via address", slog.Any("route", r))
+				t.l.Debug("Ignoring route update, invalid gateway or via address", "route", r)
 			}
 		}
 	}
@@ -834,18 +834,18 @@ func (t *tun) updateRoutes(r netlink.RouteUpdate) {
 	gateways := t.getGatewaysFromRoute(&r.Route)
 	if len(gateways) == 0 {
 		// No gateways relevant to our network, no routing changes required.
-		t.l.Debug("Ignoring route update, no gateways", slog.Any("route", r))
+		t.l.Debug("Ignoring route update, no gateways", "route", r)
 		return
 	}
 
 	if r.Dst == nil {
-		t.l.Debug("Ignoring route update, no destination address", slog.Any("route", r))
+		t.l.Debug("Ignoring route update, no destination address", "route", r)
 		return
 	}
 
 	dstAddr, ok := netip.AddrFromSlice(r.Dst.IP)
 	if !ok {
-		t.l.Debug("Ignoring route update, invalid destination address", slog.Any("route", r))
+		t.l.Debug("Ignoring route update, invalid destination address", "route", r)
 		return
 	}
 
@@ -856,12 +856,12 @@ func (t *tun) updateRoutes(r netlink.RouteUpdate) {
 
 	t.routesFromSystemLock.Lock()
 	if r.Type == unix.RTM_NEWROUTE {
-		t.l.Info("Adding route", slog.Any("destination", dst), slog.Any("via", gateways))
+		t.l.Info("Adding route", "destination", dst, "via", gateways)
 		t.routesFromSystem[dst] = gateways
 		newTree.Insert(dst, gateways)
 
 	} else {
-		t.l.Info("Removing route", slog.Any("destination", dst), slog.Any("via", gateways))
+		t.l.Info("Removing route", "destination", dst, "via", gateways)
 		delete(t.routesFromSystem, dst)
 		newTree.Delete(dst)
 	}
@@ -892,18 +892,18 @@ func (t *tun) Close() error {
 		}
 		err := t.readers[i].Close()
 		if err != nil {
-			t.l.Error("error closing tun reader", slog.Int("reader", i), slog.Any("error", err))
+			t.l.Error("error closing tun reader", "reader", i, "error", err)
 		} else {
-			t.l.Info("closed tun reader", slog.Int("reader", i))
+			t.l.Info("closed tun reader", "reader", i)
 		}
 	}
 
 	//this is t.readers[0] too
 	err := t.tunFile.Close()
 	if err != nil {
-		t.l.Error("error closing tun reader", slog.Int("reader", 0), slog.Any("error", err))
+		t.l.Error("error closing tun reader", "reader", 0, "error", err)
 	} else {
-		t.l.Info("closed tun reader", slog.Int("reader", 0))
+		t.l.Info("closed tun reader", "reader", 0)
 	}
 	return err
 }

--- a/overlay/tun_netbsd.go
+++ b/overlay/tun_netbsd.go
@@ -92,7 +92,7 @@ func newTun(c *config.C, l *slog.Logger, vpnNetworks []netip.Prefix, _ bool) (*t
 
 	err = unix.SetNonblock(fd, true)
 	if err != nil {
-		l.Warn("Failed to set the tun device as nonblocking", slog.Any("error", err))
+		l.Warn("Failed to set the tun device as nonblocking", "error", err)
 	}
 
 	t := &tun{
@@ -416,7 +416,7 @@ func (t *tun) addRoutes(logErrors bool) error {
 				return retErr
 			}
 		} else {
-			t.l.Info("Added route", slog.Any("route", r))
+			t.l.Info("Added route", "route", r)
 		}
 	}
 
@@ -431,9 +431,9 @@ func (t *tun) removeRoutes(routes []Route) error {
 
 		err := delRoute(r.Cidr, t.vpnNetworks)
 		if err != nil {
-			t.l.Error("Failed to remove route", slog.Any("error", err), slog.Any("route", r))
+			t.l.Error("Failed to remove route", "error", err, "route", r)
 		} else {
-			t.l.Info("Removed route", slog.Any("route", r))
+			t.l.Info("Removed route", "route", r)
 		}
 	}
 	return nil

--- a/overlay/tun_openbsd.go
+++ b/overlay/tun_openbsd.go
@@ -85,7 +85,7 @@ func newTun(c *config.C, l *slog.Logger, vpnNetworks []netip.Prefix, _ bool) (*t
 
 	err = unix.SetNonblock(fd, true)
 	if err != nil {
-		l.Warn("Failed to set the tun device as nonblocking", slog.Any("error", err))
+		l.Warn("Failed to set the tun device as nonblocking", "error", err)
 	}
 
 	t := &tun{
@@ -336,7 +336,7 @@ func (t *tun) addRoutes(logErrors bool) error {
 				return retErr
 			}
 		} else {
-			t.l.Info("Added route", slog.Any("route", r))
+			t.l.Info("Added route", "route", r)
 		}
 	}
 
@@ -351,9 +351,9 @@ func (t *tun) removeRoutes(routes []Route) error {
 
 		err := delRoute(r.Cidr, t.vpnNetworks)
 		if err != nil {
-			t.l.Error("Failed to remove route", slog.Any("error", err), slog.Any("route", r))
+			t.l.Error("Failed to remove route", "error", err, "route", r)
 		} else {
-			t.l.Info("Removed route", slog.Any("route", r))
+			t.l.Info("Removed route", "route", r)
 		}
 	}
 	return nil

--- a/overlay/tun_tester.go
+++ b/overlay/tun_tester.go
@@ -63,7 +63,7 @@ func (t *TestTun) Send(packet []byte) {
 	}
 
 	if t.l.Enabled(context.Background(), slog.LevelDebug) {
-		t.l.Debug("Tun receiving injected packet", slog.Int("dataLen", len(packet)))
+		t.l.Debug("Tun receiving injected packet", "dataLen", len(packet))
 	}
 	t.rxPackets <- packet
 }

--- a/overlay/tun_windows.go
+++ b/overlay/tun_windows.go
@@ -71,7 +71,7 @@ func newTun(c *config.C, l *slog.Logger, vpnNetworks []netip.Prefix, _ bool) (*w
 	if err != nil {
 		// Windows 10 has an issue with unclean shutdowns not fully cleaning up the wintun device.
 		// Trying a second time resolves the issue.
-		l.Debug("Failed to create wintun device, retrying", slog.Any("error", err))
+		l.Debug("Failed to create wintun device, retrying", "error", err)
 		tunDevice, err = wintun.CreateTUNWithRequestedGUID(deviceName, guid, t.MTU)
 		if err != nil {
 			return nil, &NameError{
@@ -170,7 +170,7 @@ func (t *winTun) addRoutes(logErrors bool) error {
 				return retErr
 			}
 		} else {
-			t.l.Info("Added route", slog.Any("route", r))
+			t.l.Info("Added route", "route", r)
 		}
 
 		if !foundDefault4 {
@@ -208,9 +208,9 @@ func (t *winTun) removeRoutes(routes []Route) error {
 		// See comment on luid.AddRoute
 		err := luid.DeleteRoute(r.Cidr, r.Via[0].Addr())
 		if err != nil {
-			t.l.Error("Failed to remove route", slog.Any("error", err), slog.Any("route", r))
+			t.l.Error("Failed to remove route", "error", err, "route", r)
 		} else {
-			t.l.Info("Removed route", slog.Any("route", r))
+			t.l.Info("Removed route", "route", r)
 		}
 	}
 	return nil

--- a/pki.go
+++ b/pki.go
@@ -182,9 +182,9 @@ func (p *PKI) reloadCerts(c *config.C, initial bool) *util.ContextualError {
 	p.cs.Store(newState)
 
 	if initial {
-		p.l.Debug("Client nebula certificate(s)", slog.Any("cert", newState))
+		p.l.Debug("Client nebula certificate(s)", "cert", newState)
 	} else {
-		p.l.Info("Client certificate(s) refreshed from disk", slog.Any("cert", newState))
+		p.l.Info("Client certificate(s) refreshed from disk", "cert", newState)
 	}
 	return nil
 }
@@ -196,7 +196,7 @@ func (p *PKI) reloadCAPool(c *config.C) *util.ContextualError {
 	}
 
 	p.caPool.Store(caPool)
-	p.l.Debug("Trusted CA fingerprints", slog.Any("fingerprints", caPool.GetFingerprints()))
+	p.l.Debug("Trusted CA fingerprints", "fingerprints", caPool.GetFingerprints())
 	return nil
 }
 
@@ -512,7 +512,7 @@ func loadCAPoolFromConfig(l *slog.Logger, c *config.C) (*cert.CAPool, error) {
 		for _, crt := range caPool.CAs {
 			if crt.Certificate.Expired(time.Now()) {
 				expired++
-				l.Warn("expired certificate present in CA pool", slog.Any("cert", crt))
+				l.Warn("expired certificate present in CA pool", "cert", crt)
 			}
 		}
 
@@ -530,7 +530,7 @@ func loadCAPoolFromConfig(l *slog.Logger, c *config.C) (*cert.CAPool, error) {
 			caPool.BlocklistFingerprint(fp)
 		}
 
-		l.Info("Blocklisted certificates", slog.Int("fingerprintCount", len(bl)))
+		l.Info("Blocklisted certificates", "fingerprintCount", len(bl))
 	}
 
 	return caPool, nil

--- a/punchy.go
+++ b/punchy.go
@@ -62,7 +62,7 @@ func (p *Punchy) reload(c *config.C, initial bool) {
 		p.respond.Store(yes)
 
 		if !initial {
-			p.l.Info("punchy.respond changed", slog.Bool("respond", p.GetRespond()))
+			p.l.Info("punchy.respond changed", "respond", p.GetRespond())
 		}
 	}
 
@@ -70,21 +70,21 @@ func (p *Punchy) reload(c *config.C, initial bool) {
 	if initial || c.HasChanged("punchy.delay") {
 		p.delay.Store((int64)(c.GetDuration("punchy.delay", time.Second)))
 		if !initial {
-			p.l.Info("punchy.delay changed", slog.Duration("delay", p.GetDelay()))
+			p.l.Info("punchy.delay changed", "delay", p.GetDelay())
 		}
 	}
 
 	if initial || c.HasChanged("punchy.target_all_remotes") {
 		p.punchEverything.Store(c.GetBool("punchy.target_all_remotes", false))
 		if !initial {
-			p.l.Info("punchy.target_all_remotes changed", slog.Bool("target_all_remotes", p.GetTargetEverything()))
+			p.l.Info("punchy.target_all_remotes changed", "target_all_remotes", p.GetTargetEverything())
 		}
 	}
 
 	if initial || c.HasChanged("punchy.respond_delay") {
 		p.respondDelay.Store((int64)(c.GetDuration("punchy.respond_delay", 5*time.Second)))
 		if !initial {
-			p.l.Info("punchy.respond_delay changed", slog.Duration("respond_delay", p.GetRespondDelay()))
+			p.l.Info("punchy.respond_delay changed", "respond_delay", p.GetRespondDelay())
 		}
 	}
 }

--- a/relay_manager.go
+++ b/relay_manager.go
@@ -29,7 +29,7 @@ func NewRelayManager(ctx context.Context, l *slog.Logger, hostmap *HostMap, c *c
 	c.RegisterReloadCallback(func(c *config.C) {
 		err := rm.reload(c, false)
 		if err != nil {
-			rm.l.Error("Failed to reload relay_manager", slog.Any("error", err))
+			rm.l.Error("Failed to reload relay_manager", "error", err)
 		}
 	})
 	return rm
@@ -105,10 +105,10 @@ func (rm *relayManager) EstablishRelay(relayHostInfo *HostInfo, m *NebulaControl
 		}
 
 		rm.l.Info("relayManager failed to update relay",
-			slog.Any("relay", relayHostInfo.vpnAddrs[0]),
-			slog.Any("initiatorRelayIndex", m.InitiatorRelayIndex),
-			slog.Any("relayFrom", relayFrom),
-			slog.Any("relayTo", relayTo),
+			"relay", relayHostInfo.vpnAddrs[0],
+			"initiatorRelayIndex", m.InitiatorRelayIndex,
+			"relayFrom", relayFrom,
+			"relayTo", relayTo,
 		)
 		return nil, fmt.Errorf("unknown relay")
 	}
@@ -120,7 +120,7 @@ func (rm *relayManager) HandleControlMsg(h *HostInfo, d []byte, f *Interface) {
 	msg := &NebulaControl{}
 	err := msg.Unmarshal(d)
 	if err != nil {
-		h.logger(f.l).Error("Failed to unmarshal control message", slog.Any("error", err))
+		h.logger(f.l).Error("Failed to unmarshal control message", "error", err)
 		return
 	}
 
@@ -148,11 +148,11 @@ func (rm *relayManager) HandleControlMsg(h *HostInfo, d []byte, f *Interface) {
 
 func (rm *relayManager) handleCreateRelayResponse(v cert.Version, h *HostInfo, f *Interface, m *NebulaControl) {
 	rm.l.Info("handleCreateRelayResponse",
-		slog.Any("relayFrom", protoAddrToNetAddr(m.RelayFromAddr)),
-		slog.Any("relayTo", protoAddrToNetAddr(m.RelayToAddr)),
-		slog.Any("initiatorRelayIndex", m.InitiatorRelayIndex),
-		slog.Any("responderRelayIndex", m.ResponderRelayIndex),
-		slog.Any("vpnAddrs", h.vpnAddrs),
+		"relayFrom", protoAddrToNetAddr(m.RelayFromAddr),
+		"relayTo", protoAddrToNetAddr(m.RelayToAddr),
+		"initiatorRelayIndex", m.InitiatorRelayIndex,
+		"responderRelayIndex", m.ResponderRelayIndex,
+		"vpnAddrs", h.vpnAddrs,
 	)
 
 	target := m.RelayToAddr
@@ -160,7 +160,7 @@ func (rm *relayManager) handleCreateRelayResponse(v cert.Version, h *HostInfo, f
 
 	relay, err := rm.EstablishRelay(h, m)
 	if err != nil {
-		rm.l.Error("Failed to update relay for relayTo", slog.Any("error", err))
+		rm.l.Error("Failed to update relay for relayTo", "error", err)
 		return
 	}
 	// Do I need to complete the relays now?
@@ -170,12 +170,12 @@ func (rm *relayManager) handleCreateRelayResponse(v cert.Version, h *HostInfo, f
 	// I'm the middle man. Let the initiator know that the I've established the relay they requested.
 	peerHostInfo := rm.hostmap.QueryVpnAddr(relay.PeerAddr)
 	if peerHostInfo == nil {
-		rm.l.Error("Can't find a HostInfo for peer", slog.Any("relayTo", relay.PeerAddr))
+		rm.l.Error("Can't find a HostInfo for peer", "relayTo", relay.PeerAddr)
 		return
 	}
 	peerRelay, ok := peerHostInfo.relayState.QueryRelayForByIp(targetAddr)
 	if !ok {
-		rm.l.Error("peerRelay does not have Relay state for relayTo", slog.Any("relayTo", peerHostInfo.vpnAddrs[0]))
+		rm.l.Error("peerRelay does not have Relay state for relayTo", "relayTo", peerHostInfo.vpnAddrs[0])
 		return
 	}
 	switch peerRelay.State {
@@ -194,11 +194,11 @@ func (rm *relayManager) handleCreateRelayResponse(v cert.Version, h *HostInfo, f
 			peer := peerHostInfo.vpnAddrs[0]
 			if !peer.Is4() {
 				rm.l.Error("Refusing to CreateRelayResponse for a v1 relay with an ipv6 address",
-					slog.Any("relayFrom", peer),
-					slog.Any("relayTo", target),
-					slog.Any("initiatorRelayIndex", resp.InitiatorRelayIndex),
-					slog.Any("responderRelayIndex", resp.ResponderRelayIndex),
-					slog.Any("vpnAddrs", peerHostInfo.vpnAddrs),
+					"relayFrom", peer,
+					"relayTo", target,
+					"initiatorRelayIndex", resp.InitiatorRelayIndex,
+					"responderRelayIndex", resp.ResponderRelayIndex,
+					"vpnAddrs", peerHostInfo.vpnAddrs,
 				)
 				return
 			}
@@ -214,15 +214,15 @@ func (rm *relayManager) handleCreateRelayResponse(v cert.Version, h *HostInfo, f
 
 		msg, err := resp.Marshal()
 		if err != nil {
-			rm.l.Error("relayManager Failed to marshal Control CreateRelayResponse message to create relay", slog.Any("error", err))
+			rm.l.Error("relayManager Failed to marshal Control CreateRelayResponse message to create relay", "error", err)
 		} else {
 			f.SendMessageToHostInfo(header.Control, 0, peerHostInfo, msg, make([]byte, 12), make([]byte, mtu))
 			rm.l.Info("send CreateRelayResponse",
-				slog.Any("relayFrom", resp.RelayFromAddr),
-				slog.Any("relayTo", resp.RelayToAddr),
-				slog.Any("initiatorRelayIndex", resp.InitiatorRelayIndex),
-				slog.Any("responderRelayIndex", resp.ResponderRelayIndex),
-				slog.Any("vpnAddrs", peerHostInfo.vpnAddrs),
+				"relayFrom", resp.RelayFromAddr,
+				"relayTo", resp.RelayToAddr,
+				"initiatorRelayIndex", resp.InitiatorRelayIndex,
+				"responderRelayIndex", resp.ResponderRelayIndex,
+				"vpnAddrs", peerHostInfo.vpnAddrs,
 			)
 		}
 	}
@@ -233,17 +233,17 @@ func (rm *relayManager) handleCreateRelayRequest(v cert.Version, h *HostInfo, f 
 	target := protoAddrToNetAddr(m.RelayToAddr)
 
 	logMsg := rm.l.With(
-		slog.Any("relayFrom", from),
-		slog.Any("relayTo", target),
-		slog.Any("initiatorRelayIndex", m.InitiatorRelayIndex),
-		slog.Any("vpnAddrs", h.vpnAddrs),
+		"relayFrom", from,
+		"relayTo", target,
+		"initiatorRelayIndex", m.InitiatorRelayIndex,
+		"vpnAddrs", h.vpnAddrs,
 	)
 
 	logMsg.Info("handleCreateRelayRequest")
 	// Is the source of the relay me? This should never happen, but did happen due to
 	// an issue migrating relays over to newly re-handshaked host info objects.
 	if f.myVpnAddrsTable.Contains(from) {
-		logMsg.Error("Discarding relay request from myself", slog.Any("myIP", from))
+		logMsg.Error("Discarding relay request from myself", "myIP", from)
 		return
 	}
 
@@ -263,7 +263,7 @@ func (rm *relayManager) handleCreateRelayRequest(v cert.Version, h *HostInfo, f 
 					// We got a brand new Relay request, because its index is different than what we saw before.
 					// This should never happen. The peer should never change an index, once created.
 					logMsg.Error("Existing relay mismatch with CreateRelayRequest",
-						slog.Any("existingRemoteIndex", existingRelay.RemoteIndex))
+						"existingRemoteIndex", existingRelay.RemoteIndex)
 					return
 				}
 			case Disestablished:
@@ -271,7 +271,7 @@ func (rm *relayManager) handleCreateRelayRequest(v cert.Version, h *HostInfo, f 
 					// We got a brand new Relay request, because its index is different than what we saw before.
 					// This should never happen. The peer should never change an index, once created.
 					logMsg.Error("Existing relay mismatch with CreateRelayRequest",
-						slog.Any("existingRemoteIndex", existingRelay.RemoteIndex))
+						"existingRemoteIndex", existingRelay.RemoteIndex)
 					return
 				}
 				// Mark the relay as 'Established' because it's safe to use again
@@ -279,20 +279,20 @@ func (rm *relayManager) handleCreateRelayRequest(v cert.Version, h *HostInfo, f 
 			case PeerRequested:
 				// I should never be in this state, because I am terminal, not forwarding.
 				logMsg.Error("Unexpected Relay State found",
-					slog.Any("existingRemoteIndex", existingRelay.RemoteIndex),
-					slog.Any("state", existingRelay.State))
+					"existingRemoteIndex", existingRelay.RemoteIndex,
+					"state", existingRelay.State)
 			}
 		} else {
 			_, err := AddRelay(rm.l, h, f.hostMap, from, &m.InitiatorRelayIndex, TerminalType, Established)
 			if err != nil {
-				logMsg.Error("Failed to add relay", slog.Any("error", err))
+				logMsg.Error("Failed to add relay", "error", err)
 				return
 			}
 		}
 
 		relay, ok := h.relayState.QueryRelayForByIp(from)
 		if !ok {
-			logMsg.Error("Relay State not found", slog.Any("from", from))
+			logMsg.Error("Relay State not found", "from", from)
 			return
 		}
 
@@ -314,15 +314,15 @@ func (rm *relayManager) handleCreateRelayRequest(v cert.Version, h *HostInfo, f 
 
 		msg, err := resp.Marshal()
 		if err != nil {
-			logMsg.Error("relayManager Failed to marshal Control CreateRelayResponse message to create relay", slog.Any("error", err))
+			logMsg.Error("relayManager Failed to marshal Control CreateRelayResponse message to create relay", "error", err)
 		} else {
 			f.SendMessageToHostInfo(header.Control, 0, h, msg, make([]byte, 12), make([]byte, mtu))
 			rm.l.Info("send CreateRelayResponse",
-				slog.Any("relayFrom", from),
-				slog.Any("relayTo", target),
-				slog.Any("initiatorRelayIndex", resp.InitiatorRelayIndex),
-				slog.Any("responderRelayIndex", resp.ResponderRelayIndex),
-				slog.Any("vpnAddrs", h.vpnAddrs),
+				"relayFrom", from,
+				"relayTo", target,
+				"initiatorRelayIndex", resp.InitiatorRelayIndex,
+				"responderRelayIndex", resp.ResponderRelayIndex,
+				"vpnAddrs", h.vpnAddrs,
 			)
 		}
 		return
@@ -364,11 +364,11 @@ func (rm *relayManager) handleCreateRelayRequest(v cert.Version, h *HostInfo, f 
 		if v == cert.Version1 {
 			if !h.vpnAddrs[0].Is4() {
 				rm.l.Error("Refusing to CreateRelayRequest for a v1 relay with an ipv6 address",
-					slog.Any("relayFrom", h.vpnAddrs[0]),
-					slog.Any("relayTo", target),
-					slog.Any("initiatorRelayIndex", req.InitiatorRelayIndex),
-					slog.Any("responderRelayIndex", req.ResponderRelayIndex),
-					slog.Any("vpnAddr", target),
+					"relayFrom", h.vpnAddrs[0],
+					"relayTo", target,
+					"initiatorRelayIndex", req.InitiatorRelayIndex,
+					"responderRelayIndex", req.ResponderRelayIndex,
+					"vpnAddr", target,
 				)
 				return
 			}
@@ -384,15 +384,15 @@ func (rm *relayManager) handleCreateRelayRequest(v cert.Version, h *HostInfo, f 
 
 		msg, err := req.Marshal()
 		if err != nil {
-			logMsg.Error("relayManager Failed to marshal Control message to create relay", slog.Any("error", err))
+			logMsg.Error("relayManager Failed to marshal Control message to create relay", "error", err)
 		} else {
 			f.SendMessageToHostInfo(header.Control, 0, peer, msg, make([]byte, 12), make([]byte, mtu))
 			rm.l.Info("send CreateRelayRequest",
-				slog.Any("relayFrom", h.vpnAddrs[0]),
-				slog.Any("relayTo", target),
-				slog.Any("initiatorRelayIndex", req.InitiatorRelayIndex),
-				slog.Any("responderRelayIndex", req.ResponderRelayIndex),
-				slog.Any("vpnAddr", target),
+				"relayFrom", h.vpnAddrs[0],
+				"relayTo", target,
+				"initiatorRelayIndex", req.InitiatorRelayIndex,
+				"responderRelayIndex", req.ResponderRelayIndex,
+				"vpnAddr", target,
 			)
 		}
 
@@ -401,7 +401,7 @@ func (rm *relayManager) handleCreateRelayRequest(v cert.Version, h *HostInfo, f 
 		if !ok {
 			_, err := AddRelay(rm.l, h, f.hostMap, target, &m.InitiatorRelayIndex, ForwardingType, PeerRequested)
 			if err != nil {
-				logMsg.Error("relayManager Failed to allocate a local index for relay", slog.Any("error", err))
+				logMsg.Error("relayManager Failed to allocate a local index for relay", "error", err)
 				return
 			}
 		}

--- a/remote_list.go
+++ b/remote_list.go
@@ -121,9 +121,9 @@ func NewHostnameResults(ctx context.Context, l *slog.Logger, d time.Duration, ne
 					timeoutCancel()
 					if err != nil {
 						l.Error("DNS resolution failed for static_map host",
-							slog.String("hostname", hostPort.name),
-							slog.String("network", r.network),
-							slog.Any("error", err),
+							"hostname", hostPort.name,
+							"network", r.network,
+							"error", err,
 						)
 						continue
 					}
@@ -149,8 +149,8 @@ func NewHostnameResults(ctx context.Context, l *slog.Logger, d time.Duration, ne
 				}
 				if different {
 					l.Info("DNS results changed for host list",
-						slog.Any("origSet", origSet),
-						slog.Any("newSet", netipAddrs),
+						"origSet", origSet,
+						"newSet", netipAddrs,
 					)
 					r.ips.Store(&netipAddrs)
 					onUpdate()

--- a/ssh.go
+++ b/ssh.go
@@ -61,7 +61,7 @@ func wireSSHReload(l *slog.Logger, ssh *sshd.SSHServer, c *config.C) {
 		if c.GetBool("sshd.enabled", false) {
 			sshRun, err := configSSH(l, ssh, c)
 			if err != nil {
-				l.Error("Failed to reconfigure the sshd", slog.Any("error", err))
+				l.Error("Failed to reconfigure the sshd", "error", err)
 				ssh.Stop()
 			}
 			if sshRun != nil {
@@ -119,7 +119,7 @@ func configSSH(l *slog.Logger, ssh *sshd.SSHServer, c *config.C) (func(), error)
 	for _, caAuthorizedKey := range rawCAs {
 		err := ssh.AddTrustedCA(caAuthorizedKey)
 		if err != nil {
-			l.Warn("SSH CA had an error, ignoring", slog.Any("error", err), slog.String("sshCA", caAuthorizedKey))
+			l.Warn("SSH CA had an error, ignoring", "error", err, "sshCA", caAuthorizedKey)
 			continue
 		}
 	}
@@ -130,13 +130,13 @@ func configSSH(l *slog.Logger, ssh *sshd.SSHServer, c *config.C) (func(), error)
 		for _, rk := range keys {
 			kDef, ok := rk.(map[string]any)
 			if !ok {
-				l.Warn("Authorized user had an error, ignoring", slog.Any("sshKeyConfig", rk))
+				l.Warn("Authorized user had an error, ignoring", "sshKeyConfig", rk)
 				continue
 			}
 
 			user, ok := kDef["user"].(string)
 			if !ok {
-				l.Warn("Authorized user is missing the user field", slog.Any("sshKeyConfig", rk))
+				l.Warn("Authorized user is missing the user field", "sshKeyConfig", rk)
 				continue
 			}
 
@@ -146,9 +146,9 @@ func configSSH(l *slog.Logger, ssh *sshd.SSHServer, c *config.C) (func(), error)
 				err := ssh.AddAuthorizedKey(user, v)
 				if err != nil {
 					l.Warn("Failed to authorize key",
-						slog.Any("error", err),
-						slog.Any("sshKeyConfig", rk),
-						slog.String("sshKey", v),
+						"error", err,
+						"sshKeyConfig", rk,
+						"sshKey", v,
 					)
 					continue
 				}
@@ -158,8 +158,8 @@ func configSSH(l *slog.Logger, ssh *sshd.SSHServer, c *config.C) (func(), error)
 					sk, ok := subK.(string)
 					if !ok {
 						l.Warn("Did not understand ssh key",
-							slog.Any("sshKeyConfig", rk),
-							slog.Any("sshKey", subK),
+							"sshKeyConfig", rk,
+							"sshKey", subK,
 						)
 						continue
 					}
@@ -167,15 +167,15 @@ func configSSH(l *slog.Logger, ssh *sshd.SSHServer, c *config.C) (func(), error)
 					err := ssh.AddAuthorizedKey(user, sk)
 					if err != nil {
 						l.Warn("Failed to authorize key",
-							slog.Any("error", err),
-							slog.String("sshKeyConfig", sk),
+							"error", err,
+							"sshKeyConfig", sk,
 						)
 						continue
 					}
 				}
 
 			default:
-				l.Warn("Authorized user is missing the keys field or was not understood", slog.Any("sshKeyConfig", rk))
+				l.Warn("Authorized user is missing the keys field or was not understood", "sshKeyConfig", rk)
 			}
 		}
 	} else {
@@ -187,7 +187,7 @@ func configSSH(l *slog.Logger, ssh *sshd.SSHServer, c *config.C) (func(), error)
 		ssh.Stop()
 		runner = func() {
 			if err := ssh.Run(listen); err != nil {
-				l.Warn("Failed to run the SSH server", slog.Any("error", err))
+				l.Warn("Failed to run the SSH server", "error", err)
 			}
 		}
 	} else {

--- a/sshd/server.go
+++ b/sshd/server.go
@@ -121,7 +121,7 @@ func (s *SSHServer) AddTrustedCA(pubKey string) error {
 	}
 
 	s.trustedCAs = append(s.trustedCAs, pk)
-	s.l.Info("Trusted CA key", slog.String("sshKey", pubKey))
+	s.l.Info("Trusted CA key", "sshKey", pubKey)
 	return nil
 }
 
@@ -140,8 +140,8 @@ func (s *SSHServer) AddAuthorizedKey(user, pubKey string) error {
 
 	tk[string(pk.Marshal())] = true
 	s.l.Info("Authorized ssh key",
-		slog.String("sshKey", pubKey),
-		slog.String("sshUser", user),
+		"sshKey", pubKey,
+		"sshUser", user,
 	)
 	return nil
 }
@@ -159,7 +159,7 @@ func (s *SSHServer) Run(addr string) error {
 		return err
 	}
 
-	s.l.Info("SSH server is listening", slog.String("sshListener", addr))
+	s.l.Info("SSH server is listening", "sshListener", addr)
 
 	// Run loops until there is an error
 	s.run()
@@ -175,7 +175,7 @@ func (s *SSHServer) run() {
 		c, err := s.listener.Accept()
 		if err != nil {
 			if !errors.Is(err, net.ErrClosed) {
-				s.l.Warn("Error in listener, shutting down", slog.Any("error", err))
+				s.l.Warn("Error in listener, shutting down", "error", err)
 			}
 			return
 		}
@@ -197,28 +197,28 @@ func (s *SSHServer) run() {
 
 			if err != nil {
 				l := s.l.With(
-					slog.Any("error", err),
-					slog.Any("remoteAddress", c.RemoteAddr()),
+					"error", err,
+					"remoteAddress", c.RemoteAddr(),
 				)
 				if conn != nil {
-					l = l.With(slog.String("sshUser", conn.User()))
+					l = l.With("sshUser", conn.User())
 					conn.Close()
 				}
 				if fp != "" {
-					l = l.With(slog.String("sshFingerprint", fp))
+					l = l.With("sshFingerprint", fp)
 				}
 				l.Warn("failed to handshake")
 				sessionCancel()
 				return
 			}
 
-			l := s.l.With(slog.String("sshUser", conn.User()))
+			l := s.l.With("sshUser", conn.User())
 			l.Info("ssh user logged in",
-				slog.Any("remoteAddress", c.RemoteAddr()),
-				slog.String("sshFingerprint", fp),
+				"remoteAddress", c.RemoteAddr(),
+				"sshFingerprint", fp,
 			)
 
-			NewSession(s.commands, conn, chans, sessionCancel, l.With(slog.String("subsystem", "sshd.session")))
+			NewSession(s.commands, conn, chans, sessionCancel, l.With("subsystem", "sshd.session"))
 
 			go ssh.DiscardRequests(reqs)
 
@@ -230,7 +230,7 @@ func (s *SSHServer) Stop() {
 	// Close the listener, this will cause all session to terminate as well, see SSHServer.Run
 	if s.listener != nil {
 		if err := s.listener.Close(); err != nil {
-			s.l.Warn("Failed to close the sshd listener", slog.Any("error", err))
+			s.l.Warn("Failed to close the sshd listener", "error", err)
 		}
 	}
 }

--- a/sshd/session.go
+++ b/sshd/session.go
@@ -45,14 +45,14 @@ func (s *session) handleChannels(chans <-chan ssh.NewChannel) {
 	defer s.Close()
 	for newChannel := range chans {
 		if newChannel.ChannelType() != "session" {
-			s.l.Error("unknown channel type", slog.String("sshChannelType", newChannel.ChannelType()))
+			s.l.Error("unknown channel type", "sshChannelType", newChannel.ChannelType())
 			newChannel.Reject(ssh.UnknownChannelType, "unknown channel type")
 			continue
 		}
 
 		channel, requests, err := newChannel.Accept()
 		if err != nil {
-			s.l.Warn("could not accept channel", slog.Any("error", err))
+			s.l.Warn("could not accept channel", "error", err)
 			continue
 		}
 
@@ -95,12 +95,12 @@ func (s *session) handleRequests(in <-chan *ssh.Request, channel ssh.Channel) {
 			return
 
 		default:
-			s.l.Debug("Rejected unknown request", slog.String("sshRequest", req.Type))
+			s.l.Debug("Rejected unknown request", "sshRequest", req.Type)
 			err = req.Reply(false, nil)
 		}
 
 		if err != nil {
-			s.l.Info("Error handling ssh session requests", slog.Any("error", err))
+			s.l.Info("Error handling ssh session requests", "error", err)
 			return
 		}
 	}

--- a/stats.go
+++ b/stats.go
@@ -74,9 +74,9 @@ func startGraphiteStats(l *slog.Logger, i time.Duration, c *config.C, configTest
 
 	if !configTest {
 		l.Info("Starting graphite",
-			slog.Duration("interval", i),
-			slog.String("prefix", prefix),
-			slog.String("addr", addr.String()),
+			"interval", i,
+			"prefix", prefix,
+			"addr", addr.String(),
 		)
 		go graphite.Graphite(metrics.DefaultRegistry, i, prefix, addr)
 	}
@@ -125,8 +125,8 @@ func startPrometheusStats(l *slog.Logger, i time.Duration, c *config.C, buildVer
 		errLog := slog.NewLogLogger(l.Handler(), slog.LevelError)
 		startFn = func() {
 			l.Info("Prometheus stats listening",
-				slog.String("listen", listen),
-				slog.String("path", path),
+				"listen", listen,
+				"path", path,
 			)
 			http.Handle(path, promhttp.HandlerFor(pr, promhttp.HandlerOpts{ErrorLog: errLog}))
 			log.Fatal(http.ListenAndServe(listen, nil))

--- a/test/logger.go
+++ b/test/logger.go
@@ -18,7 +18,7 @@ const logLevelTrace = slog.Level(-8)
 func NewLogger() *slog.Logger {
 	v := os.Getenv("TEST_LOGS")
 	if v == "" {
-		return slog.New(slog.NewTextHandler(io.Discard, nil))
+		return slog.New(slog.DiscardHandler)
 	}
 
 	level := slog.LevelInfo

--- a/udp/udp_darwin.go
+++ b/udp/udp_darwin.go
@@ -176,7 +176,7 @@ func (u *StdConn) ListenOut(r EncReader) error {
 				return err
 			}
 
-			u.l.Error("unexpected udp socket receive error", slog.Any("error", err))
+			u.l.Error("unexpected udp socket receive error", "error", err)
 		}
 
 		r(netip.AddrPortFrom(rua.Addr().Unmap(), rua.Port()), buffer[:n])
@@ -196,7 +196,7 @@ func (u *StdConn) Rebind() error {
 	}
 
 	if err != nil {
-		u.l.Error("Failed to rebind udp socket", slog.Any("error", err))
+		u.l.Error("Failed to rebind udp socket", "error", err)
 	}
 
 	return nil

--- a/udp/udp_generic.go
+++ b/udp/udp_generic.go
@@ -88,7 +88,7 @@ func (u *GenericConn) ListenOut(r EncReader) error {
 			// Dampen unexpected message warns to once per minute
 			if lastRecvErr.IsZero() || time.Since(lastRecvErr) > time.Minute {
 				lastRecvErr = time.Now()
-				u.l.Warn("unexpected udp socket receive error", slog.Any("error", err))
+				u.l.Warn("unexpected udp socket receive error", "error", err)
 			}
 			continue
 		}

--- a/udp/udp_linux.go
+++ b/udp/udp_linux.go
@@ -242,12 +242,12 @@ func (u *StdConn) ReloadConfig(c *config.C) {
 		if err == nil {
 			s, err := u.GetRecvBuffer()
 			if err == nil {
-				u.l.Info("listen.read_buffer was set", slog.Int("size", s))
+				u.l.Info("listen.read_buffer was set", "size", s)
 			} else {
-				u.l.Warn("Failed to get listen.read_buffer", slog.Any("error", err))
+				u.l.Warn("Failed to get listen.read_buffer", "error", err)
 			}
 		} else {
-			u.l.Error("Failed to set listen.read_buffer", slog.Any("error", err))
+			u.l.Error("Failed to set listen.read_buffer", "error", err)
 		}
 	}
 
@@ -257,12 +257,12 @@ func (u *StdConn) ReloadConfig(c *config.C) {
 		if err == nil {
 			s, err := u.GetSendBuffer()
 			if err == nil {
-				u.l.Info("listen.write_buffer was set", slog.Int("size", s))
+				u.l.Info("listen.write_buffer was set", "size", s)
 			} else {
-				u.l.Warn("Failed to get listen.write_buffer", slog.Any("error", err))
+				u.l.Warn("Failed to get listen.write_buffer", "error", err)
 			}
 		} else {
-			u.l.Error("Failed to set listen.write_buffer", slog.Any("error", err))
+			u.l.Error("Failed to set listen.write_buffer", "error", err)
 		}
 	}
 
@@ -273,12 +273,12 @@ func (u *StdConn) ReloadConfig(c *config.C) {
 		if err == nil {
 			s, err := u.GetSoMark()
 			if err == nil {
-				u.l.Info("listen.so_mark was set", slog.Int("mark", s))
+				u.l.Info("listen.so_mark was set", "mark", s)
 			} else {
-				u.l.Warn("Failed to get listen.so_mark", slog.Any("error", err))
+				u.l.Warn("Failed to get listen.so_mark", "error", err)
 			}
 		} else {
-			u.l.Error("Failed to set listen.so_mark", slog.Any("error", err))
+			u.l.Error("Failed to set listen.so_mark", "error", err)
 		}
 	}
 }

--- a/udp/udp_rio_windows.go
+++ b/udp/udp_rio_windows.go
@@ -103,7 +103,7 @@ func (u *RIOConn) bind(l *slog.Logger, sa windows.Sockaddr) error {
 	if err != nil {
 		// This is a best-effort to prevent errors from being returned by the udp recv operation.
 		// Quietly log a failure and continue.
-		l.Debug("failed to set UDP_CONNRESET ioctl", slog.Any("error", err))
+		l.Debug("failed to set UDP_CONNRESET ioctl", "error", err)
 	}
 
 	ret = 0
@@ -114,7 +114,7 @@ func (u *RIOConn) bind(l *slog.Logger, sa windows.Sockaddr) error {
 	if err != nil {
 		// This is a best-effort to prevent errors from being returned by the udp recv operation.
 		// Quietly log a failure and continue.
-		l.Debug("failed to set UDP_NETRESET ioctl", slog.Any("error", err))
+		l.Debug("failed to set UDP_NETRESET ioctl", "error", err)
 	}
 
 	err = u.rx.Open()
@@ -156,7 +156,7 @@ func (u *RIOConn) ListenOut(r EncReader) error {
 			// Dampen unexpected message warns to once per minute
 			if lastRecvErr.IsZero() || time.Since(lastRecvErr) > time.Minute {
 				lastRecvErr = time.Now()
-				u.l.Warn("unexpected udp socket receive error", slog.Any("error", err))
+				u.l.Warn("unexpected udp socket receive error", "error", err)
 			}
 			continue
 		}

--- a/udp/udp_tester.go
+++ b/udp/udp_tester.go
@@ -70,9 +70,9 @@ func (u *TesterConn) Send(packet *Packet) {
 	}
 	if u.l.Enabled(context.Background(), slog.LevelDebug) {
 		u.l.Debug("UDP receiving injected packet",
-			slog.Any("header", h),
-			slog.Any("udpAddr", packet.From),
-			slog.Int("dataLen", len(packet.Data)),
+			"header", h,
+			"udpAddr", packet.From,
+			"dataLen", len(packet.Data),
 		)
 	}
 	select {

--- a/udp/udp_windows.go
+++ b/udp/udp_windows.go
@@ -24,7 +24,7 @@ func NewListener(l *slog.Logger, ip netip.Addr, port int, multi bool, batch int)
 		return rc, nil
 	}
 
-	l.Error("Falling back to standard udp sockets", slog.Any("error", err))
+	l.Error("Falling back to standard udp sockets", "error", err)
 	return NewGenericListener(l, ip, port, multi, batch)
 }
 

--- a/util/error.go
+++ b/util/error.go
@@ -33,7 +33,7 @@ func LogWithContextIfNeeded(msg string, err error, l *slog.Logger) {
 	case *ContextualError:
 		v.Log(l)
 	default:
-		l.Error(msg, slog.Any("error", err))
+		l.Error(msg, "error", err)
 	}
 }
 
@@ -62,5 +62,8 @@ func (ce *ContextualError) Log(l *slog.Logger) {
 	if ce.RealError != nil {
 		attrs = append(attrs, slog.Any("error", ce.RealError))
 	}
+	// LogAttrs is intentional: attrs is built from a map[string]any so it has
+	// no pair-form equivalent.
+	//nolint:sloglint
 	l.LogAttrs(context.Background(), slog.LevelError, ce.Context, attrs...)
 }


### PR DESCRIPTION
Linter is a bit too greedy imo but all call sites changed, some got slightly worse moving from `LogAttrs` -> `Log` but it's likely not consequential 