### PR TITLE
Simplify the windows event viewer shim

### DIFF
--- a/cmd/nebula-service/logs_windows.go
+++ b/cmd/nebula-service/logs_windows.go
@@ -1,129 +1,86 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
-	"sync/atomic"
+
+	"github.com/slackhq/nebula/logging"
 )
 
 // newPlatformLogger returns a *slog.Logger that routes every log record
-// through the Windows service logger so records end up in the Windows Event
-// Viewer. Formatting is delegated to slog's builtin text or JSON handler
-// writing into a shared buffer; the formatted line is then forwarded to the
-// service logger at a severity matching the record's level. Both a text
-// and a json handler are pre-derived at each WithAttrs/WithGroup call so a
-// SetFormat flip propagates instantly without rebuilding anything.
+// through the Windows service logger so records end up in the Windows
+// Event Log. All the heavy lifting (level management, format swap,
+// timestamp toggle, WithAttrs/WithGroup) comes from logging.NewHandler;
+// this file only contributes:
+//
+//   - an io.Writer that forwards each formatted line to the service
+//     logger at the current record's Event Log severity, and
+//   - a thin severityTag that embeds *logging.Handler and overrides
+//     only Handle / WithAttrs / WithGroup, so Event Viewer's severity
+//     column and severity-based filters keep working the way they did
+//     before the slog migration.
+//
+// Format (text vs json) is carried by the embedded *logging.Handler, so
+// logging.format: json in config still produces JSON lines in Event
+// Viewer, same as the pre-slog logrus setup.
 func newPlatformLogger() *slog.Logger {
-	root := &serviceHandlerRoot{}
-	root.level.Set(slog.LevelInfo)
-	opts := &slog.HandlerOptions{Level: &root.level}
-	return slog.New(&serviceHandler{
-		root: root,
-		text: slog.NewTextHandler(&root.buf, opts),
-		json: slog.NewJSONHandler(&root.buf, opts),
-	})
+	w := &eventLogWriter{}
+	return slog.New(&severityTag{Handler: logging.NewHandler(w), w: w})
 }
 
