### PR TITLE
Move logger to its own package, have callers handle logger reconfigure

### DIFF
--- a/cmd/nebula-service/logs_generic.go
+++ b/cmd/nebula-service/logs_generic.go
@@ -7,11 +7,11 @@ import (
 	"log/slog"
 	"os"
 
-	"github.com/slackhq/nebula"
+	"github.com/slackhq/nebula/logging"
 )
 
 // newPlatformLogger returns a *slog.Logger that writes to stdout. Non-Windows
 // platforms have no special sink to integrate with.
 func newPlatformLogger() *slog.Logger {
-	return nebula.NewLogger(os.Stdout)
+	return logging.NewLogger(os.Stdout)
 }

--- a/cmd/nebula-service/logs_windows.go
+++ b/cmd/nebula-service/logs_windows.go
@@ -100,7 +100,7 @@ func (sh *serviceHandler) WithGroup(name string) slog.Handler {
 	}
 }
 
-// SetLevel lets configLogger and SSH commands honor logging.level.
+// SetLevel lets logging.ApplyConfig and the SSH commands honor logging.level.
 func (sh *serviceHandler) SetLevel(lvl slog.Level) { sh.root.level.Set(lvl) }
 
 // GetLevel is the structural counterpart used by sshLogLevel.

--- a/cmd/nebula-service/main.go
+++ b/cmd/nebula-service/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/slackhq/nebula"
 	"github.com/slackhq/nebula/config"
+	"github.com/slackhq/nebula/logging"
 	"github.com/slackhq/nebula/util"
 )
 
