### PR TITLE
Surface previously-swallowed errors in DNS, SSH, and config paths

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -335,8 +335,7 @@ func (c *C) resolve(path string, direct bool) error {
 	}
 
 	if !i.IsDir() {
-		c.addFile(path, direct)
-		return nil
+		return c.addFile(path, direct)
 	}
 
 	paths, err := readDirNames(path)
@@ -354,6 +353,13 @@ func (c *C) resolve(path string, direct bool) error {
 	return nil
 }
 
+// filepathAbs is the abs-path resolver used by addFile. It is a package
+// level var so tests can swap in a function that errors to exercise the
+// previously-swallowed propagation path. Production always uses
+// filepath.Abs. Tests that mutate filepathAbs cannot run with
+// t.Parallel().
+var filepathAbs = filepath.Abs
+
 func (c *C) addFile(path string, direct bool) error {
 	ext := filepath.Ext(path)
 
@@ -361,7 +367,7 @@ func (c *C) addFile(path string, direct bool) error {
 		return nil
 	}
 
-	ap, err := filepath.Abs(path)
+	ap, err := filepathAbs(path)
 	if err != nil {
 		return err
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,6 +39,34 @@ func TestConfig_Load(t *testing.T) {
 		"new": "hi",
 	}
 	assert.Equal(t, expected, c.Settings)
+}
+
+// TestConfig_Resolve_AddFileErrorPropagates exercises the previously-
+// swallowed addFile error path inside (*C).resolve. With a real
+// filesystem we cannot easily make filepath.Abs error (it only fails
+// when os.Getwd does, which requires deleted-cwd manipulation that is
+// platform-fragile), so we follow the same pattern as
+// cmd/nebula-cert/stdio.go's stdinReader: swap the package-level
+// filepathAbs func for one that always returns an error.
+//
+// Cannot run with t.Parallel() — mutates the package-level
+// filepathAbs var.
+func TestConfig_Resolve_AddFileErrorPropagates(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "x.yml")
+	require.NoError(t, os.WriteFile(target, []byte("k: v\n"), 0o644))
+
+	injected := errors.New("injected filepath.Abs failure")
+	origAbs := filepathAbs
+	t.Cleanup(func() { filepathAbs = origAbs })
+	filepathAbs = func(string) (string, error) { return "", injected }
+
+	c := NewC(test.NewLogger())
+	err := c.Load(target)
+
+	require.Error(t, err, "addFile error must propagate from resolve via Load")
+	require.ErrorIs(t, err, injected,
+		"propagated error must wrap the underlying cause so callers can errors.Is")
 }
 
 func TestConfig_Get(t *testing.T) {

--- a/dns_server.go
+++ b/dns_server.go
@@ -10,10 +10,55 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/miekg/dns"
+	"github.com/rcrowley/go-metrics"
 	"github.com/slackhq/nebula/config"
 )
