### PR TITLE
Return previously-swallowed errors from ssh handlers and config load

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -331,6 +331,19 @@ func (c *C) get(k string, v any) any {
 func (c *C) resolve(path string, direct bool) error {
 	i, err := os.Stat(path)
 	if err != nil {
+		if direct {
+			// The user-specified path itself could not be stat'd. Surface
+			// the underlying ENOENT/EACCES/ELOOP error so the operator
+			// sees a useful diagnostic instead of the generic
+			// "no config files found at %s" that Load would otherwise
+			// return when c.files ends up empty.
+			return fmt.Errorf("stat %s: %w", path, err)
+		}
+		// A descendant of a user-specified directory could not be stat'd
+		// (typically a dangling symlink or an unreadable entry inside an
+		// otherwise-readable directory). Log and skip so one bad entry
+		// does not abort a multi-file config reload.
+		c.l.Warn("skipping config entry", "path", path, "error", err)
 		return nil
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -40,6 +40,69 @@ func TestConfig_Load(t *testing.T) {
 	assert.Equal(t, expected, c.Settings)
 }
 
+// TestC_Load_PropagatesStatErrors exercises the directly-specified path
+// of c.Load and asserts that filesystem errors from the initial os.Stat
+// reach the caller. The pre-fix behavior swallowed any stat error in
+// resolve() and let Load fall through to its generic "no config files
+// found at %s" branch, masking ENOENT/EACCES/ELOOP/etc with a less
+// informative diagnostic.
+//
+// Each row carries a name describing the failure shape and a setupPath
+// closure that returns the path Load should be called with. wantErrContains
+// is matched against the returned error with require.ErrorContains; rows
+// flagged skipAsRoot are skipped when the test binary runs as uid 0
+// (typical for CI containers) because chmod-based permission tests have
+// no meaning when the caller can bypass file permissions.
+func TestC_Load_PropagatesStatErrors(t *testing.T) {
+	tests := []struct {
+		name            string
+		setupPath       func(t *testing.T) string
+		wantErrContains string
+		skipAsRoot      bool
+	}{
+		{
+			name: "nonexistent path returns the stat error not a generic message",
+			setupPath: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "no", "such", "file")
+			},
+			wantErrContains: "no such file or directory",
+		},
+		{
+			name: "permission denied on parent dir returns EACCES from stat",
+			setupPath: func(t *testing.T) string {
+				// chmod the *parent* directory to 0o000 so the os.Stat
+				// call inside resolve fails with EACCES. (chmodding the
+				// target directory itself to 0o000 lets os.Stat succeed
+				// and only fails the later readDirNames call, which
+				// has its own error path — that's not the swallow we're
+				// testing here.)
+				parent := t.TempDir()
+				target := filepath.Join(parent, "cfg")
+				require.NoError(t, os.Mkdir(target, 0o755))
+				require.NoError(t, os.Chmod(parent, 0o000))
+				t.Cleanup(func() { _ = os.Chmod(parent, 0o700) })
+				return target
+			},
+			wantErrContains: "permission denied",
+			skipAsRoot:      true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.skipAsRoot && os.Getuid() == 0 {
+				t.Skip("test is meaningless as root")
+			}
+			c := NewC(test.NewLogger())
+			err := c.Load(tc.setupPath(t))
+
+			require.Error(t, err)
+			require.ErrorContains(t, err, tc.wantErrContains,
+				"user should see the underlying stat error, "+
+					"not just 'no config files found'")
+		})
+	}
+}
+
 func TestConfig_Get(t *testing.T) {
 	l := test.NewLogger()
 	// test simple type

--- a/ssh.go
+++ b/ssh.go
@@ -866,7 +866,7 @@ func sshPrintCert(ifce *Interface, fs any, a []string, w sshd.StringWriter) erro
 	if args.Json || args.Pretty {
 		b, err := cert.MarshalJSON()
 		if err != nil {
-			return nil
+			return fmt.Errorf("marshal cert json: %w", err)
 		}
 
 		if args.Pretty {

--- a/ssh.go
+++ b/ssh.go
@@ -24,6 +24,20 @@ import (
 	"github.com/slackhq/nebula/sshd"
 )
 
+// jsonIndentLinePrefix is prepended to every output line when the ssh
+// handlers in this file pretty-print JSON. The handlers always use no
+// per-line prefix; this constant exists so the call sites (json.Indent
+// and json.Encoder.SetIndent) name what each argument means rather than
+// passing a bare empty string literal.
+const jsonIndentLinePrefix = ""
+
+// jsonIndentUnit is the per-level indentation used by the ssh handlers
+// when pretty-printing JSON. Four spaces are chosen to match the
+// historical wire format expected by interactive SSH clients reading
+// `host-map`, `lighthouse-map`, `print-cert`, etc. — the cert package
+// uses a tab separately for on-disk certificate JSON, which is unrelated.
+const jsonIndentUnit = "    "
+
 type sshListHostMapFlags struct {
 	Json    bool
 	Pretty  bool
@@ -455,7 +469,7 @@ func sshListHostMap(hl controlHostLister, a any, w sshd.StringWriter) error {
 	if fs.Json || fs.Pretty {
 		js := json.NewEncoder(w.GetWriter())
 		if fs.Pretty {
-			js.SetIndent("", "    ")
+			js.SetIndent(jsonIndentLinePrefix, jsonIndentUnit)
 		}
 
 		if err := js.Encode(hm); err != nil {
@@ -504,7 +518,7 @@ func sshListLighthouseMap(lightHouse *LightHouse, a any, w sshd.StringWriter) er
 	if fs.Json || fs.Pretty {
 		js := json.NewEncoder(w.GetWriter())
 		if fs.Pretty {
-			js.SetIndent("", "    ")
+			js.SetIndent(jsonIndentLinePrefix, jsonIndentUnit)
 		}
 
 		if err := js.Encode(addrMap); err != nil {
@@ -871,11 +885,10 @@ func sshPrintCert(ifce *Interface, fs any, a []string, w sshd.StringWriter) erro
 
 		if args.Pretty {
 			buf := new(bytes.Buffer)
-			err := json.Indent(buf, b, "", "    ")
-			b = buf.Bytes()
-			if err != nil {
-				return nil
+			if err := json.Indent(buf, b, jsonIndentLinePrefix, jsonIndentUnit); err != nil {
+				return fmt.Errorf("indent cert json: %w", err)
 			}
+			b = buf.Bytes()
 		}
 
 		return w.WriteBytes(b)
@@ -929,7 +942,7 @@ func sshPrintRelays(ifce *Interface, fs any, a []string, w sshd.StringWriter) er
 	enc := json.NewEncoder(w.GetWriter())
 
 	if args.Pretty {
-		enc.SetIndent("", "    ")
+		enc.SetIndent(jsonIndentLinePrefix, jsonIndentUnit)
 	}
 
 	for k, v := range relays {
@@ -1014,7 +1027,7 @@ func sshPrintTunnel(ifce *Interface, fs any, a []string, w sshd.StringWriter) er
 
 	enc := json.NewEncoder(w.GetWriter())
 	if args.Pretty {
-		enc.SetIndent("", "    ")
+		enc.SetIndent(jsonIndentLinePrefix, jsonIndentUnit)
 	}
 
 	return enc.Encode(copyHostInfo(hostInfo, ifce.hostMap.GetPreferredRanges()))
@@ -1040,7 +1053,7 @@ func sshDeviceInfo(ifce *Interface, fs any, w sshd.StringWriter) error {
 	if flags.Json || flags.Pretty {
 		js := json.NewEncoder(w.GetWriter())
 		if flags.Pretty {
-			js.SetIndent("", "    ")
+			js.SetIndent(jsonIndentLinePrefix, jsonIndentUnit)
 		}
 
 		return js.Encode(data)

--- a/ssh.go
+++ b/ssh.go
@@ -458,9 +458,8 @@ func sshListHostMap(hl controlHostLister, a any, w sshd.StringWriter) error {
 			js.SetIndent("", "    ")
 		}
 
-		err := js.Encode(hm)
-		if err != nil {
-			return nil
+		if err := js.Encode(hm); err != nil {
+			return fmt.Errorf("encode host-map json: %w", err)
 		}
 
 	} else {

--- a/ssh.go
+++ b/ssh.go
@@ -897,7 +897,7 @@ func sshPrintCert(ifce *Interface, fs any, a []string, w sshd.StringWriter) erro
 	if args.Raw {
 		b, err := cert.MarshalPEM()
 		if err != nil {
-			return nil
+			return fmt.Errorf("marshal cert pem: %w", err)
 		}
 
 		return w.WriteBytes(b)

--- a/ssh.go
+++ b/ssh.go
@@ -507,9 +507,8 @@ func sshListLighthouseMap(lightHouse *LightHouse, a any, w sshd.StringWriter) er
 			js.SetIndent("", "    ")
 		}
 
-		err := js.Encode(addrMap)
-		if err != nil {
-			return nil
+		if err := js.Encode(addrMap); err != nil {
+			return fmt.Errorf("encode lighthouse-map json: %w", err)
 		}
 
 	} else {

--- a/ssh_test.go
+++ b/ssh_test.go
@@ -1,0 +1,106 @@
+package nebula
+
+import (
+	"errors"
+	"io"
+	"net/netip"
+	"testing"
+
+	"github.com/slackhq/nebula/test"
+	"github.com/stretchr/testify/require"
+)
+
+// errInjected is the sentinel returned by failingWriter once its byte budget
+// is exhausted. Tests assert it with errors.Is to confirm the propagated
+// error preserves the wrapped cause.
+var errInjected = errors.New("injected write failure")
+
+// failingWriter is an io.Writer that returns errInjected once its cumulative
+// written total reaches afterBytes. It is used to exercise the error paths
+// of json.Encoder inside ssh handlers (sshListHostMap, sshListLighthouseMap)
+// without depending on a real SSH session.
+type failingWriter struct {
+	afterBytes int
+	written    int
+}
+
+func (f *failingWriter) Write(p []byte) (int, error) {
+	remaining := f.afterBytes - f.written
+	if remaining <= 0 {
+		return 0, errInjected
+	}
+	if len(p) > remaining {
+		f.written += remaining
+		return remaining, errInjected
+	}
+	f.written += len(p)
+	return len(p), nil
+}
+
+// recordingStringWriter is a sshd.StringWriter that delegates every call to a
+// wrapped io.Writer. Tests pass either a bytes.Buffer (capture all output)
+// or a failingWriter (exercise error paths).
+type recordingStringWriter struct{ w io.Writer }
+
+func (r *recordingStringWriter) WriteLine(s string) error {
+	_, err := r.w.Write([]byte(s + "\n"))
+	return err
+}
+func (r *recordingStringWriter) Write(s string) error      { _, err := r.w.Write([]byte(s)); return err }
+func (r *recordingStringWriter) WriteBytes(b []byte) error { _, err := r.w.Write(b); return err }
+func (r *recordingStringWriter) GetWriter() io.Writer      { return r.w }
+
+// newTestHostMapWithEntries returns a *HostMap pre-populated with n HostInfo
+// entries spread across the 192.168.0.0/16 vpn-address space. The map's
+// preferredRanges atomic is initialized so listHostMapHosts can call
+// GetPreferredRanges() without panicking.
+func newTestHostMapWithEntries(t *testing.T, n int) *HostMap {
+	t.Helper()
+	l := test.NewLogger()
+	hm := newHostMap(l)
+	empty := []netip.Prefix{}
+	hm.preferredRanges.Store(&empty)
+
+	iface := &Interface{}
+	for i := 0; i < n; i++ {
+		addr := netip.AddrFrom4([4]byte{192, 168, byte(i / 256), byte(i % 256)})
+		hi := &HostInfo{
+			vpnAddrs:     []netip.Addr{addr},
+			localIndexId: uint32(i + 1),
+		}
+		hm.unlockedAddHostInfo(hi, iface)
+	}
+	return hm
+}
+
+// TestSshListHostMap_WriteFailure_PropagatesError exercises the JSON-output
+// path of sshListHostMap with a writer that fails after a configurable byte
+// budget. The handler today returns nil on json.Encoder.Encode failure,
+// silently truncating the SSH client's output with no diagnostic for the
+// operator. Each row of this table represents one writer-failure shape.
+func TestSshListHostMap_WriteFailure_PropagatesError(t *testing.T) {
+	tests := []struct {
+		name       string
+		flags      *sshListHostMapFlags
+		afterBytes int
+	}{
+		{"json mode, immediate writer failure", &sshListHostMapFlags{Json: true}, 0},
+		{"json mode, mid-stream failure", &sshListHostMapFlags{Json: true}, 16},
+		{"pretty mode, immediate writer failure", &sshListHostMapFlags{Pretty: true}, 0},
+		{"pretty mode, mid-stream failure", &sshListHostMapFlags{Pretty: true}, 16},
+		{"pretty mode, late failure", &sshListHostMapFlags{Pretty: true}, 256},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			hm := newTestHostMapWithEntries(t, 50)
+			sw := &recordingStringWriter{w: &failingWriter{afterBytes: tc.afterBytes}}
+
+			err := sshListHostMap(hm, tc.flags, sw)
+
+			require.Error(t, err, "writer failure must propagate; got nil")
+			require.ErrorIs(t, err, errInjected,
+				"propagated error must wrap errInjected so callers can errors.Is the cause")
+		})
+	}
+}
+

--- a/ssh_test.go
+++ b/ssh_test.go
@@ -73,6 +73,20 @@ func newTestHostMapWithEntries(t *testing.T, n int) *HostMap {
 	return hm
 }
 
+// newTestLighthouseWithEntries returns a *LightHouse pre-populated with n
+// entries in addrMap. Reuses newTestLighthouse from connection_manager_test.go
+// (same package) for the surrounding initialization, then adds RemoteList
+// entries spread across 192.168.0.0/16 so the JSON output is non-trivial.
+func newTestLighthouseWithEntries(t *testing.T, n int) *LightHouse {
+	t.Helper()
+	lh := newTestLighthouse()
+	for i := 0; i < n; i++ {
+		addr := netip.AddrFrom4([4]byte{192, 168, byte(i / 256), byte(i % 256)})
+		lh.addrMap[addr] = NewRemoteList([]netip.Addr{addr}, nil)
+	}
+	return lh
+}
+
 // TestSshListHostMap_WriteFailure_PropagatesError exercises the JSON-output
 // path of sshListHostMap with a writer that fails after a configurable byte
 // budget. The handler today returns nil on json.Encoder.Encode failure,
@@ -104,3 +118,34 @@ func TestSshListHostMap_WriteFailure_PropagatesError(t *testing.T) {
 	}
 }
 
+// TestSshListLighthouseMap_WriteFailure_PropagatesError mirrors the
+// sshListHostMap test against sshListLighthouseMap, which has the same
+// json.Encoder.Encode swallow bug a few hundred lines further down in
+// ssh.go. The handler shares the same set of failure shapes — both flag
+// modes and both immediate / mid-stream failure points — because the
+// underlying encoder behavior is identical.
+func TestSshListLighthouseMap_WriteFailure_PropagatesError(t *testing.T) {
+	tests := []struct {
+		name       string
+		flags      *sshListHostMapFlags
+		afterBytes int
+	}{
+		{"json mode, immediate writer failure", &sshListHostMapFlags{Json: true}, 0},
+		{"json mode, mid-stream failure", &sshListHostMapFlags{Json: true}, 16},
+		{"pretty mode, immediate writer failure", &sshListHostMapFlags{Pretty: true}, 0},
+		{"pretty mode, mid-stream failure", &sshListHostMapFlags{Pretty: true}, 16},
+		{"pretty mode, late failure", &sshListHostMapFlags{Pretty: true}, 256},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lh := newTestLighthouseWithEntries(t, 50)
+			sw := &recordingStringWriter{w: &failingWriter{afterBytes: tc.afterBytes}}
+
+			err := sshListLighthouseMap(lh, tc.flags, sw)
+
+			require.Error(t, err, "writer failure must propagate; got nil")
+			require.ErrorIs(t, err, errInjected,
+				"propagated error must wrap errInjected so callers can errors.Is the cause")
+		})
+	}
+}

--- a/ssh_test.go
+++ b/ssh_test.go
@@ -109,6 +109,15 @@ func (invalidJSONCert) MarshalJSON() ([]byte, error) {
 	return []byte("{not valid json"), nil
 }
 
+// brokenPEMCert is a cert.Certificate whose MarshalPEM always errors.
+// Used to exercise the -raw branch of sshPrintCert. Like brokenJSONCert,
+// the embedded cert.Certificate is nil; tests using this double MUST set
+// sshPrintCertFlags.Raw so the handler only calls MarshalPEM and never
+// reaches the MarshalJSON or String() paths.
+type brokenPEMCert struct{ cert.Certificate }
+
+func (brokenPEMCert) MarshalPEM() ([]byte, error) { return nil, errInjectedCert }
+
 // newTestInterfaceWithHostCert returns a minimal *Interface with hostMap
 // containing one HostInfo at vpnAddr whose ConnectionState.peerCert wraps
 // the provided cert.Certificate. The pki field is wired with a CertState
@@ -269,6 +278,34 @@ func TestSshPrintCert_IndentError(t *testing.T) {
 				[]string{vpnAddr.String()}, sw)
 
 			tc.check(t, err, buf.Bytes())
+		})
+	}
+}
+
+// TestSshPrintCert_MarshalPEMFails_PropagatesError exercises the -raw
+// output path of sshPrintCert with a cert.Certificate whose MarshalPEM
+// always returns an error. The handler today returns nil on MarshalPEM
+// failure, so an operator running `print-cert <addr> -raw` against a
+// host with an unmarshallable cert sees an empty successful response.
+// Wrapping the error preserves errors.Is on the underlying cause.
+func TestSshPrintCert_MarshalPEMFails_PropagatesError(t *testing.T) {
+	vpnAddr := netip.MustParseAddr("10.0.0.1")
+	tests := []struct {
+		name  string
+		flags *sshPrintCertFlags
+	}{
+		{"raw flag", &sshPrintCertFlags{Raw: true}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ifce := newTestInterfaceWithHostCert(t, vpnAddr, brokenPEMCert{})
+			sw := &recordingStringWriter{w: &bytes.Buffer{}}
+
+			err := sshPrintCert(ifce, tc.flags, []string{vpnAddr.String()}, sw)
+
+			require.Error(t, err, "MarshalPEM failure must propagate; got nil")
+			require.ErrorIs(t, err, errInjectedCert,
+				"propagated error must wrap errInjectedCert so callers can errors.Is the cause")
 		})
 	}
 }

--- a/ssh_test.go
+++ b/ssh_test.go
@@ -1,14 +1,23 @@
 package nebula
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"net/netip"
 	"testing"
 
+	"github.com/slackhq/nebula/cert"
 	"github.com/slackhq/nebula/test"
 	"github.com/stretchr/testify/require"
 )
+
+// dummyCert is defined in connection_manager_test.go (same package).
+// We only need its zero value to seed PKI.cs so sshPrintCert's
+// unconditional getCertState().GetDefaultCertificate() call (called
+// even when a vpn addr is supplied) doesn't panic. The variable holding
+// the default cert is immediately overwritten by the per-host lookup,
+// so the dummy never has any of its methods called.
 
 // errInjected is the sentinel returned by failingWriter once its byte budget
 // is exhausted. Tests assert it with errors.Is to confirm the propagated
@@ -73,6 +82,58 @@ func newTestHostMapWithEntries(t *testing.T, n int) *HostMap {
 	return hm
 }
 
+// errInjectedCert is the sentinel returned by the cert.Certificate test
+// doubles used in sshPrintCert tests. Kept distinct from errInjected so
+// failure traces immediately show whether the error originated in the
+// writer (errInjected) or in the cert marshalling layer (errInjectedCert).
+var errInjectedCert = errors.New("injected cert failure")
+
+// brokenJSONCert is a cert.Certificate whose MarshalJSON always errors.
+// The embedded cert.Certificate is nil; any other interface method panics
+// if called. Tests using this double MUST set sshPrintCertFlags.Json or
+// .Pretty so the handler never reaches the cert.String() fallthrough at
+// ssh.go's print-cert function.
+type brokenJSONCert struct{ cert.Certificate }
+
+func (brokenJSONCert) MarshalJSON() ([]byte, error) { return nil, errInjectedCert }
+
+// newTestInterfaceWithHostCert returns a minimal *Interface with hostMap
+// containing one HostInfo at vpnAddr whose ConnectionState.peerCert wraps
+// the provided cert.Certificate. The pki field is wired with a CertState
+// whose default cert is a dummyCert because sshPrintCert evaluates the
+// default cert unconditionally before the per-host lookup overrides it.
+func newTestInterfaceWithHostCert(t *testing.T, vpnAddr netip.Addr, c cert.Certificate) *Interface {
+	t.Helper()
+	l := test.NewLogger()
+	hm := newHostMap(l)
+	empty := []netip.Prefix{}
+	hm.preferredRanges.Store(&empty)
+
+	hi := &HostInfo{
+		vpnAddrs:     []netip.Addr{vpnAddr},
+		localIndexId: 1,
+		ConnectionState: &ConnectionState{
+			peerCert: &cert.CachedCertificate{Certificate: c},
+		},
+	}
+	hm.unlockedAddHostInfo(hi, &Interface{})
+
+	cs, err := newCertState(
+		cert.Version2,
+		nil,
+		&dummyCert{version: cert.Version2},
+		false,
+		cert.Curve_CURVE25519,
+		nil,
+		"aes",
+	)
+	require.NoError(t, err)
+	pki := &PKI{}
+	pki.cs.Store(cs)
+
+	return &Interface{hostMap: hm, pki: pki}
+}
+
 // newTestLighthouseWithEntries returns a *LightHouse pre-populated with n
 // entries in addrMap. Reuses newTestLighthouse from connection_manager_test.go
 // (same package) for the surrounding initialization, then adds RemoteList
@@ -114,6 +175,37 @@ func TestSshListHostMap_WriteFailure_PropagatesError(t *testing.T) {
 			require.Error(t, err, "writer failure must propagate; got nil")
 			require.ErrorIs(t, err, errInjected,
 				"propagated error must wrap errInjected so callers can errors.Is the cause")
+		})
+	}
+}
+
+// TestSshPrintCert_MarshalJSONFails_PropagatesError exercises the json /
+// pretty output paths of sshPrintCert with a cert.Certificate whose
+// MarshalJSON always returns an error. The handler today returns nil on
+// MarshalJSON failure, so an operator running `print-cert <addr> -json`
+// against a host with an unmarshallable cert sees an empty successful
+// response — no diagnostic, no hint that the cert exists but won't
+// serialize. Both -json and -pretty flag modes route through MarshalJSON
+// (-pretty calls it then re-formats), so both are exercised.
+func TestSshPrintCert_MarshalJSONFails_PropagatesError(t *testing.T) {
+	vpnAddr := netip.MustParseAddr("10.0.0.1")
+	tests := []struct {
+		name  string
+		flags *sshPrintCertFlags
+	}{
+		{"json flag", &sshPrintCertFlags{Json: true}},
+		{"pretty flag", &sshPrintCertFlags{Pretty: true}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ifce := newTestInterfaceWithHostCert(t, vpnAddr, brokenJSONCert{})
+			sw := &recordingStringWriter{w: &bytes.Buffer{}}
+
+			err := sshPrintCert(ifce, tc.flags, []string{vpnAddr.String()}, sw)
+
+			require.Error(t, err, "MarshalJSON failure must propagate; got nil")
+			require.ErrorIs(t, err, errInjectedCert,
+				"propagated error must wrap errInjectedCert so callers can errors.Is the cause")
 		})
 	}
 }

