### PR TITLE
Darwin and openbsd in line with the other bsds for tun support

### DIFF
--- a/overlay/tun_darwin.go
+++ b/overlay/tun_darwin.go
@@ -23,7 +23,8 @@ import (
 )
 
 type tun struct {
-	io.ReadWriteCloser
+	f           *os.File
+	rc          syscall.RawConn
 	Device      string
 	vpnNetworks []netip.Prefix
 	DefaultMTU  int
@@ -31,9 +32,6 @@ type tun struct {
 	routeTree   atomic.Pointer[bart.Table[routing.Gateways]]
 	linkAddr    *netroute.LinkAddr
 	l           *slog.Logger
-
-	// cache out buffer since we need to prepend 4 bytes for tun metadata
-	out []byte
 }
 
 type ifReq struct {
@@ -123,12 +121,19 @@ func newTun(c *config.C, l *slog.Logger, vpnNetworks []netip.Prefix, _ bool) (*t
 		return nil, fmt.Errorf("SetNonblock: %v", err)
 	}
 
+	f := os.NewFile(uintptr(fd), "")
+	rc, err := f.SyscallConn()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get syscall conn for tun: %w", err)
+	}
+
 	t := &tun{
-		ReadWriteCloser: os.NewFile(uintptr(fd), ""),
-		Device:          name,
-		vpnNetworks:     vpnNetworks,
-		DefaultMTU:      c.GetInt("tun.mtu", DefaultMTU),
-		l:               l,
+		f:           f,
+		rc:          rc,
+		Device:      name,
+		vpnNetworks: vpnNetworks,
+		DefaultMTU:  c.GetInt("tun.mtu", DefaultMTU),
+		l:           l,
 	}
 
 	err = t.reload(c, true)
@@ -158,8 +163,8 @@ func newTunFromFd(_ *config.C, _ *slog.Logger, _ int, _ []netip.Prefix) (*tun, e
 }
 
 func (t *tun) Close() error {
-	if t.ReadWriteCloser != nil {
-		return t.ReadWriteCloser.Close()
+	if t.f != nil {
+		return t.f.Close()
 	}
 	return nil
 }
@@ -502,42 +507,79 @@ func delRoute(prefix netip.Prefix, gateway netroute.Addr) error {
 	return nil
 }
 
+// Read pulls one IP packet off the utun device.
 func (t *tun) Read(to []byte) (int, error) {
-	buf := make([]byte, len(to)+4)
+	var errno syscall.Errno
+	var n uintptr
+	err := t.rc.Read(func(fd uintptr) bool {
+		var head [4]byte
+		iovecs := [2]syscall.Iovec{
+			{Base: &head[0], Len: 4},
+			{Base: &to[0], Len: uint64(len(to))},
+		}
+		n, _, errno = syscall.Syscall(syscall.SYS_READV, fd, uintptr(unsafe.Pointer(&iovecs[0])), 2)
+		// EAGAIN/EWOULDBLOCK: tell the runtime to wait for the fd to be
+		// readable and call us again.
+		if errno.Temporary() {
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		if err == syscall.EBADF || err.Error() == "use of closed file" {
+			return 0, os.ErrClosed
+		}
+		return 0, fmt.Errorf("failed to make read call for tun: %w", err)
+	}
+	if errno != 0 {
+		return 0, fmt.Errorf("failed to make inner read call for tun: %w", errno)
+	}
 
-	n, err := t.ReadWriteCloser.Read(buf)
-
-	copy(to, buf[4:])
-	return n - 4, err
+	bytesRead := int(n)
+	if bytesRead < 4 {
+		return 0, nil
+	}
+	return bytesRead - 4, nil
 }
 
-// Write is only valid for single threaded use
+// Write pushes one IP packet onto the utun device.
 func (t *tun) Write(from []byte) (int, error) {
-	buf := t.out
-	if cap(buf) < len(from)+4 {
-		buf = make([]byte, len(from)+4)
-		t.out = buf
-	}
-	buf = buf[:len(from)+4]
-
 	if len(from) == 0 {
 		return 0, syscall.EIO
 	}
 
-	// Determine the IP Family for the NULL L2 Header
 	ipVer := from[0] >> 4
-	if ipVer == 4 {
-		buf[3] = syscall.AF_INET
-	} else if ipVer == 6 {
-		buf[3] = syscall.AF_INET6
-	} else {
+	var head [4]byte
+	switch ipVer {
+	case 4:
+		head[3] = syscall.AF_INET
+	case 6:
+		head[3] = syscall.AF_INET6
+	default:
 		return 0, fmt.Errorf("unable to determine IP version from packet")
 	}
 
-	copy(buf[4:], from)
+	var errno syscall.Errno
+	var n uintptr
+	err := t.rc.Write(func(fd uintptr) bool {
+		iovecs := [2]syscall.Iovec{
+			{Base: &head[0], Len: 4},
+			{Base: &from[0], Len: uint64(len(from))},
+		}
+		n, _, errno = syscall.Syscall(syscall.SYS_WRITEV, fd, uintptr(unsafe.Pointer(&iovecs[0])), 2)
+		if errno.Temporary() {
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		return 0, err
+	}
+	if errno != 0 {
+		return 0, errno
+	}
 
-	n, err := t.ReadWriteCloser.Write(buf)
-	return n - 4, err
+	return int(n) - 4, nil
 }
 
 func (t *tun) Networks() []netip.Prefix {

--- a/overlay/tun_darwin.go
+++ b/overlay/tun_darwin.go
@@ -24,7 +24,6 @@ import (
 
 type tun struct {
 	f           *os.File
-	rc          syscall.RawConn
 	Device      string
 	vpnNetworks []netip.Prefix
 	DefaultMTU  int
@@ -121,15 +120,8 @@ func newTun(c *config.C, l *slog.Logger, vpnNetworks []netip.Prefix, _ bool) (*t
 		return nil, fmt.Errorf("SetNonblock: %v", err)
 	}
 
-	f := os.NewFile(uintptr(fd), "")
-	rc, err := f.SyscallConn()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get syscall conn for tun: %w", err)
-	}
-
 	t := &tun{
-		f:           f,
-		rc:          rc,
+		f:           os.NewFile(uintptr(fd), ""),
 		Device:      name,
 		vpnNetworks: vpnNetworks,
 		DefaultMTU:  c.GetInt("tun.mtu", DefaultMTU),
@@ -509,9 +501,15 @@ func delRoute(prefix netip.Prefix, gateway netroute.Addr) error {
 
 // Read pulls one IP packet off the utun device.
 func (t *tun) Read(to []byte) (int, error) {
+	// Grab rc as a local so the compiler can devirtualize the call and keep the closure on the stack.
+	rc, err := t.f.SyscallConn()
+	if err != nil {
+		return 0, err
+	}
+
 	var errno syscall.Errno
 	var n uintptr
-	err := t.rc.Read(func(fd uintptr) bool {
+	err = rc.Read(func(fd uintptr) bool {
 		var head [4]byte
 		iovecs := [2]syscall.Iovec{
 			{Base: &head[0], Len: 4},
@@ -529,10 +527,10 @@ func (t *tun) Read(to []byte) (int, error) {
 		if err == syscall.EBADF || err.Error() == "use of closed file" {
 			return 0, os.ErrClosed
 		}
-		return 0, fmt.Errorf("failed to make read call for tun: %w", err)
+		return 0, err
 	}
 	if errno != 0 {
-		return 0, fmt.Errorf("failed to make inner read call for tun: %w", errno)
+		return 0, errno
 	}
 
 	bytesRead := int(n)
@@ -559,9 +557,14 @@ func (t *tun) Write(from []byte) (int, error) {
 		return 0, fmt.Errorf("unable to determine IP version from packet")
 	}
 
+	rc, err := t.f.SyscallConn()
+	if err != nil {
+		return 0, err
+	}
+
 	var errno syscall.Errno
 	var n uintptr
-	err := t.rc.Write(func(fd uintptr) bool {
+	err = rc.Write(func(fd uintptr) bool {
 		iovecs := [2]syscall.Iovec{
 			{Base: &head[0], Len: 4},
 			{Base: &from[0], Len: uint64(len(from))},

--- a/overlay/tun_darwin.go
+++ b/overlay/tun_darwin.go
@@ -31,6 +31,16 @@ type tun struct {
 	routeTree   atomic.Pointer[bart.Table[routing.Gateways]]
 	linkAddr    *netroute.LinkAddr
 	l           *slog.Logger
+
+	// readBuf is the per-tun read scratch reused across calls so we don't allocate per Read.
+	// We could call readv via syscall.Syscall(SYS_READV, ...), but on darwin/arm64 that path emits
+	// a raw SVC #0x80 trap (see $GOROOT/src/syscall/asm_darwin_arm64.s) rather than going through
+	// libSystem. Apple has been signaling for years that direct syscalls are deprecated, so we
+	// stick to libc-pinned writev via linkname (see tunWritev) and use plain f.Read for the read
+	// path. Stdlib doesn't keep syscall.readv alive for external linkname (only writev gets that
+	// treatment via linkname_libc.go), so the read path can't use readv and has to do the
+	// prefix-skip copy.
+	readBuf []byte
 }
 
 type ifReq struct {
@@ -120,12 +130,14 @@ func newTun(c *config.C, l *slog.Logger, vpnNetworks []netip.Prefix, _ bool) (*t
 		return nil, fmt.Errorf("SetNonblock: %v", err)
 	}
 
+	mtu := c.GetInt("tun.mtu", DefaultMTU)
 	t := &tun{
 		f:           os.NewFile(uintptr(fd), ""),
 		Device:      name,
 		vpnNetworks: vpnNetworks,
-		DefaultMTU:  c.GetInt("tun.mtu", DefaultMTU),
+		DefaultMTU:  mtu,
 		l:           l,
+		readBuf:     make([]byte, mtu+4),
 	}
 
 	err = t.reload(c, true)
@@ -499,45 +511,34 @@ func delRoute(prefix netip.Prefix, gateway netroute.Addr) error {
 	return nil
 }
 
+// tunWritev is linkname'd from the standard library so the writev call goes through libSystem's
+// pinned trampoline. syscall.Syscall(SYS_WRITEV, ...) on darwin/arm64 emits a raw SVC #0x80 trap
+// (see $GOROOT/src/syscall/asm_darwin_arm64.s), which is the path Apple has signaled they will
+// eventually disallow. Stdlib's $GOROOT/src/syscall/linkname_libc.go has a bare
+// `//go:linkname writev` directive that opts in external linkname and keeps the symbol alive for
+// the linker on darwin (and openbsd). There is no equivalent for readv, which is why Read uses
+// f.Read with a prefix-skip copy instead.
+
+//go:linkname tunWritev syscall.writev
+//go:noescape
+func tunWritev(fd int, iovecs []syscall.Iovec) (n uintptr, err error)
+
 // Read pulls one IP packet off the utun device.
 func (t *tun) Read(to []byte) (int, error) {
-	// Grab rc as a local so the compiler can devirtualize the call and keep the closure on the stack.
-	rc, err := t.f.SyscallConn()
+	if cap(t.readBuf) < len(to)+4 {
+		t.readBuf = make([]byte, len(to)+4)
+	}
+	buf := t.readBuf[:len(to)+4]
+
+	n, err := t.f.Read(buf)
 	if err != nil {
 		return 0, err
 	}
-
-	var errno syscall.Errno
-	var n uintptr
-	err = rc.Read(func(fd uintptr) bool {
-		var head [4]byte
-		iovecs := [2]syscall.Iovec{
-			{Base: &head[0], Len: 4},
-			{Base: &to[0], Len: uint64(len(to))},
-		}
-		n, _, errno = syscall.Syscall(syscall.SYS_READV, fd, uintptr(unsafe.Pointer(&iovecs[0])), 2)
-		// EAGAIN/EWOULDBLOCK: tell the runtime to wait for the fd to be
-		// readable and call us again.
-		if errno.Temporary() {
-			return false
-		}
-		return true
-	})
-	if err != nil {
-		if err == syscall.EBADF || err.Error() == "use of closed file" {
-			return 0, os.ErrClosed
-		}
-		return 0, err
-	}
-	if errno != 0 {
-		return 0, errno
-	}
-
-	bytesRead := int(n)
-	if bytesRead < 4 {
+	if n < 4 {
 		return 0, nil
 	}
-	return bytesRead - 4, nil
+	copy(to, buf[4:n])
+	return n - 4, nil
 }
 
 // Write pushes one IP packet onto the utun device.
@@ -557,20 +558,23 @@ func (t *tun) Write(from []byte) (int, error) {
 		return 0, fmt.Errorf("unable to determine IP version from packet")
 	}
 
+	// Grab rc as a local so the compiler can devirtualize the call and keep the closure on the stack.
 	rc, err := t.f.SyscallConn()
 	if err != nil {
 		return 0, err
 	}
 
-	var errno syscall.Errno
 	var n uintptr
+	var callErr error
 	err = rc.Write(func(fd uintptr) bool {
-		iovecs := [2]syscall.Iovec{
+		iovecs := []syscall.Iovec{
 			{Base: &head[0], Len: 4},
 			{Base: &from[0], Len: uint64(len(from))},
 		}
-		n, _, errno = syscall.Syscall(syscall.SYS_WRITEV, fd, uintptr(unsafe.Pointer(&iovecs[0])), 2)
-		if errno.Temporary() {
+		n, callErr = tunWritev(int(fd), iovecs)
+		// Type-assert to syscall.Errno so the EAGAIN/EWOULDBLOCK/EINTR check doesn't box the errno
+		// constants into error interfaces on every call.
+		if errno, ok := callErr.(syscall.Errno); ok && errno.Temporary() {
 			return false
 		}
 		return true
@@ -578,8 +582,8 @@ func (t *tun) Write(from []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	if errno != 0 {
-		return 0, errno
+	if callErr != nil {
+		return 0, callErr
 	}
 
 	return int(n) - 4, nil

--- a/overlay/tun_darwin.go
+++ b/overlay/tun_darwin.go
@@ -31,16 +31,6 @@ type tun struct {
 	routeTree   atomic.Pointer[bart.Table[routing.Gateways]]
 	linkAddr    *netroute.LinkAddr
 	l           *slog.Logger
-
-	// readBuf is the per-tun read scratch reused across calls so we don't allocate per Read.
-	// We could call readv via syscall.Syscall(SYS_READV, ...), but on darwin/arm64 that path emits
-	// a raw SVC #0x80 trap (see $GOROOT/src/syscall/asm_darwin_arm64.s) rather than going through
-	// libSystem. Apple has been signaling for years that direct syscalls are deprecated, so we
-	// stick to libc-pinned writev via linkname (see tunWritev) and use plain f.Read for the read
-	// path. Stdlib doesn't keep syscall.readv alive for external linkname (only writev gets that
-	// treatment via linkname_libc.go), so the read path can't use readv and has to do the
-	// prefix-skip copy.
-	readBuf []byte
 }
 
 type ifReq struct {
@@ -130,14 +120,12 @@ func newTun(c *config.C, l *slog.Logger, vpnNetworks []netip.Prefix, _ bool) (*t
 		return nil, fmt.Errorf("SetNonblock: %v", err)
 	}
 
-	mtu := c.GetInt("tun.mtu", DefaultMTU)
 	t := &tun{
 		f:           os.NewFile(uintptr(fd), ""),
 		Device:      name,
 		vpnNetworks: vpnNetworks,
-		DefaultMTU:  mtu,
+		DefaultMTU:  c.GetInt("tun.mtu", DefaultMTU),
 		l:           l,
-		readBuf:     make([]byte, mtu+4),
 	}
 
 	err = t.reload(c, true)
@@ -511,33 +499,54 @@ func delRoute(prefix netip.Prefix, gateway netroute.Addr) error {
 	return nil
 }
 
-// tunWritev is linkname'd from the standard library so the writev call goes through libSystem's
-// pinned trampoline. syscall.Syscall(SYS_WRITEV, ...) on darwin/arm64 emits a raw SVC #0x80 trap
-// (see $GOROOT/src/syscall/asm_darwin_arm64.s), which is the path Apple has signaled they will
-// eventually disallow. Stdlib's $GOROOT/src/syscall/linkname_libc.go has a bare
-// `//go:linkname writev` directive that opts in external linkname and keeps the symbol alive for
-// the linker on darwin (and openbsd). There is no equivalent for readv, which is why Read uses
-// f.Read with a prefix-skip copy instead.
+// tunWritev and tunReadv are linkname'd to x/sys/unix's libc-routed writev/readv stubs so the
+// calls go through libSystem's pinned trampoline. A raw syscall.Syscall(SYS_WRITEV/SYS_READV, ...)
+// on darwin/arm64 emits an SVC #0x80 trap (see $GOROOT/src/syscall/asm_darwin_arm64.s), the path
+// Apple keeps warning they will eventually disallow. We pull the low-level stubs instead of calling
+// unix.Writev/unix.Readv because those take [][]byte and rebuild the []Iovec every call, which
+// heap-allocates the header; linkname'ing the stubs lets us hand them our own stack-allocated
+// iovecs. See golang/go#78049.
 
-//go:linkname tunWritev syscall.writev
+//go:linkname tunWritev golang.org/x/sys/unix.writev
 //go:noescape
-func tunWritev(fd int, iovecs []syscall.Iovec) (n uintptr, err error)
+func tunWritev(fd int, iovecs []unix.Iovec) (n int, err error)
 
-// Read pulls one IP packet off the utun device.
+//go:linkname tunReadv golang.org/x/sys/unix.readv
+//go:noescape
+func tunReadv(fd int, iovecs []unix.Iovec) (n int, err error)
+
+// Read pulls one IP packet off the utun device, scattering the 4 byte protocol header away from
+// the packet so the payload lands directly in to.
 func (t *tun) Read(to []byte) (int, error) {
-	if cap(t.readBuf) < len(to)+4 {
-		t.readBuf = make([]byte, len(to)+4)
-	}
-	buf := t.readBuf[:len(to)+4]
+	var head [4]byte
 
-	n, err := t.f.Read(buf)
+	rc, err := t.f.SyscallConn()
 	if err != nil {
 		return 0, err
+	}
+
+	var n int
+	var callErr error
+	err = rc.Read(func(fd uintptr) bool {
+		iovecs := []unix.Iovec{
+			{Base: &head[0], Len: 4},
+			{Base: &to[0], Len: uint64(len(to))},
+		}
+		n, callErr = tunReadv(int(fd), iovecs)
+		if errno, ok := callErr.(syscall.Errno); ok && errno.Temporary() {
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		return 0, err
+	}
+	if callErr != nil {
+		return 0, callErr
 	}
 	if n < 4 {
 		return 0, nil
 	}
-	copy(to, buf[4:n])
 	return n - 4, nil
 }
 
@@ -564,10 +573,10 @@ func (t *tun) Write(from []byte) (int, error) {
 		return 0, err
 	}
 
-	var n uintptr
+	var n int
 	var callErr error
 	err = rc.Write(func(fd uintptr) bool {
-		iovecs := []syscall.Iovec{
+		iovecs := []unix.Iovec{
 			{Base: &head[0], Len: 4},
 			{Base: &from[0], Len: uint64(len(from))},
 		}
@@ -586,7 +595,7 @@ func (t *tun) Write(from []byte) (int, error) {
 		return 0, callErr
 	}
 
-	return int(n) - 4, nil
+	return n - 4, nil
 }
 
 func (t *tun) Networks() []netip.Prefix {

--- a/overlay/tun_openbsd.go
+++ b/overlay/tun_openbsd.go
@@ -57,7 +57,6 @@ type tun struct {
 	l           *slog.Logger
 	f           *os.File
 	fd          int
-	rc          syscall.RawConn
 
 	// readBuf is the per-tun read scratch reused across calls so we don't allocate per Read.
 	// OpenBSD's pinsyscall protection forbids raw syscall.Syscall(SYS_READV, ...) and stdlib doesn't keep syscall.readv
@@ -95,16 +94,9 @@ func newTun(c *config.C, l *slog.Logger, vpnNetworks []netip.Prefix, _ bool) (*t
 	}
 
 	mtu := c.GetInt("tun.mtu", DefaultMTU)
-	f := os.NewFile(uintptr(fd), "")
-	rc, err := f.SyscallConn()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get syscall conn for tun: %w", err)
-	}
-
 	t := &tun{
-		f:           f,
+		f:           os.NewFile(uintptr(fd), ""),
 		fd:          fd,
-		rc:          rc,
 		Device:      deviceName,
 		vpnNetworks: vpnNetworks,
 		MTU:         mtu,
@@ -186,15 +178,23 @@ func (t *tun) Write(from []byte) (int, error) {
 		return 0, fmt.Errorf("unable to determine IP version from packet")
 	}
 
+	// Grab rc as a local so the compiler can devirtualize the call and keep the closure on the stack.
+	rc, err := t.f.SyscallConn()
+	if err != nil {
+		return 0, err
+	}
+
 	var n uintptr
 	var callErr error
-	err := t.rc.Write(func(fd uintptr) bool {
+	err = rc.Write(func(fd uintptr) bool {
 		iovecs := []syscall.Iovec{
 			{Base: &head[0], Len: 4},
 			{Base: &from[0], Len: uint64(len(from))},
 		}
 		n, callErr = tunWritev(int(fd), iovecs)
-		if errors.Is(callErr, syscall.EAGAIN) || errors.Is(callErr, syscall.EWOULDBLOCK) || errors.Is(callErr, syscall.EINTR) {
+		// Type-assert to syscall.Errno so the EAGAIN/EWOULDBLOCK/EINTR check doesn't box the errno
+		// constants into error interfaces on every call.
+		if errno, ok := callErr.(syscall.Errno); ok && errno.Temporary() {
 			return false
 		}
 		return true

--- a/overlay/tun_openbsd.go
+++ b/overlay/tun_openbsd.go
@@ -57,8 +57,14 @@ type tun struct {
 	l           *slog.Logger
 	f           *os.File
 	fd          int
-	// cache out buffer since we need to prepend 4 bytes for tun metadata
-	out []byte
+	rc          syscall.RawConn
+
+	// readBuf is the per-tun read scratch reused across calls so we don't allocate per Read.
+	// OpenBSD's pinsyscall protection forbids raw syscall.Syscall(SYS_READV, ...) and stdlib doesn't keep syscall.readv
+	// alive for external linkname (only writev gets that treatment via linkname_libc.go)
+	// so the read path can't use readv and has to do the prefix-skip copy.
+	// https://github.com/golang/go/issues/78049
+	readBuf []byte
 }
 
 var deviceNameRE = regexp.MustCompile(`^tun[0-9]+$`)
@@ -88,13 +94,22 @@ func newTun(c *config.C, l *slog.Logger, vpnNetworks []netip.Prefix, _ bool) (*t
 		l.Warn("Failed to set the tun device as nonblocking", "error", err)
 	}
 
+	mtu := c.GetInt("tun.mtu", DefaultMTU)
+	f := os.NewFile(uintptr(fd), "")
+	rc, err := f.SyscallConn()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get syscall conn for tun: %w", err)
+	}
+
 	t := &tun{
-		f:           os.NewFile(uintptr(fd), ""),
+		f:           f,
 		fd:          fd,
+		rc:          rc,
 		Device:      deviceName,
 		vpnNetworks: vpnNetworks,
-		MTU:         c.GetInt("tun.mtu", DefaultMTU),
+		MTU:         mtu,
 		l:           l,
+		readBuf:     make([]byte, mtu+4),
 	}
 
 	err = t.reload(c, true)
@@ -124,42 +139,74 @@ func (t *tun) Close() error {
 	return nil
 }
 
+// tunWritev is linkname'd from the standard library so the writev call goes through libc's pinned syscall trampoline.
+// OpenBSD's pinsyscall protection rejects raw syscall.Syscall(SYS_WRITEV, ...) calls because they don't originate from
+// the libc-pinned addresses, so we can't use the same syscall.Syscall pattern that freebsd / netbsd use.
+// Stdlib's $GOROOT/src/syscall/linkname_libc.go has a bare `//go:linkname writev` directive that both opt-ins external
+// linkname and keeps the symbol alive for the linker.
+// There is no equivalent for readv, which is why Read still uses a copy-based path.
+// https://github.com/golang/go/issues/78049
+
+//go:linkname tunWritev syscall.writev
+//go:noescape
+func tunWritev(fd int, iovecs []syscall.Iovec) (n uintptr, err error)
+
+// Read pulls one IP packet off the tun device.
 func (t *tun) Read(to []byte) (int, error) {
-	buf := make([]byte, len(to)+4)
+	if cap(t.readBuf) < len(to)+4 {
+		t.readBuf = make([]byte, len(to)+4)
+	}
+	buf := t.readBuf[:len(to)+4]
 
 	n, err := t.f.Read(buf)
-
-	copy(to, buf[4:])
-	return n - 4, err
+	if err != nil {
+		return 0, err
+	}
+	if n < 4 {
+		return 0, nil
+	}
+	copy(to, buf[4:n])
+	return n - 4, nil
 }
 
-// Write is only valid for single threaded use
+// Write pushes one IP packet onto the tun device.
 func (t *tun) Write(from []byte) (int, error) {
-	buf := t.out
-	if cap(buf) < len(from)+4 {
-		buf = make([]byte, len(from)+4)
-		t.out = buf
-	}
-	buf = buf[:len(from)+4]
-
 	if len(from) == 0 {
 		return 0, syscall.EIO
 	}
 
-	// Determine the IP Family for the NULL L2 Header
 	ipVer := from[0] >> 4
-	if ipVer == 4 {
-		buf[3] = syscall.AF_INET
-	} else if ipVer == 6 {
-		buf[3] = syscall.AF_INET6
-	} else {
+	var head [4]byte
+	switch ipVer {
+	case 4:
+		head[3] = syscall.AF_INET
+	case 6:
+		head[3] = syscall.AF_INET6
+	default:
 		return 0, fmt.Errorf("unable to determine IP version from packet")
 	}
 
-	copy(buf[4:], from)
+	var n uintptr
+	var callErr error
+	err := t.rc.Write(func(fd uintptr) bool {
+		iovecs := []syscall.Iovec{
+			{Base: &head[0], Len: 4},
+			{Base: &from[0], Len: uint64(len(from))},
+		}
+		n, callErr = tunWritev(int(fd), iovecs)
+		if errors.Is(callErr, syscall.EAGAIN) || errors.Is(callErr, syscall.EWOULDBLOCK) || errors.Is(callErr, syscall.EINTR) {
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		return 0, err
+	}
+	if callErr != nil {
+		return 0, callErr
+	}
 
-	n, err := t.f.Write(buf)
-	return n - 4, err
+	return int(n) - 4, nil
 }
 
 func (t *tun) addIp(cidr netip.Prefix) error {

--- a/overlay/tun_openbsd.go
+++ b/overlay/tun_openbsd.go
@@ -57,13 +57,6 @@ type tun struct {
 	l           *slog.Logger
 	f           *os.File
 	fd          int
-
-	// readBuf is the per-tun read scratch reused across calls so we don't allocate per Read.
-	// OpenBSD's pinsyscall protection forbids raw syscall.Syscall(SYS_READV, ...) and stdlib doesn't keep syscall.readv
-	// alive for external linkname (only writev gets that treatment via linkname_libc.go)
-	// so the read path can't use readv and has to do the prefix-skip copy.
-	// https://github.com/golang/go/issues/78049
-	readBuf []byte
 }
 
 var deviceNameRE = regexp.MustCompile(`^tun[0-9]+$`)
@@ -93,15 +86,13 @@ func newTun(c *config.C, l *slog.Logger, vpnNetworks []netip.Prefix, _ bool) (*t
 		l.Warn("Failed to set the tun device as nonblocking", "error", err)
 	}
 
-	mtu := c.GetInt("tun.mtu", DefaultMTU)
 	t := &tun{
 		f:           os.NewFile(uintptr(fd), ""),
 		fd:          fd,
 		Device:      deviceName,
 		vpnNetworks: vpnNetworks,
-		MTU:         mtu,
+		MTU:         c.GetInt("tun.mtu", DefaultMTU),
 		l:           l,
-		readBuf:     make([]byte, mtu+4),
 	}
 
 	err = t.reload(c, true)
@@ -131,33 +122,54 @@ func (t *tun) Close() error {
 	return nil
 }
 
-// tunWritev is linkname'd from the standard library so the writev call goes through libc's pinned syscall trampoline.
-// OpenBSD's pinsyscall protection rejects raw syscall.Syscall(SYS_WRITEV, ...) calls because they don't originate from
-// the libc-pinned addresses, so we can't use the same syscall.Syscall pattern that freebsd / netbsd use.
-// Stdlib's $GOROOT/src/syscall/linkname_libc.go has a bare `//go:linkname writev` directive that both opt-ins external
-// linkname and keeps the symbol alive for the linker.
-// There is no equivalent for readv, which is why Read still uses a copy-based path.
-// https://github.com/golang/go/issues/78049
+// tunWritev and tunReadv are linkname'd to x/sys/unix's libc-routed writev/readv stubs so the
+// calls go through libc's pinned trampoline. OpenBSD's pinsyscall protection rejects a raw
+// syscall.Syscall(SYS_WRITEV/SYS_READV, ...) because it doesn't originate from a libc-pinned
+// address, so we can't use the syscall.Syscall pattern that freebsd / netbsd use. We pull the
+// low-level stubs instead of calling unix.Writev/unix.Readv because those take [][]byte and rebuild
+// the []Iovec every call, which heap-allocates the header; linkname'ing the stubs lets us hand them
+// our own stack-allocated iovecs. See golang/go#78049.
 
-//go:linkname tunWritev syscall.writev
+//go:linkname tunWritev golang.org/x/sys/unix.writev
 //go:noescape
-func tunWritev(fd int, iovecs []syscall.Iovec) (n uintptr, err error)
+func tunWritev(fd int, iovecs []unix.Iovec) (n int, err error)
 
-// Read pulls one IP packet off the tun device.
+//go:linkname tunReadv golang.org/x/sys/unix.readv
+//go:noescape
+func tunReadv(fd int, iovecs []unix.Iovec) (n int, err error)
+
+// Read pulls one IP packet off the tun device, scattering the 4 byte protocol header away from the
+// packet so the payload lands directly in to.
 func (t *tun) Read(to []byte) (int, error) {
-	if cap(t.readBuf) < len(to)+4 {
-		t.readBuf = make([]byte, len(to)+4)
-	}
-	buf := t.readBuf[:len(to)+4]
+	var head [4]byte
 
-	n, err := t.f.Read(buf)
+	rc, err := t.f.SyscallConn()
 	if err != nil {
 		return 0, err
+	}
+
+	var n int
+	var callErr error
+	err = rc.Read(func(fd uintptr) bool {
+		iovecs := []unix.Iovec{
+			{Base: &head[0], Len: 4},
+			{Base: &to[0], Len: uint64(len(to))},
+		}
+		n, callErr = tunReadv(int(fd), iovecs)
+		if errno, ok := callErr.(syscall.Errno); ok && errno.Temporary() {
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		return 0, err
+	}
+	if callErr != nil {
+		return 0, callErr
 	}
 	if n < 4 {
 		return 0, nil
 	}
-	copy(to, buf[4:n])
 	return n - 4, nil
 }
 
@@ -184,10 +196,10 @@ func (t *tun) Write(from []byte) (int, error) {
 		return 0, err
 	}
 
-	var n uintptr
+	var n int
 	var callErr error
 	err = rc.Write(func(fd uintptr) bool {
-		iovecs := []syscall.Iovec{
+		iovecs := []unix.Iovec{
 			{Base: &head[0], Len: 4},
 			{Base: &from[0], Len: uint64(len(from))},
 		}
@@ -206,7 +218,7 @@ func (t *tun) Write(from []byte) (int, error) {
 		return 0, callErr
 	}
 
-	return int(n) - 4, nil
+	return n - 4, nil
 }
 
 func (t *tun) addIp(cidr netip.Prefix) error {


### PR DESCRIPTION
Gets Darwin and OpenBSD up to snuff with free/netbsd tun implementation.

The main problem is that the BSDs put a 4 byte header on their tun read/write and using readv/writev is an elegant way to deal with it. Since a raw syscall.Syscall(SYS_READV/WRITEV) won't fly on OpenBSD (pinsyscall) or darwin (the SVC trap Apple keeps threatening to disallow), we //go:linkname x/sys/unix's libc-routed readv/writev stubs instead.

I did a very light smoke of Darwin, NetBSD, OpenBSD, and FreeBSD.