+
+// dnsWriteWarnLogWindow gates the WriteMsg-failure Warn log line. Failures
+// within the window are counted; the next Warn after the window elapses
+// includes the suppressed-count as an slog attr so an operator can
+// reconstruct the rate from a single log line. The value is intentionally
+// not configurable — it is operator protection, not policy.
+const dnsWriteWarnLogWindow = 10 * time.Second
+
+// dnsWriteWarnLimiter throttles dnsServer's WriteMsg-failure Warn so a
+// network-wide problem cannot flood the log. Semantics: the first call
+// after the window elapses logs and returns the count of suppressed
+// failures since the previous log; calls inside the window increment
+// the counter and stay silent. Concurrent-callers-safe via CompareAndSwap
+// on lastLogged — exactly one caller wins the "log" slot per window.
+type dnsWriteWarnLimiter struct {
+	suppressed atomic.Int64
+	lastLogged atomic.Int64 // unix nanos; zero on first call so the first failure always logs
+	windowNs   int64
+}
+
+func newDNSWriteWarnLimiter(window time.Duration) *dnsWriteWarnLimiter {
+	l := &dnsWriteWarnLimiter{windowNs: window.Nanoseconds()}
+	// Seed lastLogged so the very first call always logs regardless of
+	// the absolute value of `now` (the diff against the zero value would
+	// be small for tiny timestamps even though in production now ≈ 1.7e18
+	// makes the diff trivially exceed any reasonable window).
+	l.lastLogged.Store(-l.windowNs)
+	return l
+}
+
+// shouldLog reports whether the caller should emit a Warn now, and the
+// number of failures that were suppressed since the previous log (zero
+// if this is the first log, or if a concurrent caller raced this one).
+func (l *dnsWriteWarnLimiter) shouldLog(now int64) (bool, int64) {
+	last := l.lastLogged.Load()
+	if now-last >= l.windowNs {
+		if l.lastLogged.CompareAndSwap(last, now) {
+			return true, l.suppressed.Swap(0)
+		}
+	}
+	l.suppressed.Add(1)
+	return false, 0
+}
 
 type dnsServer struct {
 	sync.RWMutex
@@ -45,6 +90,14 @@ type dnsServer struct {
 	// ignored, leaving the listener running forever.
 	started chan struct{}
 	addr    string
+
+	// metricWriteFailures counts every dns.ResponseWriter.WriteMsg error.
+	// Operators graph this against query volume to spot DNS path
+	// breakage.
+	metricWriteFailures metrics.Counter
+	// warnLimiter throttles the WriteMsg-failure Warn log; see
+	// dnsWriteWarnLimiter.
+	warnLimiter *dnsWriteWarnLimiter
 }
 
 // newDnsServerFromConfig builds a dnsServer, applies the initial config, and
@@ -59,12 +112,14 @@ type dnsServer struct {
 // pointer is always non-nil, even on error.
 func newDnsServerFromConfig(ctx context.Context, l *slog.Logger, pki *PKI, hostMap *HostMap, c *config.C) (*dnsServer, error) {
 	ds := &dnsServer{
-		l:       l,
-		ctx:     ctx,
-		dnsMap4: make(map[string]netip.Addr),
-		dnsMap6: make(map[string]netip.Addr),
-		hostMap: hostMap,
-		pki:     pki,
+		l:                   l,
+		ctx:                 ctx,
+		dnsMap4:             make(map[string]netip.Addr),
+		dnsMap6:             make(map[string]netip.Addr),
+		hostMap:             hostMap,
+		pki:                 pki,
+		metricWriteFailures: metrics.GetOrRegisterCounter("dns.responses.write_failures", nil),
+		warnLimiter:         newDNSWriteWarnLimiter(dnsWriteWarnLogWindow),
 	}
 	ds.mux = dns.NewServeMux()
 	ds.mux.HandleFunc(".", ds.handleDnsRequest)
@@ -436,7 +491,15 @@ func (d *dnsServer) handleDnsRequest(w dns.ResponseWriter, r *dns.Msg) {
 		d.parseQuery(m, w)
 	}
 
-	w.WriteMsg(m)
+	if err := w.WriteMsg(m); err != nil {
+		d.metricWriteFailures.Inc(1)
+		if log, suppressed := d.warnLimiter.shouldLog(time.Now().UnixNano()); log {
+			d.l.Warn("dns: failed to write response",
+				"error", err,
+				"client", w.RemoteAddr().String(),
+				"suppressed_since_last_log", suppressed)
+		}
+	}
 }
 
 func getDnsServerAddr(c *config.C) string {

--- a/dns_server_test.go
+++ b/dns_server_test.go
@@ -1,7 +1,9 @@
 package nebula
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"log/slog"
 	"net"
 	"net/netip"
@@ -11,12 +13,24 @@ import (
 
 	"github.com/gaissmai/bart"
 	"github.com/miekg/dns"
+	"github.com/rcrowley/go-metrics"
 	"github.com/slackhq/nebula/cert"
 	"github.com/slackhq/nebula/cert_test"
 	"github.com/slackhq/nebula/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// errInjectedWriteMsg is the sentinel returned by failingDNSWriter.WriteMsg
+// so tests can errors.Is the wrapped cause.
+var errInjectedWriteMsg = errors.New("injected WriteMsg failure")
+
+// failingDNSWriter wraps stubDNSWriter and returns errInjectedWriteMsg from
+// WriteMsg. Used to exercise the previously-swallowed error branch in
+// dnsServer.handleDnsRequest without standing up a real DNS listener.
+type failingDNSWriter struct{ stubDNSWriter }
+
+func (failingDNSWriter) WriteMsg(*dns.Msg) error { return errInjectedWriteMsg }
 
 type stubDNSWriter struct{}
 
@@ -30,6 +44,115 @@ func (stubDNSWriter) Close() error              { return nil }
 func (stubDNSWriter) TsigStatus() error         { return nil }
 func (stubDNSWriter) TsigTimersOnly(bool)       {}
 func (stubDNSWriter) Hijack()                   {}
+
+// TestDNSWriteWarnLimiter walks the rate-limiter's state machine
+// deterministically by passing explicit unix-nano timestamps in place of a
+// real clock. Each row carries a name describing what is exercised; a
+// failure clearly identifies which case regressed.
+func TestDNSWriteWarnLimiter(t *testing.T) {
+	const sec = int64(time.Second)
+	tests := []struct {
+		name        string
+		windowNs    int64
+		calls       []int64 // simulated `now` passed to shouldLog
+		wantLogged  []bool  // expected shouldLog return value, per call
+		wantPrevSup []int64 // expected suppressed count, per call (meaningful only when logged=true)
+	}{
+		{
+			name:        "first call always logs with zero suppressed",
+			windowNs:    10 * sec,
+			calls:       []int64{1},
+			wantLogged:  []bool{true},
+			wantPrevSup: []int64{0},
+		},
+		{
+			name:        "second call inside window is suppressed",
+			windowNs:    10 * sec,
+			calls:       []int64{1, 1 + 5*sec},
+			wantLogged:  []bool{true, false},
+			wantPrevSup: []int64{0, 0},
+		},
+		{
+			name:        "call past window emits with the suppressed count",
+			windowNs:    10 * sec,
+			calls:       []int64{1, 1 + 5*sec, 1 + 11*sec},
+			wantLogged:  []bool{true, false, true},
+			wantPrevSup: []int64{0, 0, 1},
+		},
+		{
+			name:        "tied exactly at the window edge logs",
+			windowNs:    10 * sec,
+			calls:       []int64{1, 1 + 10*sec},
+			wantLogged:  []bool{true, true},
+			wantPrevSup: []int64{0, 0},
+		},
+		{
+			name:        "many suppressed in a row then one log gets accumulated count",
+			windowNs:    10 * sec,
+			calls:       []int64{1, 2, 3, 4, 5, 1 + 11*sec},
+			wantLogged:  []bool{true, false, false, false, false, true},
+			wantPrevSup: []int64{0, 0, 0, 0, 0, 4},
+		},
+		{
+			name:        "non-monotonic clock (defensive: now < lastLogged) keeps suppressing",
+			windowNs:    10 * sec,
+			calls:       []int64{1 + 100*sec, 50 * sec},
+			wantLogged:  []bool{true, false},
+			wantPrevSup: []int64{0, 0},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lim := newDNSWriteWarnLimiter(time.Duration(tc.windowNs))
+			require.Len(t, tc.wantLogged, len(tc.calls), "table row consistency")
+			require.Len(t, tc.wantPrevSup, len(tc.calls), "table row consistency")
+			for i, now := range tc.calls {
+				gotLog, gotSup := lim.shouldLog(now)
+				assert.Equal(t, tc.wantLogged[i], gotLog,
+					"call %d at now=%d: log decision", i, now)
+				if tc.wantLogged[i] {
+					assert.Equal(t, tc.wantPrevSup[i], gotSup,
+						"call %d at now=%d: suppressed count returned", i, now)
+				}
+			}
+		})
+	}
+}
+
+// TestDnsServer_HandleDnsRequest_WriteMsgFailure_LogsAndMeters wires
+// handleDnsRequest against a failingDNSWriter and asserts that the
+// WriteMsg error is now (a) counted in dns.responses.write_failures,
+// (b) emitted as a Warn log line that includes the injected error and
+// the suppressed-since-last-log attr.
+func TestDnsServer_HandleDnsRequest_WriteMsgFailure_LogsAndMeters(t *testing.T) {
+	var logBuf bytes.Buffer
+	l := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	counter := metrics.NewCounter() // a fresh counter so other tests do not pollute our delta
+	ds := &dnsServer{
+		l:                   l,
+		dnsMap4:             make(map[string]netip.Addr),
+		dnsMap6:             make(map[string]netip.Addr),
+		hostMap:             &HostMap{},
+		metricWriteFailures: counter,
+		warnLimiter:         newDNSWriteWarnLimiter(dnsWriteWarnLogWindow),
+	}
+	ds.enabled.Store(true)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.test.", dns.TypeA)
+
+	ds.handleDnsRequest(failingDNSWriter{}, q)
+
+	assert.Equal(t, int64(1), counter.Count(),
+		"metricWriteFailures must increment on WriteMsg error")
+	logged := logBuf.String()
+	assert.Contains(t, logged, "dns: failed to write response",
+		"Warn message must identify the dns/WriteMsg layer")
+	assert.Contains(t, logged, errInjectedWriteMsg.Error(),
+		"Warn must include the underlying error so operators can correlate")
+	assert.Contains(t, logged, "suppressed_since_last_log=0",
+		"first failure must report zero suppressed entries")
+}
 
 func TestParsequery(t *testing.T) {
 	l := slog.New(slog.DiscardHandler)

--- a/sshd/metrics.go
+++ b/sshd/metrics.go
@@ -5,3 +5,7 @@ import "github.com/rcrowley/go-metrics"
 // metricReplyErrors counts ssh.Request.Reply failures. Use replyAndLog
 // rather than calling Reply directly so failures land here.
 var metricReplyErrors = metrics.GetOrRegisterCounter("sshd.reply.errors", nil)
+
+// metricSendRequestErrors counts ssh.Channel.SendRequest failures. Use
+// sendRequestAndLog rather than calling SendRequest directly.
+var metricSendRequestErrors = metrics.GetOrRegisterCounter("sshd.send_request.errors", nil)

--- a/sshd/metrics.go
+++ b/sshd/metrics.go
@@ -1,0 +1,7 @@
+package sshd
+
+import "github.com/rcrowley/go-metrics"
+
+// metricReplyErrors counts ssh.Request.Reply failures. Use replyAndLog
+// rather than calling Reply directly so failures land here.
+var metricReplyErrors = metrics.GetOrRegisterCounter("sshd.reply.errors", nil)

--- a/sshd/reply.go
+++ b/sshd/reply.go
@@ -1,0 +1,21 @@
+package sshd
+
+import "log/slog"
+
+// replyer is the subset of *ssh.Request used for protocol-level replies.
+// *ssh.Request satisfies it unchanged; tests inject a fake.
+type replyer interface {
+	Reply(ok bool, payload []byte) error
+}
+
+// replyAndLog calls r.Reply and, on error, increments sshd.reply.errors
+// and emits a Warn so the failure is not silently dropped. The error is
+// returned so callers can choose to bail out.
+func replyAndLog(r replyer, ok bool, payload []byte, l *slog.Logger) error {
+	if err := r.Reply(ok, payload); err != nil {
+		metricReplyErrors.Inc(1)
+		l.Warn("ssh: protocol reply failed", "ok", ok, "error", err)
+		return err
+	}
+	return nil
+}

--- a/sshd/reply.go
+++ b/sshd/reply.go
@@ -19,3 +19,22 @@ func replyAndLog(r replyer, ok bool, payload []byte, l *slog.Logger) error {
 	}
 	return nil
 }
+
+// requester is the subset of ssh.Channel used for out-of-band requests.
+// ssh.Channel satisfies it unchanged; tests inject a fake.
+type requester interface {
+	SendRequest(name string, wantReply bool, payload []byte) (bool, error)
+}
+
+// sendRequestAndLog calls r.SendRequest and, on error, increments
+// sshd.send_request.errors and emits a Warn. The bool and error are
+// returned so callers can branch.
+func sendRequestAndLog(r requester, name string, wantReply bool, payload []byte, l *slog.Logger) (bool, error) {
+	ok, err := r.SendRequest(name, wantReply, payload)
+	if err != nil {
+		metricSendRequestErrors.Inc(1)
+		l.Warn("ssh: channel send-request failed", "name", name, "wantReply", wantReply, "error", err)
+		return ok, err
+	}
+	return ok, nil
+}

--- a/sshd/reply_test.go
+++ b/sshd/reply_test.go
@@ -1,0 +1,123 @@
+package sshd
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/rcrowley/go-metrics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errInjectedReply = errors.New("injected reply failure")
+
+// fakeReplyer satisfies replyer with a configurable error return.
+type fakeReplyer struct {
+	err        error
+	gotOK      bool
+	gotPayload []byte
+	calls      int
+}
+
+func (f *fakeReplyer) Reply(ok bool, payload []byte) error {
+	f.calls++
+	f.gotOK = ok
+	f.gotPayload = payload
+	return f.err
+}
+
+// TestReplyAndLog covers the four (success/failure) × (ok flag) shapes.
+func TestReplyAndLog(t *testing.T) {
+	tests := []struct {
+		name        string
+		replyErr    error
+		ok          bool
+		payload     []byte
+		wantLog     bool   // expect a Warn line in the log buffer
+		wantOKAttr  string // expected `ok` attr in the log line when wantLog
+		wantMetric  int64  // expected delta on sshd.reply.errors
+		wantErrIs   error  // require.ErrorIs target on the return value (nil if no error expected)
+		wantNoError bool   // require.NoError on the return value
+	}{
+		{
+			name:        "success path, ok=true: no log, no metric, returns nil",
+			replyErr:    nil,
+			ok:          true,
+			payload:     nil,
+			wantLog:     false,
+			wantMetric:  0,
+			wantNoError: true,
+		},
+		{
+			name:        "success path, ok=false (rejection that succeeded): no log, no metric, returns nil",
+			replyErr:    nil,
+			ok:          false,
+			payload:     []byte("ignored"),
+			wantLog:     false,
+			wantMetric:  0,
+			wantNoError: true,
+		},
+		{
+			name:       "failure path, ok=true: log, metric, returns injected error",
+			replyErr:   errInjectedReply,
+			ok:         true,
+			payload:    []byte("payload"),
+			wantLog:    true,
+			wantOKAttr: "ok=true",
+			wantMetric: 1,
+			wantErrIs:  errInjectedReply,
+		},
+		{
+			name:       "failure path, ok=false: log, metric, returns injected error",
+			replyErr:   errInjectedReply,
+			ok:         false,
+			payload:    nil,
+			wantLog:    true,
+			wantOKAttr: "ok=false",
+			wantMetric: 1,
+			wantErrIs:  errInjectedReply,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			l := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			// Snapshot the package-level counter so a delta comparison is
+			// robust to other tests that touched the same registry.
+			counterBefore := metrics.GetOrRegisterCounter("sshd.reply.errors", nil).Count()
+
+			r := &fakeReplyer{err: tc.replyErr}
+			gotErr := replyAndLog(r, tc.ok, tc.payload, l)
+
+			assert.Equal(t, 1, r.calls, "Reply must be called exactly once")
+			assert.Equal(t, tc.ok, r.gotOK, "ok flag must be forwarded to Reply")
+			assert.Equal(t, tc.payload, r.gotPayload, "payload must be forwarded to Reply")
+
+			counterAfter := metrics.GetOrRegisterCounter("sshd.reply.errors", nil).Count()
+			assert.Equal(t, tc.wantMetric, counterAfter-counterBefore,
+				"sshd.reply.errors must increment by %d", tc.wantMetric)
+
+			logged := logBuf.String()
+			if tc.wantLog {
+				assert.Contains(t, logged, "ssh: protocol reply failed",
+					"Warn line must identify the layer")
+				assert.Contains(t, logged, errInjectedReply.Error(),
+					"Warn line must include the underlying error so operators can correlate")
+				assert.Contains(t, logged, tc.wantOKAttr,
+					"Warn line must record the ok flag so operators can distinguish accept-fail from reject-fail")
+			} else {
+				assert.Empty(t, logged, "success path must not log")
+			}
+
+			if tc.wantNoError {
+				require.NoError(t, gotErr)
+			} else if tc.wantErrIs != nil {
+				require.Error(t, gotErr)
+				require.ErrorIs(t, gotErr, tc.wantErrIs,
+					"returned error must be the underlying r.Reply error so callers can branch")
+			}
+		})
+	}
+}

--- a/sshd/reply_test.go
+++ b/sshd/reply_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 var errInjectedReply = errors.New("injected reply failure")
+var errInjectedSendRequest = errors.New("injected send-request failure")
 
 // fakeReplyer satisfies replyer with a configurable error return.
 type fakeReplyer struct {
@@ -117,6 +118,123 @@ func TestReplyAndLog(t *testing.T) {
 				require.Error(t, gotErr)
 				require.ErrorIs(t, gotErr, tc.wantErrIs,
 					"returned error must be the underlying r.Reply error so callers can branch")
+			}
+		})
+	}
+}
+
+// fakeRequester satisfies requester with a configurable bool/error return.
+type fakeRequester struct {
+	ok           bool
+	err          error
+	gotName      string
+	gotWantReply bool
+	gotPayload   []byte
+	calls        int
+}
+
+func (f *fakeRequester) SendRequest(name string, wantReply bool, payload []byte) (bool, error) {
+	f.calls++
+	f.gotName = name
+	f.gotWantReply = wantReply
+	f.gotPayload = payload
+	return f.ok, f.err
+}
+
+func TestSendRequestAndLog(t *testing.T) {
+	tests := []struct {
+		name           string
+		fakeOK         bool
+		sendErr        error
+		wantReply      bool
+		payload        []byte
+		wantLog        bool
+		wantMetric     int64
+		wantReturnedOK bool
+		wantErrIs      error
+		wantNoError    bool
+	}{
+		{
+			name:           "success, wantReply=false, fake ok=false: no log, no metric, returns false/nil",
+			fakeOK:         false,
+			sendErr:        nil,
+			wantReply:      false,
+			payload:        []byte("status"),
+			wantLog:        false,
+			wantMetric:     0,
+			wantReturnedOK: false,
+			wantNoError:    true,
+		},
+		{
+			name:           "success, wantReply=true, fake ok=true: no log, no metric, returns true/nil",
+			fakeOK:         true,
+			sendErr:        nil,
+			wantReply:      true,
+			payload:        nil,
+			wantLog:        false,
+			wantMetric:     0,
+			wantReturnedOK: true,
+			wantNoError:    true,
+		},
+		{
+			name:           "failure, wantReply=false: log, metric, returns false/error",
+			fakeOK:         false,
+			sendErr:        errInjectedSendRequest,
+			wantReply:      false,
+			payload:        []byte("status"),
+			wantLog:        true,
+			wantMetric:     1,
+			wantReturnedOK: false,
+			wantErrIs:      errInjectedSendRequest,
+		},
+		{
+			name:           "failure, wantReply=true: log, metric, returns false/error",
+			fakeOK:         false,
+			sendErr:        errInjectedSendRequest,
+			wantReply:      true,
+			payload:        nil,
+			wantLog:        true,
+			wantMetric:     1,
+			wantReturnedOK: false,
+			wantErrIs:      errInjectedSendRequest,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var logBuf bytes.Buffer
+			l := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			counterBefore := metrics.GetOrRegisterCounter("sshd.send_request.errors", nil).Count()
+
+			r := &fakeRequester{ok: tc.fakeOK, err: tc.sendErr}
+			gotOK, gotErr := sendRequestAndLog(r, "exit-status", tc.wantReply, tc.payload, l)
+
+			assert.Equal(t, 1, r.calls, "SendRequest must be called exactly once")
+			assert.Equal(t, "exit-status", r.gotName, "name must be forwarded")
+			assert.Equal(t, tc.wantReply, r.gotWantReply, "wantReply must be forwarded")
+			assert.Equal(t, tc.payload, r.gotPayload, "payload must be forwarded")
+			assert.Equal(t, tc.wantReturnedOK, gotOK, "underlying SendRequest bool must be forwarded")
+
+			counterAfter := metrics.GetOrRegisterCounter("sshd.send_request.errors", nil).Count()
+			assert.Equal(t, tc.wantMetric, counterAfter-counterBefore,
+				"sshd.send_request.errors must increment by %d", tc.wantMetric)
+
+			logged := logBuf.String()
+			if tc.wantLog {
+				assert.Contains(t, logged, "ssh: channel send-request failed",
+					"Warn line must identify the layer")
+				assert.Contains(t, logged, errInjectedSendRequest.Error(),
+					"Warn line must include the underlying error")
+				assert.Contains(t, logged, "name=exit-status",
+					"Warn line must record the request name so operators can correlate")
+			} else {
+				assert.Empty(t, logged, "success path must not log")
+			}
+
+			if tc.wantNoError {
+				require.NoError(t, gotErr)
+			} else if tc.wantErrIs != nil {
+				require.Error(t, gotErr)
+				require.ErrorIs(t, gotErr, tc.wantErrIs)
 			}
 		})
 	}