--- a/ssh_test.go
+++ b/ssh_test.go
@@ -97,6 +97,18 @@ type brokenJSONCert struct{ cert.Certificate }
 
 func (brokenJSONCert) MarshalJSON() ([]byte, error) { return nil, errInjectedCert }
 
+// invalidJSONCert succeeds at MarshalJSON but returns syntactically
+// invalid JSON. This forces json.Indent (used by the -pretty path in
+// sshPrintCert) to error while the surrounding MarshalJSON call appears
+// to have succeeded — the exact shape needed to test the json.Indent
+// error-handling branch and the latent "b = buf.Bytes() before err
+// check" reorder hazard.
+type invalidJSONCert struct{ cert.Certificate }
+
+func (invalidJSONCert) MarshalJSON() ([]byte, error) {
+	return []byte("{not valid json"), nil
+}
+
 // newTestInterfaceWithHostCert returns a minimal *Interface with hostMap
 // containing one HostInfo at vpnAddr whose ConnectionState.peerCert wraps
 // the provided cert.Certificate. The pki field is wired with a CertState
@@ -206,6 +218,57 @@ func TestSshPrintCert_MarshalJSONFails_PropagatesError(t *testing.T) {
 			require.Error(t, err, "MarshalJSON failure must propagate; got nil")
 			require.ErrorIs(t, err, errInjectedCert,
 				"propagated error must wrap errInjectedCert so callers can errors.Is the cause")
+		})
+	}
+}
+
+// TestSshPrintCert_IndentError covers two intertwined hazards in the
+// -pretty branch of sshPrintCert:
+//
+//  1. json.Indent errors were swallowed (return nil), so operators saw an
+//     empty successful response when a cert's MarshalJSON returned bytes
+//     that did not round-trip through Indent.
+//
+//  2. The buggy code assigned `b = buf.Bytes()` *before* checking the
+//     Indent error. Today the assignment is masked by the immediate
+//     `return nil`, but any future refactor that converted the swallow to
+//     `return err` while leaving the reorder intact would emit a partially
+//     indented buffer to the SSH client. The "no partial buffer written"
+//     row locks the invariant down so that refactor can't quietly happen.
+func TestSshPrintCert_IndentError(t *testing.T) {
+	vpnAddr := netip.MustParseAddr("10.0.0.1")
+	tests := []struct {
+		name  string
+		check func(t *testing.T, err error, written []byte)
+	}{
+		{
+			name: "indent error propagates",
+			check: func(t *testing.T, err error, _ []byte) {
+				require.Error(t, err, "json.Indent failure must propagate; got nil")
+				require.ErrorContains(t, err, "indent cert json",
+					"error message must identify the indent layer for operators")
+			},
+		},
+		{
+			name: "indent error does not write partial buffer",
+			check: func(t *testing.T, _ error, written []byte) {
+				require.Empty(t, written,
+					"handler must not emit partially-indented bytes when "+
+						"json.Indent fails — protects against future refactors "+
+						"that remove the swallow without fixing the reorder")
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ifce := newTestInterfaceWithHostCert(t, vpnAddr, invalidJSONCert{})
+			buf := &bytes.Buffer{}
+			sw := &recordingStringWriter{w: buf}
+
+			err := sshPrintCert(ifce, &sshPrintCertFlags{Pretty: true},
+				[]string{vpnAddr.String()}, sw)
+
+			tc.check(t, err, buf.Bytes())
 		})
 	}
 }


