### PR TITLE
Drop casts in logging

### DIFF
--- a/connection_manager.go
+++ b/connection_manager.go
@@ -312,8 +312,8 @@ func (cm *connectionManager) migrateRelayUsed(oldhostinfo, newhostinfo *HostInfo
 			cm.l.Info("send CreateRelayRequest",
 				"relayFrom", req.RelayFromAddr,
 				"relayTo", req.RelayToAddr,
-				"initiatorRelayIndex", uint64(req.InitiatorRelayIndex),
-				"responderRelayIndex", uint64(req.ResponderRelayIndex),
+				"initiatorRelayIndex", req.InitiatorRelayIndex,
+				"responderRelayIndex", req.ResponderRelayIndex,
 				"vpnAddrs", newhostinfo.vpnAddrs,
 			)
 		}
@@ -327,7 +327,7 @@ func (cm *connectionManager) makeTrafficDecision(localIndex uint32, now time.Tim
 
 	hostinfo := cm.hostMap.Indexes[localIndex]
 	if hostinfo == nil {
-		cm.l.Debug("Not found in hostmap", "localIndex", uint64(localIndex))
+		cm.l.Debug("Not found in hostmap", "localIndex", localIndex)
 		return doNothing, nil, nil
 	}
 

--- a/handshake_ix.go
+++ b/handshake_ix.go
@@ -308,9 +308,9 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 		"certVersion", certVersion,
 		"fingerprint", fingerprint,
 		"issuer", issuer,
-		"initiatorIndex", uint64(hs.Details.InitiatorIndex),
-		"responderIndex", uint64(hs.Details.ResponderIndex),
-		"remoteIndex", uint64(h.RemoteIndex),
+		"initiatorIndex", hs.Details.InitiatorIndex,
+		"responderIndex", hs.Details.ResponderIndex,
+		"remoteIndex", h.RemoteIndex,
 		"handshake", m{"stage": 1, "style": "ix_psk0"},
 	)
 
@@ -456,9 +456,9 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 				"newHandshakeTime", hostinfo.lastHandshakeTime,
 				"fingerprint", fingerprint,
 				"issuer", issuer,
-				"initiatorIndex", uint64(hs.Details.InitiatorIndex),
-				"responderIndex", uint64(hs.Details.ResponderIndex),
-				"remoteIndex", uint64(h.RemoteIndex),
+				"initiatorIndex", hs.Details.InitiatorIndex,
+				"responderIndex", hs.Details.ResponderIndex,
+				"remoteIndex", h.RemoteIndex,
 				"handshake", m{"stage": 1, "style": "ix_psk0"},
 			)
 
@@ -474,11 +474,11 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 				"certVersion", certVersion,
 				"fingerprint", fingerprint,
 				"issuer", issuer,
-				"initiatorIndex", uint64(hs.Details.InitiatorIndex),
-				"responderIndex", uint64(hs.Details.ResponderIndex),
-				"remoteIndex", uint64(h.RemoteIndex),
+				"initiatorIndex", hs.Details.InitiatorIndex,
+				"responderIndex", hs.Details.ResponderIndex,
+				"remoteIndex", h.RemoteIndex,
 				"handshake", m{"stage": 1, "style": "ix_psk0"},
-				"localIndex", uint64(hostinfo.localIndexId),
+				"localIndex", hostinfo.localIndexId,
 				"collision", existing.vpnAddrs,
 			)
 			return
@@ -493,9 +493,9 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 				"certVersion", certVersion,
 				"fingerprint", fingerprint,
 				"issuer", issuer,
-				"initiatorIndex", uint64(hs.Details.InitiatorIndex),
-				"responderIndex", uint64(hs.Details.ResponderIndex),
-				"remoteIndex", uint64(h.RemoteIndex),
+				"initiatorIndex", hs.Details.InitiatorIndex,
+				"responderIndex", hs.Details.ResponderIndex,
+				"remoteIndex", h.RemoteIndex,
 				"handshake", m{"stage": 1, "style": "ix_psk0"},
 			)
 			return
@@ -513,9 +513,9 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 			"certVersion", certVersion,
 			"fingerprint", fingerprint,
 			"issuer", issuer,