--- a/sshd/session.go
+++ b/sshd/session.go
@@ -82,7 +82,7 @@ func (s *session) handleRequests(in <-chan *ssh.Request, channel ssh.Channel) {
 			var payload = struct{ Value string }{}
 			cErr := ssh.Unmarshal(req.Payload, &payload)
 			if cErr != nil {
-				req.Reply(false, nil)
+				_ = replyAndLog(req, false, nil, s.l)
 				return
 			}
 

--- a/sshd/session.go
+++ b/sshd/session.go
@@ -93,7 +93,7 @@ func (s *session) handleRequests(in <-chan *ssh.Request, channel ssh.Channel) {
 			s.dispatchCommand(payload.Value, &stringWriter{channel})
 
 			status := struct{ Status uint32 }{uint32(0)}
-			channel.SendRequest("exit-status", false, ssh.Marshal(status))
+			_, _ = sendRequestAndLog(channel, "exit-status", false, ssh.Marshal(status), s.l)
 			channel.Close()
 			return
 

--- a/sshd/session.go
+++ b/sshd/session.go
@@ -86,7 +86,10 @@ func (s *session) handleRequests(in <-chan *ssh.Request, channel ssh.Channel) {
 				return
 			}
 
-			req.Reply(true, nil)
+			if err := replyAndLog(req, true, nil, s.l); err != nil {
+				channel.Close()
+				return
+			}
 			s.dispatchCommand(payload.Value, &stringWriter{channel})
 
 			status := struct{ Status uint32 }{uint32(0)}


### PR DESCRIPTION

### Hi 👋

Five places inside `dns_server.go`, `sshd/session.go`, and `config/config.go` quietly swallowed the error returned by a write/reply/stat call. In each case the operator saw normal output or a misleading success while a real failure (UDP write error, channel torn down mid-handshake, addFile failing on an unresolvable path) went unrecorded. This PR resolves all five at the root, in five small bisect-safe commits. Where the calling API can carry an error, it is now propagated; where it cannot (DNS write callbacks, SSH protocol replies inside a goroutine), the failure is now logged via `slog.Warn` and counted in a `rcrowley/go-metrics` counter so it shows up in the existing metrics export.

### How we found these

We ran [`errcheck`](https://github.com/kisielk/errcheck) via golangci-lint as part of a strict static-analysis pipeline downstream of this fork. `errcheck` flags every call whose returned error is discarded. After triaging the full report into "real bugs", "cosmetic (test setup, defer-close)", and "false-positive", five real-bug call sites remained:

```
config/config.go:351:14:  Error return value of `c.addFile` is not checked
dns_server.go:194:14:     Error return value of `w.WriteMsg` is not checked
sshd/session.go:85:13:    Error return value of `req.Reply` is not checked
sshd/session.go:89:13:    Error return value of `req.Reply` is not checked
sshd/session.go:96:21:    Error return value of `channel.SendRequest` is not checked
```

Each line maps to one commit.

### Per-site operator impact

| File:line | Function | Pre-fix operator experience |
|---|---|---|
| `config/config.go:351` | `(c *C).resolve` | A user-specified config path whose `filepath.Abs` fails is silently dropped — the user sees "no config files found" with no hint of the real cause |
| `dns_server.go:194` | `handleDnsRequest` | `WriteMsg` failures (client socket closed, FD exhaustion, UDP send error) are invisible; clients quietly timeout and the operator has no signal |
| `sshd/session.go:85` | `handleRequests` (bad-payload reject) | A malformed exec request rejection that fails to reach the client is invisible — the user sees a hung session, the operator sees nothing |
| `sshd/session.go:89` | `handleRequests` (accept-exec) | Same shape, but the consequence is worse: today the handler still proceeds to dispatch the command and emit exit-status to a client that never confirmed the accept |
| `sshd/session.go:96` | `handleRequests` (exit-status) | The final exit-status notification can fail with no record; the client appears to hang for a moment before close |

The `dns_server.go` case is the one most likely to bite an operator in the wild — a single failing client (e.g. a closed-socket replay or a transient UDP error) is currently silent, so a misbehaving DNS consumer is invisible until it is widespread enough to show up elsewhere.

### Design notes

We thought carefully about how to handle each site:

1. **No retry**, even for the DNS WriteMsg case. UDP DNS responses are stateless: if the client socket is gone, retrying the same response with the same DNS transaction ID is a protocol violation. FD exhaustion is not solvable by retry. The DNS protocol already expects the resolver layer to retry on no-answer, so adding handler-side retry would only delay the eventual `WriteMsg` failure. **Decision: observe, do not retry.**

2. **No new dependencies.** The DNS commit adds a `~20`-line atomic-int-based `dnsWriteWarnLimiter` rather than pulling in `golang.org/x/time/rate`. The limiter coalesces high-rate failure bursts so a runaway client does not flood the journal: the first failure in a 10-second window logs immediately with the count of suppressed messages since the last log, the rest only increment the counter. (The counter is exposed regardless of the log rate-limit.)

3. **`rcrowley/go-metrics` counters everywhere**, following the same dot-separated registry convention the rest of nebula already uses (e.g. `messages.tx.*`). Three new counters:
    - `dns.responses.write_failures`
    - `sshd.reply.errors`
    - `sshd.send_request.errors`

4. **`replyer` / `requester` interfaces** for the SSH side. `*ssh.Request.Reply` and `*ssh.Channel.SendRequest` are not testable in isolation without standing up a full SSH transport; we extracted single-method interfaces and route the call sites through small helpers (`replyAndLog`, `sendRequestAndLog`). `*ssh.Request` and `*ssh.Channel` satisfy them unchanged; tests inject fakes.

5. **One commit bails out, the others observe.** Specifically, the SSH `accept-exec` site (sshd/session.go:89) now branches on the helper's return: if the accept-reply fails, the handler closes the channel and bails without running the user's command — proceeding would dispatch a command for which the client never received the accept and would lead to a confused exit-status that the client cannot correlate. The other SSH sites and the DNS site only observe, because at those points the work is either done or there is no useful follow-up action.

### Commit map

1. `Return addFile errors from config.resolve` — propagates `filepath.Abs` failures through `addFile` to `resolve`. Test injects a fake `filepathAbs` via a package-level var.
2. `Log and meter dns_server WriteMsg failures` — adds the `dnsWriteWarnLimiter` (with a 6-row table-driven test) and routes `WriteMsg` errors through it. Counter `dns.responses.write_failures` increments unconditionally; the Warn is rate-limited to one per 10s.
3. `Log and meter SSH protocol reply failures from session handler` — introduces `sshd/metrics.go`, `sshd/reply.go` (`replyer` interface + `replyAndLog`), and `sshd/reply_test.go` (`TestReplyAndLog`, 4-row table). Routes the bad-payload reject site through the helper.
4. `Bail out of SSH exec handler when accept-reply fails` — routes the accept-reply through `replyAndLog` and branches on its return so the handler stops cleanly when the accept never reaches the client.
5. `Log and meter ssh.Channel.SendRequest failures` — extends `sshd/reply.go` with `requester` + `sendRequestAndLog`, adds `metricSendRequestErrors`, routes the exit-status request through the helper. `TestSendRequestAndLog` is a 4-row table covering success/failure × wantReply.

Mutation-tested: at every commit that adds an observability helper, I removed the metric line and the log line in turn and confirmed the table test catches each mutation. The tests are not tautologies.

All five commits are independently bisect-safe — `go test -count=1 ./...` passes at every SHA on the branch.

### How to run the new tests locally

```
go test -count=1 -v -run 'TestConfig_Resolve_AddFileErrorPropagates' ./config
go test -count=1 -v -run 'TestDNSWriteWarnLimiter|TestDnsServer_HandleDnsRequest_WriteMsgFailure' .
go test -count=1 -v -run 'TestReplyAndLog|TestSendRequestAndLog' ./sshd
```

### Backward compatibility

No CLI flag, config key, or public API changes. The only observable behaviour change is that previously-silent failures now appear in the metrics export and the journal, plus the SSH accept-exec path now cleanly aborts on a broken handshake rather than dispatching a command whose accept never landed. All existing tests continue to pass with no edits.