### PR DESCRIPTION

### Hi 👋

Six places inside `ssh.go` and `config/config.go` quietly swallowed errors and returned `nil`. Each one is a path where today a real failure (writer error, malformed cert, missing config path) leaves the operator staring at empty output or a misleading "no files found" message with nothing useful in the logs. This PR resolves all six at the root, in six small bisect-safe commits. Hopefully these tighten the diagnostics that downstream nebula operators rely on when something is off — fewer "huh, that should have worked" moments for anyone running `print-cert`, `host-map`, or just loading a config from a typo'd path.

### How we found these

We ran [`nilerr`](https://github.com/gostaticanalysis/nilerr) via golangci-lint as part of a strict static-analysis pipeline downstream of this fork. `nilerr` flags any function where a non-nil `err` is observed and then `nil` is returned — exactly the silent-failure pattern we wanted to surface. The lint output was:

```
config/config.go:334:3:  error is not nil (line 332) but it returns nil
ssh.go:463:4:            error is not nil (line 461) but it returns nil
ssh.go:513:4:            error is not nil (line 511) but it returns nil
ssh.go:871:4:            error is not nil (line 869) but it returns nil
ssh.go:879:5:            error is not nil (line 876) but it returns nil
ssh.go:889:4:            error is not nil (line 887) but it returns nil
```

Each line maps to one commit. We label them N1…N6 internally and use those tags below for cross-referencing.

### Per-site operator impact

| Tag | File:line | Function | What the operator saw on failure (pre-fix) |
|---|---|---|---|
| **N2** | `ssh.go:461` | `sshListHostMap` | SSH `host-map -json` writer error mid-stream → truncated JSON, command reports success |
| **N3** | `ssh.go:511` | `sshListLighthouseMap` | Same as N2 but for `lighthouse-map` |
| **N4** | `ssh.go:869` | `sshPrintCert` (`-json`/`-pretty`) | Host's cert refuses `MarshalJSON` → empty success response |
| **N5** | `ssh.go:876` | `sshPrintCert` (`-pretty`) | `json.Indent` fails → empty success response **and** a latent "corrupted-partial-buffer" hazard masked only by the `return nil` |
| **N6** | `ssh.go:887` | `sshPrintCert` (`-raw`) | Host's cert refuses `MarshalPEM` → empty success response |
| **N1** | `config/config.go:334` | `(c *C).resolve` | `-config /typoed/path` → "no config files found at /typoed/path" instead of "no such file or directory" |

The N1 case is the one most likely to bite an operator in the wild: a typo in `--config` produces an error message that says "no files found in this directory" when in fact the directory doesn't exist at all. With this fix the operator sees the real `ENOENT`/`EACCES`/`ELOOP` and can fix the typo immediately.

### How each commit is structured (TDD)

Each commit is one finding, fixed test-first:

1. **Write a table-driven test** that targets the specific swallow. Every row carries a descriptive `name` so failure traces immediately identify which case regressed.
2. **Run the test against the unmodified upstream code** — it MUST fail. This proves the test catches the bug rather than being a tautology.
3. **Apply the minimal fix** — turn `return nil` into `return fmt.Errorf("<context>: %w", err)`. The `%w` wrapping preserves `errors.Is` / `errors.As` for callers that want to react to the underlying cause.
4. **Run the test again** — must pass.
5. **Run the full suite** — `go test -count=1 ./...` stays green; no other tests depended on the swallowed behavior.

Mutation-tested: temporarily reverting the fix line in each commit while keeping the test in place causes at least one new test row to fail. The tests are not tautologies.

All six commits are independently bisect-safe — `go test ./...` passes at every SHA on the branch.

### How to run the new tests locally

A reviewer can verify the full suite of new tests with two commands:

```
go test -count=1 -v -run 'TestC_Load_PropagatesStatErrors' ./config
go test -count=1 -v -run 'TestSshListHostMap|TestSshListLighthouseMap|TestSshPrintCert' .
```

Expected output (17 subtests across 6 parent tests, all PASS):

```
# config package — N1
=== RUN   TestC_Load_PropagatesStatErrors
=== RUN   TestC_Load_PropagatesStatErrors/nonexistent_path_returns_the_stat_error_not_a_generic_message
=== RUN   TestC_Load_PropagatesStatErrors/permission_denied_on_parent_dir_returns_EACCES_from_stat
--- PASS: TestC_Load_PropagatesStatErrors (0.00s)
PASS
ok  github.com/slackhq/nebula/config

# nebula package — N2 through N6
=== RUN   TestSshListHostMap_WriteFailure_PropagatesError
    ─── json_mode,_immediate_writer_failure
    ─── json_mode,_mid-stream_failure
    ─── pretty_mode,_immediate_writer_failure
    ─── pretty_mode,_mid-stream_failure
    ─── pretty_mode,_late_failure
--- PASS: TestSshListHostMap_WriteFailure_PropagatesError
=== RUN   TestSshPrintCert_MarshalJSONFails_PropagatesError
    ─── json_flag
    ─── pretty_flag
--- PASS: TestSshPrintCert_MarshalJSONFails_PropagatesError
=== RUN   TestSshPrintCert_IndentError
    ─── indent_error_propagates
    ─── indent_error_does_not_write_partial_buffer
--- PASS: TestSshPrintCert_IndentError
=== RUN   TestSshPrintCert_MarshalPEMFails_PropagatesError
    ─── raw_flag
--- PASS: TestSshPrintCert_MarshalPEMFails_PropagatesError
=== RUN   TestSshListLighthouseMap_WriteFailure_PropagatesError
    ─── json_mode,_immediate_writer_failure
    ─── json_mode,_mid-stream_failure
    ─── pretty_mode,_immediate_writer_failure
    ─── pretty_mode,_mid-stream_failure
    ─── pretty_mode,_late_failure
--- PASS: TestSshListLighthouseMap_WriteFailure_PropagatesError
PASS
ok  github.com/slackhq/nebula
```

To verify each test actually catches its bug (mutation-test a single commit):

```
# check out the commit before the fix, run the test from that commit
git checkout <SHA-of-commit-N>^   # parent SHA
git checkout <SHA-of-commit-N> -- ssh_test.go   # take just the test from the fix commit
go test -v -run 'TestSshListHostMap_WriteFailure_PropagatesError' .   # MUST FAIL
git checkout <SHA-of-commit-N> -- ssh.go        # now take the fix
go test -v -run 'TestSshListHostMap_WriteFailure_PropagatesError' .   # MUST PASS
git checkout <branch>                           # return to head
```

### Approach notes

One small companion cleanup landed in commit N5: `ssh.go` had six call sites that all passed `"", "    "` to `json.Encoder.SetIndent` or `json.Indent` — the JSON line-prefix and indent-unit for SSH command output. While editing the N5 call we extracted those into file-scope constants `jsonIndentLinePrefix` and `jsonIndentUnit` and renamed all six sites so each call now says what its arguments mean. Doing it in the same commit avoids leaving five sites with the old magic-string spelling next to one named site.

N1's fix branches on the `direct` flag rather than blanket-propagating: a `direct=true` stat failure (the user-supplied `-config` path) propagates with `%w` wrapping, while a `direct=false` failure (a recursed descendant — e.g. a dangling symlink inside an otherwise-valid config directory) logs via `c.l.Warn` and skips so a single bad entry does not abort a multi-file config reload. This preserves the existing reload resilience while fixing the misleading diagnostic for the direct path.

### Backward compatibility

No CLI flag, config key, or public API changes. The only observable behaviour change is that previously-silent failures (writer mid-stream errors, unmarshallable certs, missing config paths) now return descriptive errors at the failing call site rather than empty success responses or generic "no files found" messages. All existing tests continue to pass with no edits. No upstream test asserted the exact `"no config files found at %s"` string for a nonexistent path (greped — only the `fmt.Errorf` definition itself appears).