-// serviceHandlerRoot holds the per-logger mutable state shared across
-// WithAttrs/WithGroup derivations. The buffer is shared because Handle
-// serializes on mu before each serialize + route + reset cycle.
-type serviceHandlerRoot struct {
-	level    slog.LevelVar
-	jsonMode atomic.Bool
-
-	mu  sync.Mutex
-	buf bytes.Buffer
+// eventLogWriter forwards slog-formatted lines to the Windows service
+// logger at the severity most recently stashed by severityTag.Handle.
+// The mutex serializes the stash + inner.Handle + Write cycle per record
+// across all concurrent goroutines; slog's builtin text/json handlers
+// each hold their own mutex around Write, but that only protects the
+// Write call itself, not our stash-then-handle sequence.
+type eventLogWriter struct {
+	mu    sync.Mutex
+	level slog.Level
 }
 
-// serviceHandler dispatches each record to either a text or a json
-// slog.Handler (both write into the shared buffer), then forwards the
-// formatted line to the Windows service logger at the matching severity.
-type serviceHandler struct {
-	root *serviceHandlerRoot
-	text slog.Handler
-	json slog.Handler
-}
-
-func (sh *serviceHandler) Enabled(_ context.Context, l slog.Level) bool {
-	return sh.root.level.Level() <= l
-}
-
-func (sh *serviceHandler) Handle(ctx context.Context, r slog.Record) error {
-	sh.root.mu.Lock()
-	defer sh.root.mu.Unlock()
-	sh.root.buf.Reset()
-
-	var err error
-	if sh.root.jsonMode.Load() {
-		err = sh.json.Handle(ctx, r)
-	} else {
-		err = sh.text.Handle(ctx, r)
-	}
-	if err != nil {
-		return err
-	}
-
-	line := strings.TrimRight(sh.root.buf.String(), "\n")
+func (w *eventLogWriter) Write(p []byte) (int, error) {
+	line := strings.TrimRight(string(p), "\n")
 	switch {
-	case r.Level >= slog.LevelError:
-		return logger.Error(line)
-	case r.Level >= slog.LevelWarn:
-		return logger.Warning(line)
+	case w.level >= slog.LevelError:
+		return len(p), logger.Error(line)
+	case w.level >= slog.LevelWarn:
+		return len(p), logger.Warning(line)
 	default:
-		return logger.Info(line)
+		return len(p), logger.Info(line)
 	}
 }
 
-func (sh *serviceHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+// severityTag embeds *logging.Handler to pick up everything it does for
+// free (Enabled, SetLevel, GetLevel, SetFormat, GetFormat,
+// SetDisableTimestamp) and overrides only Handle / WithAttrs / WithGroup
+// so each record's slog.Level is stashed on the writer before formatting
+// and so derived handlers stay wrapped as severityTag rather than
+// downgrading to bare *logging.Handler.
+type severityTag struct {
+	*logging.Handler
+	w *eventLogWriter
+}
+
+func (s *severityTag) Handle(ctx context.Context, r slog.Record) error {
+	s.w.mu.Lock()
+	defer s.w.mu.Unlock()
+	s.w.level = r.Level
+	return s.Handler.Handle(ctx, r)
+}
+
+func (s *severityTag) WithAttrs(attrs []slog.Attr) slog.Handler {
 	if len(attrs) == 0 {
-		return sh
+		return s
 	}
-	return &serviceHandler{
-		root: sh.root,
-		text: sh.text.WithAttrs(attrs),
-		json: sh.json.WithAttrs(attrs),
-	}
+	return &severityTag{Handler: s.Handler.WithAttrs(attrs).(*logging.Handler), w: s.w}
 }
 
-func (sh *serviceHandler) WithGroup(name string) slog.Handler {
+func (s *severityTag) WithGroup(name string) slog.Handler {
 	if name == "" {
-		return sh
+		return s
 	}
-	return &serviceHandler{
-		root: sh.root,
-		text: sh.text.WithGroup(name),
-		json: sh.json.WithGroup(name),
-	}
-}
-
-// SetLevel lets logging.ApplyConfig and the SSH commands honor logging.level.
-func (sh *serviceHandler) SetLevel(lvl slog.Level) { sh.root.level.Set(lvl) }
-
-// GetLevel is the structural counterpart used by sshLogLevel.
-func (sh *serviceHandler) GetLevel() slog.Level { return sh.root.level.Level() }
-
-// SetFormat flips which inner handler Handle dispatches to. The change
-// propagates to every derived handler immediately; no rebuild is required.
-func (sh *serviceHandler) SetFormat(format string) error {
-	switch format {
-	case "text":
-		sh.root.jsonMode.Store(false)
-	case "json":
-		sh.root.jsonMode.Store(true)
-	default:
-		return fmt.Errorf("unknown log format `%s`. possible formats: %s", format, []string{"text", "json"})
-	}
-	return nil
-}
-
-// GetFormat is the structural counterpart used by sshLogFormat.
-func (sh *serviceHandler) GetFormat() string {
-	if sh.root.jsonMode.Load() {
-		return "json"
-	}
-	return "text"
+	return &severityTag{Handler: s.Handler.WithGroup(name).(*logging.Handler), w: s.w}
 }

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -44,45 +44,54 @@ const LevelTrace = slog.Level(-8)
 // they care about. Callers that pass a plain *slog.Logger without these
 // methods get a silent no-op; reconfiguration is always opt-in.
 func NewLogger(w io.Writer) *slog.Logger {
+	return slog.New(NewHandler(w))
+}
+
+// NewHandler builds the *Handler that NewLogger wraps. Exported for
+// platform-specific sinks (notably cmd/nebula-service/logs_windows.go)
+// that want to wrap the handler with extra behavior, such as tagging each
+// record with its Event Log severity, while still benefiting from all the
+// level / format / timestamp / WithAttrs machinery implemented here.
+func NewHandler(w io.Writer) *Handler {
 	root := &handlerRoot{}
 	root.level.Set(slog.LevelInfo)
 	opts := &slog.HandlerOptions{Level: &root.level}
-	return slog.New(&handler{
+	return &Handler{
 		root: root,
 		text: slog.NewTextHandler(w, opts),
 		json: slog.NewJSONHandler(w, opts),
-	})
+	}
 }
 
 // handlerRoot carries the reconfiguration state shared by every logger
-// derived from a NewLogger call. All fields are consulted on the log path
-// and updated lock-free.
+// derived from a NewHandler call. All fields are consulted on the log
+// path and updated lock-free.
 type handlerRoot struct {
 	level            slog.LevelVar
 	disableTimestamp atomic.Bool
-	// jsonMode picks which of the pre-derived inner handlers handler.Handle
+	// jsonMode picks which of the pre-derived inner handlers Handler.Handle
 	// dispatches to. Flipping it propagates instantly to every derived logger
 	// without rebuilding or chain-replaying anything.
 	jsonMode atomic.Bool
 }
 
-// handler is the slog.Handler returned by NewLogger. It holds two
+// Handler is the slog.Handler returned by NewHandler. It holds two
 // pre-derived slog handlers -- one text, one json -- both built from the
 // same accumulated WithAttrs/WithGroup state. Handle picks which one to
 // dispatch to based on handlerRoot.jsonMode, so a SetFormat call takes
 // effect immediately across the whole process without having to rebuild
 // any derived loggers.
-type handler struct {
+type Handler struct {
 	root *handlerRoot
 	text slog.Handler
 	json slog.Handler
 }
 
-func (h *handler) Enabled(_ context.Context, l slog.Level) bool {
+func (h *Handler) Enabled(_ context.Context, l slog.Level) bool {
 	return h.root.level.Level() <= l
 }
 
-func (h *handler) Handle(ctx context.Context, r slog.Record) error {
+func (h *Handler) Handle(ctx context.Context, r slog.Record) error {
 	if h.root.disableTimestamp.Load() {
 		r.Time = time.Time{}
 	}
@@ -92,22 +101,22 @@ func (h *handler) Handle(ctx context.Context, r slog.Record) error {
 	return h.text.Handle(ctx, r)
 }
 
-func (h *handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	if len(attrs) == 0 {
 		return h
 	}
-	return &handler{
+	return &Handler{
 		root: h.root,
 		text: h.text.WithAttrs(attrs),
 		json: h.json.WithAttrs(attrs),
 	}
 }
 
-func (h *handler) WithGroup(name string) slog.Handler {
+func (h *Handler) WithGroup(name string) slog.Handler {
 	if name == "" {
 		return h
 	}
-	return &handler{
+	return &Handler{
 		root: h.root,
 		text: h.text.WithGroup(name),
 		json: h.json.WithGroup(name),
@@ -116,15 +125,15 @@ func (h *handler) WithGroup(name string) slog.Handler {
 
 // SetLevel updates the effective log level. Propagates to every derived
 // logger via the shared LevelVar.
-func (h *handler) SetLevel(level slog.Level) { h.root.level.Set(level) }
+func (h *Handler) SetLevel(level slog.Level) { h.root.level.Set(level) }
 
 // GetLevel reports the current log level.
-func (h *handler) GetLevel() slog.Level { return h.root.level.Level() }
+func (h *Handler) GetLevel() slog.Level { return h.root.level.Level() }
 
 // SetFormat flips the output format atomically. Valid formats are "text"
 // and "json". Every derived logger sees the new format on its next Handle
 // call; no rebuild or registration is required.
-func (h *handler) SetFormat(format string) error {
+func (h *Handler) SetFormat(format string) error {
 	switch format {
 	case "text":
 		h.root.jsonMode.Store(false)
@@ -137,7 +146,7 @@ func (h *handler) SetFormat(format string) error {
 }
 
 // GetFormat reports the currently selected format name.
-func (h *handler) GetFormat() string {
+func (h *Handler) GetFormat() string {
 	if h.root.jsonMode.Load() {
 		return "json"
 	}
@@ -147,7 +156,7 @@ func (h *handler) GetFormat() string {
 // SetDisableTimestamp toggles whether Handle zeroes r.Time before
 // dispatching (slog's builtin text/json handlers skip emitting the time
 // attribute on a zero time).
-func (h *handler) SetDisableTimestamp(v bool) { h.root.disableTimestamp.Store(v) }
+func (h *Handler) SetDisableTimestamp(v bool) { h.root.disableTimestamp.Store(v) }
 
 // ApplyConfig reads logging.level, logging.format, and (optionally)
 // logging.disable_timestamp from c and applies them to l. The reconfig


### PR DESCRIPTION
This uses the main `logging.Handler` from nebula to hoist all its functionality up and means we can stop duplicating a lot of that work in the event viewer shim.