@@ -49,7 +50,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	l := nebula.NewLogger(os.Stdout)
+	l := logging.NewLogger(os.Stdout)
 
 	if *serviceFlag != "" {
 		if err := doService(configPath, configTest, Build, serviceFlag); err != nil {
@@ -71,6 +72,16 @@ func main() {
 		fmt.Printf("failed to load config: %s", err)
 		os.Exit(1)
 	}
+
+	if err := logging.ApplyConfig(l, c); err != nil {
+		fmt.Printf("failed to apply logging config: %s", err)
+		os.Exit(1)
+	}
+	c.RegisterReloadCallback(func(c *config.C) {
+		if err := logging.ApplyConfig(l, c); err != nil {
+			l.Error("Failed to reconfigure logger on reload", "error", err)
+		}
+	})
 
 	ctrl, err := nebula.Main(c, *configTest, Build, l, nil)
 	if err != nil {

--- a/cmd/nebula-service/service.go
+++ b/cmd/nebula-service/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kardianos/service"
 	"github.com/slackhq/nebula"
 	"github.com/slackhq/nebula/config"
+	"github.com/slackhq/nebula/logging"
 )
 
 var logger service.Logger
@@ -31,6 +32,15 @@ func (p *program) Start(s service.Service) error {
 	if err != nil {
 		return fmt.Errorf("failed to load config: %s", err)
 	}
+
+	if err := logging.ApplyConfig(l, c); err != nil {
+		return fmt.Errorf("failed to apply logging config: %s", err)
+	}
+	c.RegisterReloadCallback(func(c *config.C) {
+		if err := logging.ApplyConfig(l, c); err != nil {
+			l.Error("Failed to reconfigure logger on reload", "error", err)
+		}
+	})
 
 	p.control, err = nebula.Main(c, *p.configTest, Build, l, nil)
 	if err != nil {

--- a/cmd/nebula/main.go
+++ b/cmd/nebula/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/slackhq/nebula"
 	"github.com/slackhq/nebula/config"
+	"github.com/slackhq/nebula/logging"
 	"github.com/slackhq/nebula/util"
 )
 
@@ -54,7 +55,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	l := nebula.NewLogger(os.Stdout)
+	l := logging.NewLogger(os.Stdout)
 
 	c := config.NewC(l)
 	err := c.Load(*configPath)
@@ -62,6 +63,16 @@ func main() {
 		fmt.Printf("failed to load config: %s", err)
 		os.Exit(1)
 	}
+
+	if err := logging.ApplyConfig(l, c); err != nil {
+		fmt.Printf("failed to apply logging config: %s", err)
+		os.Exit(1)
+	}
+	c.RegisterReloadCallback(func(c *config.C) {
+		if err := logging.ApplyConfig(l, c); err != nil {
+			l.Error("Failed to reconfigure logger on reload", "error", err)
+		}
+	})
 
 	ctrl, err := nebula.Main(c, *configTest, Build, l, nil)
 	if err != nil {

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/slackhq/nebula/cert_test"
 	"github.com/slackhq/nebula/config"
 	"github.com/slackhq/nebula/e2e/router"
+	"github.com/slackhq/nebula/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
@@ -389,13 +390,13 @@ func NewTestLogger() *slog.Logger {
 	case "2":
 		level = slog.LevelDebug
 	case "3":
-		level = nebula.LogLevelTrace
+		level = logging.LevelTrace
 	}
 	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
 }
 
-// testLogLevelName returns the level name string accepted by configLogger for
-// the current TEST_LOGS setting. Kept in sync with NewTestLogger.
+// testLogLevelName returns the level name string accepted by logging.ApplyConfig
+// for the current TEST_LOGS setting. Kept in sync with NewTestLogger.
 func testLogLevelName() string {
 	switch os.Getenv("TEST_LOGS") {
 	case "2":

--- a/examples/go_service/main.go
+++ b/examples/go_service/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/slackhq/nebula"
 	"github.com/slackhq/nebula/config"
+	"github.com/slackhq/nebula/logging"
 	"github.com/slackhq/nebula/overlay"
 	"github.com/slackhq/nebula/service"
 )
@@ -63,7 +64,7 @@ pki:
 		return err
 	}
 
-	logger := nebula.NewLogger(os.Stdout)
+	logger := logging.NewLogger(os.Stdout)
 
 	ctrl, err := nebula.Main(&cfg, false, "custom-app", logger, overlay.NewUserDeviceFromConfig)
 	if err != nil {

--- a/hostmap.go
+++ b/hostmap.go
@@ -18,6 +18,7 @@ import (
 	"github.com/slackhq/nebula/cert"
 	"github.com/slackhq/nebula/config"
 	"github.com/slackhq/nebula/header"
+	"github.com/slackhq/nebula/logging"
 )
 
 const defaultPromoteEvery = 1000       // Count of packets sent before we try moving a tunnel to a preferred underlay ip address
@@ -821,8 +822,8 @@ func localAddrs(l *slog.Logger, allowList *LocalAllowList) []netip.Addr {
 	ifaces, _ := net.Interfaces()
 	for _, i := range ifaces {
 		allow := allowList.AllowName(i.Name)
-		if l.Enabled(context.Background(), LogLevelTrace) {
-			l.Log(context.Background(), LogLevelTrace, "localAllowList.AllowName",
+		if l.Enabled(context.Background(), logging.LevelTrace) {
+			l.Log(context.Background(), logging.LevelTrace, "localAllowList.AllowName",
 				"interfaceName", i.Name,
 				"allow", allow,
 			)
@@ -852,8 +853,8 @@ func localAddrs(l *slog.Logger, allowList *LocalAllowList) []netip.Addr {
 
 			if addr.IsLoopback() == false && addr.IsLinkLocalUnicast() == false {
 				isAllowed := allowList.Allow(addr)
-				if l.Enabled(context.Background(), LogLevelTrace) {
-					l.Log(context.Background(), LogLevelTrace, "localAllowList.Allow",
+				if l.Enabled(context.Background(), logging.LevelTrace) {
+					l.Log(context.Background(), logging.LevelTrace, "localAllowList.Allow",
 						"localAddr", addr,
 						"allowed", isAllowed,
 					)

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -19,6 +19,7 @@ import (
 	"github.com/slackhq/nebula/cert"
 	"github.com/slackhq/nebula/config"
 	"github.com/slackhq/nebula/header"
+	"github.com/slackhq/nebula/logging"
 	"github.com/slackhq/nebula/udp"
 	"github.com/slackhq/nebula/util"
 )
@@ -672,8 +673,8 @@ func (lh *LightHouse) unlockedGetRemoteList(allAddrs []netip.Addr) *RemoteList {
 
 func (lh *LightHouse) shouldAdd(vpnAddrs []netip.Addr, to netip.Addr) bool {
 	allow := lh.GetRemoteAllowList().AllowAll(vpnAddrs, to)
-	if lh.l.Enabled(context.Background(), LogLevelTrace) {
-		lh.l.Log(context.Background(), LogLevelTrace, "remoteAllowList.Allow",
+	if lh.l.Enabled(context.Background(), logging.LevelTrace) {
+		lh.l.Log(context.Background(), logging.LevelTrace, "remoteAllowList.Allow",
 			"vpnAddrs", vpnAddrs,
 			"udpAddr", to,
 			"allow", allow,
@@ -694,8 +695,8 @@ func (lh *LightHouse) shouldAdd(vpnAddrs []netip.Addr, to netip.Addr) bool {
 func (lh *LightHouse) unlockedShouldAddV4(vpnAddr netip.Addr, to *V4AddrPort) bool {
 	udpAddr := protoV4AddrPortToNetAddrPort(to)
 	allow := lh.GetRemoteAllowList().Allow(vpnAddr, udpAddr.Addr())
-	if lh.l.Enabled(context.Background(), LogLevelTrace) {
-		lh.l.Log(context.Background(), LogLevelTrace, "remoteAllowList.Allow",
+	if lh.l.Enabled(context.Background(), logging.LevelTrace) {
+		lh.l.Log(context.Background(), logging.LevelTrace, "remoteAllowList.Allow",
 			"vpnAddr", vpnAddr,
 			"udpAddr", udpAddr,
 			"allow", allow,
@@ -717,8 +718,8 @@ func (lh *LightHouse) unlockedShouldAddV4(vpnAddr netip.Addr, to *V4AddrPort) bo
 func (lh *LightHouse) unlockedShouldAddV6(vpnAddr netip.Addr, to *V6AddrPort) bool {
 	udpAddr := protoV6AddrPortToNetAddrPort(to)
 	allow := lh.GetRemoteAllowList().Allow(vpnAddr, udpAddr.Addr())
-	if lh.l.Enabled(context.Background(), LogLevelTrace) {
-		lh.l.Log(context.Background(), LogLevelTrace, "remoteAllowList.Allow",
+	if lh.l.Enabled(context.Background(), logging.LevelTrace) {
+		lh.l.Log(context.Background(), logging.LevelTrace, "remoteAllowList.Allow",
 			"vpnAddr", vpnAddr,
 			"udpAddr", udpAddr,
 			"allow", allow,

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -1,4 +1,9 @@
-package nebula
+// Package logging wires the nebula runtime-reconfigurable slog handler used
+// by nebula.Main and the nebula CLI binaries. Callers build a logger with
+// NewLogger, then call ApplyConfig at startup and from a config reload
+// callback to push logging.level, logging.format, and
+// logging.disable_timestamp changes onto the logger without rebuilding it.
+package logging
 
 import (
 	"context"
@@ -8,34 +13,41 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
-
-	"github.com/slackhq/nebula/config"
 )
 
-// LogLevelTrace is a custom slog level below Debug, used when logging.level
-// is "trace". slog has no builtin trace level; the value is one step below
+// Config is the subset of *config.C that ApplyConfig reads. Declaring it
+// here keeps the logging package from depending on config directly, which
+// would cycle through the shared test helpers (test.NewLogger imports
+// logging, and config's tests import test). *config.C satisfies this
+// interface structurally with no adapter.
+type Config interface {
+	GetString(key, def string) string
+	GetBool(key string, def bool) bool
+}
+
+// LevelTrace is a custom slog level below Debug, used when logging.level is
+// "trace". slog has no builtin trace level; the value is one step below
 // slog.LevelDebug in slog's 4-point spacing.
-const LogLevelTrace = slog.Level(-8)
+const LevelTrace = slog.Level(-8)
 
 // NewLogger returns a *slog.Logger whose level, format, and timestamp
-// emission can be reconfigured at runtime via configLogger and the SSH
-// debug commands. The default configuration is info-level text output so
-// log calls made before configLogger runs still produce output. Timestamps
+// emission can be reconfigured at runtime via ApplyConfig and the SSH debug
+// commands. The default configuration is info-level text output so log
+// calls made before ApplyConfig runs still produce output. Timestamps
 // follow slog's default RFC3339Nano format; set logging.disable_timestamp
 // in config to suppress them.
 //
-// configLogger and the SSH commands discover the reconfig surface via
+// ApplyConfig and the SSH commands discover the reconfig surface via
 // structural type-assertion on l.Handler(), so replacement implementations
 // (tests, platform-specific sinks) need only implement the subset of
 // {SetLevel(slog.Level), SetFormat(string) error, SetDisableTimestamp(bool)}
-// they care about. Callers that do not need reconfig can pass a plain
-// *slog.Logger to nebula.Main; configLogger becomes a no-op for handlers it
-// does not recognize.
+// they care about. Callers that pass a plain *slog.Logger without these
+// methods get a silent no-op; reconfiguration is always opt-in.
 func NewLogger(w io.Writer) *slog.Logger {
 	root := &handlerRoot{}
 	root.level.Set(slog.LevelInfo)
 	opts := &slog.HandlerOptions{Level: &root.level}
-	return slog.New(&nebulaHandler{
+	return slog.New(&handler{
 		root: root,
 		text: slog.NewTextHandler(w, opts),
 		json: slog.NewJSONHandler(w, opts),
@@ -48,29 +60,29 @@ func NewLogger(w io.Writer) *slog.Logger {
 type handlerRoot struct {
 	level            slog.LevelVar
 	disableTimestamp atomic.Bool
-	// jsonMode picks which of the pre-derived inner handlers nebulaHandler.Handle
+	// jsonMode picks which of the pre-derived inner handlers handler.Handle
 	// dispatches to. Flipping it propagates instantly to every derived logger
 	// without rebuilding or chain-replaying anything.
 	jsonMode atomic.Bool
 }
 
-// nebulaHandler is the slog.Handler returned by NewLogger. It holds two
+// handler is the slog.Handler returned by NewLogger. It holds two
 // pre-derived slog handlers -- one text, one json -- both built from the
 // same accumulated WithAttrs/WithGroup state. Handle picks which one to
 // dispatch to based on handlerRoot.jsonMode, so a SetFormat call takes
 // effect immediately across the whole process without having to rebuild
 // any derived loggers.
-type nebulaHandler struct {
+type handler struct {
 	root *handlerRoot
 	text slog.Handler
 	json slog.Handler
 }
 
-func (h *nebulaHandler) Enabled(_ context.Context, l slog.Level) bool {
+func (h *handler) Enabled(_ context.Context, l slog.Level) bool {
 	return h.root.level.Level() <= l
 }
 
-func (h *nebulaHandler) Handle(ctx context.Context, r slog.Record) error {
+func (h *handler) Handle(ctx context.Context, r slog.Record) error {
 	if h.root.disableTimestamp.Load() {
 		r.Time = time.Time{}
 	}
@@ -80,22 +92,22 @@ func (h *nebulaHandler) Handle(ctx context.Context, r slog.Record) error {
 	return h.text.Handle(ctx, r)
 }
 
-func (h *nebulaHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+func (h *handler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	if len(attrs) == 0 {
 		return h
 	}
-	return &nebulaHandler{
+	return &handler{
 		root: h.root,
 		text: h.text.WithAttrs(attrs),
 		json: h.json.WithAttrs(attrs),
 	}
 }
 
-func (h *nebulaHandler) WithGroup(name string) slog.Handler {
+func (h *handler) WithGroup(name string) slog.Handler {
 	if name == "" {
 		return h
 	}
-	return &nebulaHandler{
+	return &handler{
 		root: h.root,
 		text: h.text.WithGroup(name),
 		json: h.json.WithGroup(name),
@@ -104,15 +116,15 @@ func (h *nebulaHandler) WithGroup(name string) slog.Handler {
 
 // SetLevel updates the effective log level. Propagates to every derived
 // logger via the shared LevelVar.
-func (h *nebulaHandler) SetLevel(level slog.Level) { h.root.level.Set(level) }
+func (h *handler) SetLevel(level slog.Level) { h.root.level.Set(level) }
 
 // GetLevel reports the current log level.
-func (h *nebulaHandler) GetLevel() slog.Level { return h.root.level.Level() }
+func (h *handler) GetLevel() slog.Level { return h.root.level.Level() }
 
 // SetFormat flips the output format atomically. Valid formats are "text"
 // and "json". Every derived logger sees the new format on its next Handle
 // call; no rebuild or registration is required.
-func (h *nebulaHandler) SetFormat(format string) error {
+func (h *handler) SetFormat(format string) error {
 	switch format {
 	case "text":
 		h.root.jsonMode.Store(false)
@@ -125,7 +137,7 @@ func (h *nebulaHandler) SetFormat(format string) error {
 }
 
 // GetFormat reports the currently selected format name.
-func (h *nebulaHandler) GetFormat() string {
+func (h *handler) GetFormat() string {
 	if h.root.jsonMode.Load() {
 		return "json"
 	}
@@ -135,17 +147,22 @@ func (h *nebulaHandler) GetFormat() string {
 // SetDisableTimestamp toggles whether Handle zeroes r.Time before
 // dispatching (slog's builtin text/json handlers skip emitting the time
 // attribute on a zero time).
-func (h *nebulaHandler) SetDisableTimestamp(v bool) { h.root.disableTimestamp.Store(v) }
+func (h *handler) SetDisableTimestamp(v bool) { h.root.disableTimestamp.Store(v) }
 
-// configLogger reads logging.level, logging.format, and (optionally)
+// ApplyConfig reads logging.level, logging.format, and (optionally)
 // logging.disable_timestamp from c and applies them to l. The reconfig
 // surface is discovered via structural type-assertion on l.Handler(), so
 // foreign handlers silently opt out of whichever capabilities they do not
 // implement.
-func configLogger(l *slog.Logger, c *config.C) error {
+//
+// nebula.Main does NOT call this function on your behalf; callers that want
+// config-driven log level / format / timestamp updates invoke it at
+// startup and register it as a reload callback themselves. This keeps the
+// library from mutating an embedder's logger without their say-so.
+func ApplyConfig(l *slog.Logger, c Config) error {
 	h := l.Handler()
 
-	lvl, err := parseLogLevel(strings.ToLower(c.GetString("logging.level", "info")))
+	lvl, err := ParseLevel(strings.ToLower(c.GetString("logging.level", "info")))
 	if err != nil {
 		return err
 	}
@@ -166,10 +183,14 @@ func configLogger(l *slog.Logger, c *config.C) error {
 	return nil
 }
 
-func parseLogLevel(s string) (slog.Level, error) {
+// ParseLevel converts a config-string level name ("trace", "debug", "info",
+// "warn"/"warning", "error", "fatal"/"panic") to a slog.Level. "fatal" and
+// "panic" are accepted for backwards compatibility with pre-slog configs
+// and both map to slog.LevelError.
+func ParseLevel(s string) (slog.Level, error) {
 	switch s {
 	case "trace":
-		return LogLevelTrace, nil
+		return LevelTrace, nil
 	case "debug":
 		return slog.LevelDebug, nil
 	case "info":
@@ -179,19 +200,17 @@ func parseLogLevel(s string) (slog.Level, error) {
 	case "error":
 		return slog.LevelError, nil
 	case "fatal", "panic":
-		// Accepted for backwards compatibility with older configs. slog has
-		// no fatal or panic level; both map to error.
 		return slog.LevelError, nil
 	default:
 		return 0, fmt.Errorf("not a valid logging level: %q", s)
 	}
 }
 
-// logLevelName returns a human-readable name for a slog.Level matching the
-// strings accepted by parseLogLevel.
-func logLevelName(l slog.Level) string {
+// LevelName returns a human-readable name for a slog.Level matching the
+// strings accepted by ParseLevel.
+func LevelName(l slog.Level) string {
 	switch {
-	case l <= LogLevelTrace:
+	case l <= LevelTrace:
 		return "trace"
 	case l <= slog.LevelDebug:
 		return "debug"

--- a/logging/logger_bench_test.go
+++ b/logging/logger_bench_test.go
@@ -1,4 +1,4 @@
-package nebula
+package logging
 
 import (
 	"context"
@@ -7,8 +7,8 @@ import (
 	"testing"
 )
 
-// BenchmarkLogger_* compare the nebulaHandler returned by NewLogger against
-// a stock slog text handler. The key thing we care about is the per-log
+// BenchmarkLogger_* compare the handler returned by NewLogger against a
+// stock slog text handler. The key thing we care about is the per-log
 // cost on a logger that has been derived via .With(), because that is the
 // shape subsystems store on their structs (HostInfo.logger(),
 // lh.l.With("subsystem", ...), etc.) and call from hot paths.

--- a/main.go
+++ b/main.go
@@ -44,18 +44,6 @@ func Main(c *config.C, configTest bool, buildVersion string, l *slog.Logger, dev
 		l.Info(string(b))
 	}
 
-	err := configLogger(l, c)
-	if err != nil {
-		return nil, util.ContextualizeIfNeeded("Failed to configure the logger", err)
-	}
-
-	c.RegisterReloadCallback(func(c *config.C) {
-		err := configLogger(l, c)
-		if err != nil {
-			l.Error("Failed to configure the logger", "error", err)
-		}
-	})
-
 	pki, err := NewPKIFromConfig(l, c)
 	if err != nil {
 		return nil, util.ContextualizeIfNeeded("Failed to load PKI from config", err)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/slackhq/nebula/cert"
 	"github.com/slackhq/nebula/cert_test"
 	"github.com/slackhq/nebula/config"
+	"github.com/slackhq/nebula/logging"
 	"github.com/slackhq/nebula/overlay"
 	"go.yaml.in/yaml/v3"
 	"golang.org/x/sync/errgroup"
@@ -74,7 +75,7 @@ func newSimpleService(caCrt cert.Certificate, caKey []byte, name string, udpIp n
 		panic(err)
 	}
 
-	logger := nebula.NewLogger(os.Stdout)
+	logger := logging.NewLogger(os.Stdout)
 
 	control, err := nebula.Main(&c, false, "custom-app", logger, overlay.NewUserDeviceFromConfig)
 	if err != nil {

--- a/ssh.go
+++ b/ssh.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/slackhq/nebula/config"
 	"github.com/slackhq/nebula/header"
+	"github.com/slackhq/nebula/logging"
 	"github.com/slackhq/nebula/sshd"
 )
 
@@ -808,16 +809,16 @@ func sshLogLevel(l *slog.Logger, fs any, a []string, w sshd.StringWriter) error 
 	}
 
 	if len(a) == 0 {
-		return w.WriteLine(fmt.Sprintf("Log level is: %s", logLevelName(ctrl.GetLevel())))
+		return w.WriteLine(fmt.Sprintf("Log level is: %s", logging.LevelName(ctrl.GetLevel())))
 	}
 
-	level, err := parseLogLevel(strings.ToLower(a[0]))
+	level, err := logging.ParseLevel(strings.ToLower(a[0]))
 	if err != nil {
 		return w.WriteLine(fmt.Sprintf("Unknown log level %s. Possible log levels: trace, debug, info, warn, error", a))
 	}
 
 	ctrl.SetLevel(level)
-	return w.WriteLine(fmt.Sprintf("Log level is: %s", logLevelName(ctrl.GetLevel())))
+	return w.WriteLine(fmt.Sprintf("Log level is: %s", logging.LevelName(ctrl.GetLevel())))
 }
 
 func sshLogFormat(l *slog.Logger, fs any, a []string, w sshd.StringWriter) error {

--- a/test/logger.go
+++ b/test/logger.go
@@ -6,11 +6,9 @@ import (
 	"log/slog"
 	"os"
 	"time"
-)
 
-// logLevelTrace mirrors nebula.LogLevelTrace. Duplicated to keep this package
-// free of an import cycle on the nebula package.
-const logLevelTrace = slog.Level(-8)
+	"github.com/slackhq/nebula/logging"
+)
 
 // NewLogger returns a *slog.Logger suitable for use in tests. Output goes to
 // io.Discard by default; set TEST_LOGS=1 (info), 2 (debug), or 3 (trace) to
@@ -26,7 +24,7 @@ func NewLogger() *slog.Logger {
 	case "2":
 		level = slog.LevelDebug
 	case "3":
-		level = logLevelTrace
+		level = logging.LevelTrace
 	}
 	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
 }


### PR DESCRIPTION
Moved the self contained logger helper functions to a logger package.
Moved logger reconfiguration up to the caller (cmd/, service impls)