-			"initiatorIndex", uint64(hs.Details.InitiatorIndex),
-			"responderIndex", uint64(hs.Details.ResponderIndex),
-			"remoteIndex", uint64(h.RemoteIndex),
+			"initiatorIndex", hs.Details.InitiatorIndex,
+			"responderIndex", hs.Details.ResponderIndex,
+			"remoteIndex", h.RemoteIndex,
 			"handshake", m{"stage": 2, "style": "ix_psk0"},
 		)
 		if err != nil {
@@ -540,9 +540,9 @@ func ixHandshakeStage1(f *Interface, via ViaSender, packet []byte, h *header.H) 
 			"certVersion", certVersion,
 			"fingerprint", fingerprint,
 			"issuer", issuer,
-			"initiatorIndex", uint64(hs.Details.InitiatorIndex),
-			"responderIndex", uint64(hs.Details.ResponderIndex),
-			"remoteIndex", uint64(h.RemoteIndex),
+			"initiatorIndex", hs.Details.InitiatorIndex,
+			"responderIndex", hs.Details.ResponderIndex,
+			"remoteIndex", h.RemoteIndex,
 			"handshake", m{"stage": 2, "style": "ix_psk0"},
 		)
 	}
@@ -764,9 +764,9 @@ func ixHandshakeStage2(f *Interface, via ViaSender, hh *HandshakeHostInfo, packe
 		"certVersion", certVersion,
 		"fingerprint", fingerprint,
 		"issuer", issuer,
-		"initiatorIndex", uint64(hs.Details.InitiatorIndex),
-		"responderIndex", uint64(hs.Details.ResponderIndex),
-		"remoteIndex", uint64(h.RemoteIndex),
+		"initiatorIndex", hs.Details.InitiatorIndex,
+		"responderIndex", hs.Details.ResponderIndex,
+		"remoteIndex", h.RemoteIndex,
 		"handshake", m{"stage": 2, "style": "ix_psk0"},
 		"durationNs", duration,
 		"sentCachedPackets", len(hh.packetStore),

--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -185,8 +185,8 @@ func (hm *HandshakeManager) handleOutbound(vpnIp netip.Addr, lighthouseTriggered
 	if hh.counter >= hm.config.retries {
 		hh.hostinfo.logger(hm.l).Info("Handshake timed out",
 			"udpAddrs", hh.hostinfo.remotes.CopyAddrs(hm.mainHostMap.GetPreferredRanges()),
-			"initiatorIndex", uint64(hh.hostinfo.localIndexId),
-			"remoteIndex", uint64(hh.hostinfo.remoteIndexId),
+			"initiatorIndex", hh.hostinfo.localIndexId,
+			"remoteIndex", hh.hostinfo.remoteIndexId,
 			"handshake", m{"stage": 1, "style": "ix_psk0"},
 			"durationNs", time.Since(hh.startTime).Nanoseconds(),
 		)
@@ -244,7 +244,7 @@ func (hm *HandshakeManager) handleOutbound(vpnIp netip.Addr, lighthouseTriggered
 		if err != nil {
 			hostinfo.logger(hm.l).Error("Failed to send handshake message",
 				"udpAddr", addr,
-				"initiatorIndex", uint64(hostinfo.localIndexId),
+				"initiatorIndex", hostinfo.localIndexId,
 				"handshake", m{"stage": 1, "style": "ix_psk0"},
 				"error", err,
 			)
@@ -259,13 +259,13 @@ func (hm *HandshakeManager) handleOutbound(vpnIp netip.Addr, lighthouseTriggered
 	if remotesHaveChanged {
 		hostinfo.logger(hm.l).Info("Handshake message sent",
 			"udpAddrs", sentTo,
-			"initiatorIndex", uint64(hostinfo.localIndexId),
+			"initiatorIndex", hostinfo.localIndexId,
 			"handshake", m{"stage": 1, "style": "ix_psk0"},
 		)
 	} else if hm.l.Enabled(context.Background(), slog.LevelDebug) {
 		hostinfo.logger(hm.l).Debug("Handshake message sent",
 			"udpAddrs", sentTo,
-			"initiatorIndex", uint64(hostinfo.localIndexId),
+			"initiatorIndex", hostinfo.localIndexId,
 			"handshake", m{"stage": 1, "style": "ix_psk0"},
 		)
 	}
@@ -337,7 +337,7 @@ func (hm *HandshakeManager) handleOutbound(vpnIp netip.Addr, lighthouseTriggered
 						hm.l.Info("send CreateRelayRequest",
 							"relayFrom", hm.f.myVpnAddrs[0],
 							"relayTo", vpnIp,
-							"initiatorRelayIndex", uint64(idx),
+							"initiatorRelayIndex", idx,
 							"relay", relay,
 						)
 					}
@@ -393,7 +393,7 @@ func (hm *HandshakeManager) handleOutbound(vpnIp netip.Addr, lighthouseTriggered
 					hm.l.Info("send CreateRelayRequest",
 						"relayFrom", hm.f.myVpnAddrs[0],
 						"relayTo", vpnIp,
-						"initiatorRelayIndex", uint64(existingRelay.LocalIndex),
+						"initiatorRelayIndex", existingRelay.LocalIndex,
 						"relay", relay,
 					)
 				}
@@ -551,7 +551,7 @@ func (hm *HandshakeManager) CheckAndComplete(hostinfo *HostInfo, handshakePacket
 		// We have a collision, but this can happen since we can't control
 		// the remote ID. Just log about the situation as a note.
 		hostinfo.logger(hm.l).Info("New host shadows existing host remoteIndex",
-			"remoteIndex", uint64(hostinfo.remoteIndexId),
+			"remoteIndex", hostinfo.remoteIndexId,
 			"collision", existingRemoteIndex.vpnAddrs,
 		)
 	}
@@ -574,7 +574,7 @@ func (hm *HandshakeManager) Complete(hostinfo *HostInfo, f *Interface) {
 		// We have a collision, but this can happen since we can't control
 		// the remote ID. Just log about the situation as a note.
 		hostinfo.logger(hm.l).Info("New host shadows existing host remoteIndex",
-			"remoteIndex", uint64(hostinfo.remoteIndexId),
+			"remoteIndex", hostinfo.remoteIndexId,
 			"collision", existingRemoteIndex.vpnAddrs,
 		)
 	}

--- a/hostmap.go
+++ b/hostmap.go
@@ -801,8 +801,8 @@ func (i *HostInfo) logger(l *slog.Logger) *slog.Logger {
 
 	li := l.With(
 		"vpnAddrs", i.vpnAddrs,
-		"localIndex", uint64(i.localIndexId),
-		"remoteIndex", uint64(i.remoteIndexId),
+		"localIndex", i.localIndexId,
+		"remoteIndex", i.remoteIndexId,
 	)
 
 	if connState := i.ConnectionState; connState != nil {

--- a/outside.go
+++ b/outside.go
@@ -94,7 +94,7 @@ func (f *Interface) readOutsidePackets(via ViaSender, out []byte, packet []byte,
 				// its internal mapping. This should never happen.
 				hostinfo.logger(f.l).Error("HostInfo missing remote relay index",
 					"vpnAddrs", hostinfo.vpnAddrs,
-					"remoteIndex", uint64(h.RemoteIndex),
+					"remoteIndex", h.RemoteIndex,
 				)
 				return
 			}
@@ -592,7 +592,7 @@ func (f *Interface) sendRecvError(endpoint netip.AddrPort, index uint32) {
 	_ = f.outside.WriteTo(b, endpoint)
 	if f.l.Enabled(context.Background(), slog.LevelDebug) {
 		f.l.Debug("Recv error sent",
-			"index", uint64(index),
+			"index", index,
 			"udpAddr", endpoint,
 		)
 	}
@@ -601,7 +601,7 @@ func (f *Interface) sendRecvError(endpoint netip.AddrPort, index uint32) {
 func (f *Interface) handleRecvError(addr netip.AddrPort, h *header.H) {
 	if !f.acceptRecvErrorConfig.ShouldRecvError(addr) {
 		f.l.Debug("Recv error received, ignoring",
-			"index", uint64(h.RemoteIndex),
+			"index", h.RemoteIndex,
 			"udpAddr", addr,
 		)
 		return
@@ -609,14 +609,14 @@ func (f *Interface) handleRecvError(addr netip.AddrPort, h *header.H) {
 
 	if f.l.Enabled(context.Background(), slog.LevelDebug) {
 		f.l.Debug("Recv error received",
-			"index", uint64(h.RemoteIndex),
+			"index", h.RemoteIndex,
 			"udpAddr", addr,
 		)
 	}
 
 	hostinfo := f.hostMap.QueryReverseIndex(h.RemoteIndex)
 	if hostinfo == nil {
-		f.l.Debug("Did not find remote index in main hostmap", "remoteIndex", uint64(h.RemoteIndex))
+		f.l.Debug("Did not find remote index in main hostmap", "remoteIndex", h.RemoteIndex)
 		return
 	}
 


### PR DESCRIPTION
This was a holdover from when we were using slog.Attrs.