### PR TITLE
overlay/tio: KeepAlive writev iovec + payloads through syscall

### DIFF
--- a/overlay/tio/tio_gso_linux.go
+++ b/overlay/tio/tio_gso_linux.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"sync/atomic"
 	"syscall"
 	"unsafe"
@@ -264,12 +265,23 @@ func (r *Offload) writeWithScratch(buf []byte, iovs *[2]unix.Iovec) (int, error)
 	iovs[1].Base = &buf[0]
 	iovs[1].SetLen(len(buf))
 	iovPtr := unsafe.Pointer(&iovs[0])
-	return r.rawWrite(iovPtr, 2)
+	// Pin the caller's buffer AND the iovec array through the syscall.
+	return r.rawWrite(iovPtr, 2, buf, iovs)
 }
 
-func (r *Offload) rawWrite(iovs unsafe.Pointer, iovcnt int) (int, error) {
+func (r *Offload) rawWrite(iovs unsafe.Pointer, iovcnt int, keepAlive ...interface{}) (int, error) {
 	for {
 		n, _, errno := syscall.Syscall(unix.SYS_WRITEV, uintptr(r.fd), uintptr(iovs), uintptr(iovcnt))
+		// Anchor the iovec array + every user-supplied payload slice
+		// through the syscall return. Without these, Go's GC may move or
+		// collect the underlying backing arrays while the kernel is still
+		// reading them via DMA (we pass the iovec as uintptr, so the
+		// compiler does not keep it live). Observed in practice as a
+		// kernel refcount underflow on tun_chr_write_iter / sock_wfree.
+		runtime.KeepAlive(iovs)
+		for _, ka := range keepAlive {
+			runtime.KeepAlive(ka)
+		}
 		if errno == 0 {
 			if int(n) < virtioNetHdrLen {
 				return 0, io.ErrShortWrite
@@ -354,7 +366,11 @@ func (r *Offload) WriteGSO(hdr []byte, pays [][]byte, gsoSize uint16, isV6 bool,
 
 	iovPtr := unsafe.Pointer(&r.gsoIovs[0])
 	iovCnt := len(r.gsoIovs)
-	_, err := r.rawWrite(iovPtr, iovCnt)
+	// Pin EVERYTHING the kernel might still read via DMA: the backing iovec
+	// slice, the IP/TCP header buffer, and every individual payload
+	// fragment. Skipping any of these risks a use-after-free in
+	// tun_chr_write_iter if GC runs mid-syscall.
+	_, err := r.rawWrite(iovPtr, iovCnt, r.gsoIovs, hdr, pays)
 	return err
 }
 

--- a/overlay/tio/tio_poll_linux.go
+++ b/overlay/tio/tio_poll_linux.go
@@ -3,6 +3,7 @@ package tio
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"sync/atomic"
 	"syscall"
 	"unsafe"
@@ -120,6 +121,13 @@ func (t *Poll) readOne(to []byte) (int, error) {
 	}
 	for {
 		n, _, errno := syscall.Syscall(syscall.SYS_READV, uintptr(t.fd), uintptr(unsafe.Pointer(&iovecs[0])), 2)
+		// Pin the iovec + destination buffer backing array across the syscall.
+		// Without these the Go runtime may move/GC them while the kernel is
+		// still writing via DMA (we pass the iovec as uintptr, which hides it
+		// from escape analysis). Same class of bug as rawWrite in the Offload
+		// path.
+		runtime.KeepAlive(iovecs)
+		runtime.KeepAlive(to)
 		if errno == 0 {
 			bytesRead := int(n)
 			if bytesRead < 4 {
@@ -166,6 +174,10 @@ func (t *Poll) Write(from []byte) (int, error) {
 	}
 	for {
 		n, _, errno := syscall.Syscall(syscall.SYS_WRITEV, uintptr(t.fd), uintptr(unsafe.Pointer(&iovecs[0])), 2)
+		// Pin the iovec + source buffer backing array across the syscall.
+		// See readOne's KeepAlive comment for rationale.
+		runtime.KeepAlive(iovecs)
+		runtime.KeepAlive(from)
 		if errno == 0 {
 			return int(n) - 4, nil
 		}


### PR DESCRIPTION
Obsolete: Jack landed equivalent or better fixes for both pieces independently:

- `8fd724d` ("fix?"): same hdr_len trust fix this PR's first commit had.
- `c9d5a6e` ("be safer"): cleaner structural fix to `rawWrite` — converted the `unsafe.Pointer` → `uintptr` pattern to a proper `[]unix.Iovec` slice, which lets the compiler keep the iovec rooted automatically without `runtime.KeepAlive`.
- `334dd7a` ("NAPI broken on old kernels and also not helpful"): removes `IFF_NAPI` from the TUN open. This is the actual fix for the kernel UAF I reported in PR comments — `IFF_NAPI` causes `tun_napi_receive` to call `napi_gro_receive` instead of `netif_receive_skb`, which doesn't orphan the skb. On Linux 4.19 (UniFi UXG-Pro), the skb retains TUN-socket ownership through forwarding into a local TCP socket; `tcp_recvmsg` then calls `sock_wfree` against the TUN socket, underflowing `sk_wmem_alloc`. The `kfree_skb` + `tcp_recvmsg` paired warnings I posted earlier all originate from this.

All three bugs reproduced/verified on a UXG-Pro under iperf3 -R; box is now stable on `better-tun-interface@334dd7a` with full GSO/GRO + TSO write-side coalescing.

Closing as superseded. Thanks Jack.

Not filing a separate PR for the IFF_NAPI removal since you've already done it; the analysis is in PR #1695 comments if anyone needs it later.