### PR TITLE
Set timeouts on the Prometheus stats HTTP listener

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -351,6 +351,22 @@ logging:
   #subsystem: nebula
   #interval: 10s
 
+  # Timeouts on the prometheus HTTP listener. Defending against slow
+  # clients (slowloris, slowpost, slow-read) and bounding keep-alive
+  # idle. Each defaults to a conservative value; the values below are
+  # the defaults. Set any to 0 to disable that limit (not recommended
+  # for read_header_timeout: it is the primary slowloris defense).
+  # All are reloadable along with the rest of the stats: section.
+  #read_header_timeout: 10s
+  #read_timeout: 15s
+  #write_timeout: 30s
+  #idle_timeout: 120s
+  # handler_timeout wraps the prometheus scrape handler in
+  # http.TimeoutHandler so a slow registry surfaces as a clean 503
+  # response with this message instead of an abrupt connection close.
+  # Set to 0 to disable the wrap and rely on write_timeout alone.
+  #handler_timeout: 30s
+
   # enables counter metrics for meta packets
   #   e.g.: `messages.tx.handshake`
   # NOTE: `message.{tx,rx}.recv_error` is always emitted

--- a/stats.go
+++ b/stats.go
@@ -21,6 +21,32 @@ import (
 	"github.com/slackhq/nebula/config"
 )
 
+// Default timeouts for the Prometheus stats HTTP listener. Each one
+// defends against a specific class of slow-client / slow-network
+// failure that would otherwise tie up server resources indefinitely.
+const (
+	// defaultStatsReadHeaderTimeout bounds the time spent reading the
+	// HTTP request line and all headers. This is the primary slowloris
+	// defense - it fires before the application handler runs, so it
+	// protects the pre-handler read phase that no request context can
+	// reach.
+	defaultStatsReadHeaderTimeout = 10 * time.Second
+
+	// defaultStatsReadTimeout bounds the entire request read (headers
+	// plus body). Must be >= defaultStatsReadHeaderTimeout.
+	defaultStatsReadTimeout = 15 * time.Second
+
+	// defaultStatsWriteTimeout bounds the time from end-of-headers-read
+	// to end-of-response-write. Sized for large Prometheus registries
+	// behind slow scrapers.
+	defaultStatsWriteTimeout = 30 * time.Second
+
+	// defaultStatsIdleTimeout bounds keep-alive idle time before the
+	// server closes the connection. Sized to span ~8 scrapes at a 15s
+	// interval so a steady scrape cadence reuses one TCP/TLS handshake.
+	defaultStatsIdleTimeout = 120 * time.Second
+)
+
 // statsServer owns nebula's stats subsystem: the periodic metric capture
 // goroutine and (for prometheus) an HTTP listener. It mirrors the lifecycle
 // shape of dnsServer: constructor wires the reload callback, reload records
@@ -301,7 +327,14 @@ func (s *statsServer) buildRuntime(cfg statsConfig) ([]func(), *http.Server) {
 		errLog := slog.NewLogLogger(s.l.Handler(), slog.LevelError)
 		mux := http.NewServeMux()
 		mux.Handle(cfg.prom.path, promhttp.HandlerFor(pr, promhttp.HandlerOpts{ErrorLog: errLog}))
-		return captureFns, &http.Server{Addr: cfg.prom.listen, Handler: mux}
+		return captureFns, &http.Server{
+			Addr:              cfg.prom.listen,
+			Handler:           mux,
+			ReadHeaderTimeout: defaultStatsReadHeaderTimeout,
+			ReadTimeout:       defaultStatsReadTimeout,
+			WriteTimeout:      defaultStatsWriteTimeout,
+			IdleTimeout:       defaultStatsIdleTimeout,
+		}
 	}
 	return captureFns, nil
 }

--- a/stats.go
+++ b/stats.go
@@ -45,6 +45,12 @@ const (
 	// server closes the connection. Sized to span ~8 scrapes at a 15s
 	// interval so a steady scrape cadence reuses one TCP/TLS handshake.
 	defaultStatsIdleTimeout = 120 * time.Second
+
+	// defaultStatsHandlerTimeout bounds a single Prometheus scrape via
+	// http.TimeoutHandler so a slow registry surfaces as a clean 503
+	// rather than an abrupt connection close. A zero config value
+	// disables the wrap entirely.
+	defaultStatsHandlerTimeout = 30 * time.Second
 )
 
 // statsServer owns nebula's stats subsystem: the periodic metric capture
@@ -99,6 +105,18 @@ type promConfig struct {
 	path      string
 	namespace string
 	subsystem string
+
+	// HTTP server timeouts. See the default* constants for the meaning
+	// of each field; zero means "no limit" per net/http semantics, but
+	// loadStatsConfig substitutes the default when a key is absent.
+	readHeaderTimeout time.Duration
+	readTimeout       time.Duration
+	writeTimeout      time.Duration
+	idleTimeout       time.Duration
+	// handlerTimeout drives the optional http.TimeoutHandler wrap.
+	// A zero value disables the wrap; non-zero installs it with this
+	// budget.
+	handlerTimeout time.Duration
 }
 
 // newStatsServerFromConfig builds a statsServer, applies the initial config,
@@ -330,10 +348,10 @@ func (s *statsServer) buildRuntime(cfg statsConfig) ([]func(), *http.Server) {
 		return captureFns, &http.Server{
 			Addr:              cfg.prom.listen,
 			Handler:           mux,
-			ReadHeaderTimeout: defaultStatsReadHeaderTimeout,
-			ReadTimeout:       defaultStatsReadTimeout,
-			WriteTimeout:      defaultStatsWriteTimeout,
-			IdleTimeout:       defaultStatsIdleTimeout,
+			ReadHeaderTimeout: cfg.prom.readHeaderTimeout,
+			ReadTimeout:       cfg.prom.readTimeout,
+			WriteTimeout:      cfg.prom.writeTimeout,
+			IdleTimeout:       cfg.prom.idleTimeout,
 		}
 	}
 	return captureFns, nil
@@ -392,6 +410,25 @@ func loadStatsConfig(c *config.C) (statsConfig, error) {
 		}
 		cfg.prom.namespace = c.GetString("stats.namespace", "")
 		cfg.prom.subsystem = c.GetString("stats.subsystem", "")
+		cfg.prom.readHeaderTimeout = c.GetDuration("stats.read_header_timeout", defaultStatsReadHeaderTimeout)
+		cfg.prom.readTimeout = c.GetDuration("stats.read_timeout", defaultStatsReadTimeout)
+		cfg.prom.writeTimeout = c.GetDuration("stats.write_timeout", defaultStatsWriteTimeout)
+		cfg.prom.idleTimeout = c.GetDuration("stats.idle_timeout", defaultStatsIdleTimeout)
+		cfg.prom.handlerTimeout = c.GetDuration("stats.handler_timeout", defaultStatsHandlerTimeout)
+		for _, e := range []struct {
+			key string
+			v   time.Duration
+		}{
+			{"stats.read_header_timeout", cfg.prom.readHeaderTimeout},
+			{"stats.read_timeout", cfg.prom.readTimeout},
+			{"stats.write_timeout", cfg.prom.writeTimeout},
+			{"stats.idle_timeout", cfg.prom.idleTimeout},
+			{"stats.handler_timeout", cfg.prom.handlerTimeout},
+		} {
+			if e.v < 0 {
+				return cfg, fmt.Errorf("%s must be >= 0, got %s", e.key, e.v)
+			}
+		}
 	default:
 		return cfg, fmt.Errorf("stats.type was not understood: %s", cfg.typ)
 	}

--- a/stats.go
+++ b/stats.go
@@ -344,7 +344,8 @@ func (s *statsServer) buildRuntime(cfg statsConfig) ([]func(), *http.Server) {
 		// so bridge our slog.Logger back to a *log.Logger that emits at Error.
 		errLog := slog.NewLogLogger(s.l.Handler(), slog.LevelError)
 		mux := http.NewServeMux()
-		mux.Handle(cfg.prom.path, promhttp.HandlerFor(pr, promhttp.HandlerOpts{ErrorLog: errLog}))
+		prom := promhttp.HandlerFor(pr, promhttp.HandlerOpts{ErrorLog: errLog})
+		mux.Handle(cfg.prom.path, wrapPromHandler(prom, cfg.prom.handlerTimeout))
 		return captureFns, &http.Server{
 			Addr:              cfg.prom.listen,
 			Handler:           mux,
@@ -355,6 +356,20 @@ func (s *statsServer) buildRuntime(cfg statsConfig) ([]func(), *http.Server) {
 		}
 	}
 	return captureFns, nil
+}
+
+// promScrapeTimeoutBody is the response body http.TimeoutHandler emits
+// when a prometheus scrape exceeds its handlerTimeout budget.
+const promScrapeTimeoutBody = "prometheus scrape timeout"
+
+// wrapPromHandler conditionally wraps h with http.TimeoutHandler. A
+// non-positive handlerTimeout returns h unchanged so the wrap can be
+// disabled by configuring stats.handler_timeout: 0.
+func wrapPromHandler(h http.Handler, handlerTimeout time.Duration) http.Handler {
+	if handlerTimeout <= 0 {
+		return h
+	}
+	return http.TimeoutHandler(h, handlerTimeout, promScrapeTimeoutBody)
 }
 
 // captureStatsLoop runs each fn on every tick of d until ctx is cancelled.

--- a/stats_test.go
+++ b/stats_test.go
@@ -409,20 +409,22 @@ func freeTCPPort(t *testing.T) string {
 	return strconv.Itoa(port)
 }
 
-// TestStatsServer_buildRuntime_AppliesDefaultTimeouts pins the four
-// http.Server timeout fields to their default constants, so a future
-// edit that drops a field is caught at the source rather than only
-// surfacing as a missing slowloris defense in production.
+// TestStatsServer_buildRuntime_AppliesDefaultTimeouts asserts the full
+// pipeline: with no timeout keys set, loadStatsConfig substitutes the
+// default constants, and buildRuntime forwards them onto the
+// *http.Server. A future edit that drops a field is caught at the
+// source rather than only surfacing as a missing slowloris defense in
+// production.
 func TestStatsServer_buildRuntime_AppliesDefaultTimeouts(t *testing.T) {
-	s, _ := newTestStatsServer(t)
-	cfg := statsConfig{
-		typ:      "prometheus",
-		interval: time.Second,
-		prom: promConfig{
-			listen: "127.0.0.1:0",
-			path:   "/metrics",
-		},
-	}
+	s, c := newTestStatsServer(t)
+	setStatsConfig(c, map[string]any{
+		"type":     "prometheus",
+		"interval": "1s",
+		"listen":   "127.0.0.1:0",
+		"path":     "/metrics",
+	})
+	cfg, err := loadStatsConfig(c)
+	require.NoError(t, err)
 
 	_, server := s.buildRuntime(cfg)
 	require.NotNil(t, server, "prometheus config must produce an *http.Server")
@@ -441,6 +443,148 @@ func TestStatsServer_buildRuntime_AppliesDefaultTimeouts(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.want, tc.got,
 				"%s must be set to its default constant", tc.name)
+		})
+	}
+	assert.Equal(t, defaultStatsHandlerTimeout, cfg.prom.handlerTimeout,
+		"cfg.prom.handlerTimeout must default to defaultStatsHandlerTimeout")
+}
+
+// TestLoadStatsConfig_PromTimeouts_Overrides asserts that each
+// stats.*_timeout YAML key overrides the corresponding default. One
+// row per key plus a final row asserting all keys overridden together,
+// which catches plumbing mistakes where one key's value silently lands
+// in another field.
+func TestLoadStatsConfig_PromTimeouts_Overrides(t *testing.T) {
+	tests := []struct {
+		name     string
+		override map[string]any
+		want     promConfig
+	}{
+		{
+			name:     "read_header_timeout only",
+			override: map[string]any{"read_header_timeout": "3s"},
+			want: promConfig{
+				readHeaderTimeout: 3 * time.Second,
+				readTimeout:       defaultStatsReadTimeout,
+				writeTimeout:      defaultStatsWriteTimeout,
+				idleTimeout:       defaultStatsIdleTimeout,
+				handlerTimeout:    defaultStatsHandlerTimeout,
+			},
+		},
+		{
+			name:     "read_timeout only",
+			override: map[string]any{"read_timeout": "7s"},
+			want: promConfig{
+				readHeaderTimeout: defaultStatsReadHeaderTimeout,
+				readTimeout:       7 * time.Second,
+				writeTimeout:      defaultStatsWriteTimeout,
+				idleTimeout:       defaultStatsIdleTimeout,
+				handlerTimeout:    defaultStatsHandlerTimeout,
+			},
+		},
+		{
+			name:     "write_timeout only",
+			override: map[string]any{"write_timeout": "45s"},
+			want: promConfig{
+				readHeaderTimeout: defaultStatsReadHeaderTimeout,
+				readTimeout:       defaultStatsReadTimeout,
+				writeTimeout:      45 * time.Second,
+				idleTimeout:       defaultStatsIdleTimeout,
+				handlerTimeout:    defaultStatsHandlerTimeout,
+			},
+		},
+		{
+			name:     "idle_timeout only",
+			override: map[string]any{"idle_timeout": "200s"},
+			want: promConfig{
+				readHeaderTimeout: defaultStatsReadHeaderTimeout,
+				readTimeout:       defaultStatsReadTimeout,
+				writeTimeout:      defaultStatsWriteTimeout,
+				idleTimeout:       200 * time.Second,
+				handlerTimeout:    defaultStatsHandlerTimeout,
+			},
+		},
+		{
+			name:     "handler_timeout zero disables the wrap",
+			override: map[string]any{"handler_timeout": "0s"},
+			want: promConfig{
+				readHeaderTimeout: defaultStatsReadHeaderTimeout,
+				readTimeout:       defaultStatsReadTimeout,
+				writeTimeout:      defaultStatsWriteTimeout,
+				idleTimeout:       defaultStatsIdleTimeout,
+				handlerTimeout:    0,
+			},
+		},
+		{
+			name: "all five overridden together",
+			override: map[string]any{
+				"read_header_timeout": "1s",
+				"read_timeout":        "2s",
+				"write_timeout":       "3s",
+				"idle_timeout":        "4s",
+				"handler_timeout":     "5s",
+			},
+			want: promConfig{
+				readHeaderTimeout: 1 * time.Second,
+				readTimeout:       2 * time.Second,
+				writeTimeout:      3 * time.Second,
+				idleTimeout:       4 * time.Second,
+				handlerTimeout:    5 * time.Second,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, c := newTestStatsServer(t)
+			base := map[string]any{
+				"type":     "prometheus",
+				"interval": "1s",
+				"listen":   "127.0.0.1:0",
+				"path":     "/metrics",
+			}
+			for k, v := range tc.override {
+				base[k] = v
+			}
+			setStatsConfig(c, base)
+
+			cfg, err := loadStatsConfig(c)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want.readHeaderTimeout, cfg.prom.readHeaderTimeout, "readHeaderTimeout")
+			assert.Equal(t, tc.want.readTimeout, cfg.prom.readTimeout, "readTimeout")
+			assert.Equal(t, tc.want.writeTimeout, cfg.prom.writeTimeout, "writeTimeout")
+			assert.Equal(t, tc.want.idleTimeout, cfg.prom.idleTimeout, "idleTimeout")
+			assert.Equal(t, tc.want.handlerTimeout, cfg.prom.handlerTimeout, "handlerTimeout")
+		})
+	}
+}
+
+// TestLoadStatsConfig_PromTimeouts_NegativeRejected verifies that a
+// negative duration on any of the five timeout keys is rejected at
+// config-load time. A negative net/http timeout silently breaks the
+// server in non-obvious ways (zero would be the safer "no limit"
+// interpretation), so we reject rather than silently substitute.
+func TestLoadStatsConfig_PromTimeouts_NegativeRejected(t *testing.T) {
+	tests := []string{
+		"read_header_timeout",
+		"read_timeout",
+		"write_timeout",
+		"idle_timeout",
+		"handler_timeout",
+	}
+	for _, key := range tests {
+		t.Run(key, func(t *testing.T) {
+			_, c := newTestStatsServer(t)
+			setStatsConfig(c, map[string]any{
+				"type":     "prometheus",
+				"interval": "1s",
+				"listen":   "127.0.0.1:0",
+				"path":     "/metrics",
+				key:        "-5s",
+			})
+			_, err := loadStatsConfig(c)
+			require.Error(t, err, "negative %s must be rejected", key)
+			require.Contains(t, err.Error(), "stats."+key,
+				"error must name the offending key so the operator can find it")
 		})
 	}
 }

--- a/stats_test.go
+++ b/stats_test.go
@@ -5,6 +5,9 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
 	"strconv"
 	"testing"
 	"time"
@@ -599,4 +602,135 @@ func TestStatsTimeoutDefaults_AreConsistent(t *testing.T) {
 	require.GreaterOrEqual(t,
 		defaultStatsReadTimeout, defaultStatsReadHeaderTimeout,
 		"defaultStatsReadTimeout must be >= defaultStatsReadHeaderTimeout")
+}
+
+// TestWrapPromHandler_ZeroTimeoutPassesThrough asserts that the wrap
+// is truly a noop when handlerTimeout is 0 - the returned handler is
+// the same function value as the input, so a future edit that
+// accidentally wraps with a zero timeout is caught.
+func TestWrapPromHandler_ZeroTimeoutPassesThrough(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	innerPC := reflect.ValueOf(inner).Pointer()
+
+	got := wrapPromHandler(inner, 0)
+	gotFn, ok := got.(http.HandlerFunc)
+	require.True(t, ok, "wrapPromHandler with handlerTimeout=0 must return the input handler type")
+	require.Equal(t, innerPC, reflect.ValueOf(gotFn).Pointer(),
+		"wrapPromHandler must return its input unchanged when handlerTimeout is 0")
+
+	gotNeg := wrapPromHandler(inner, -1*time.Second)
+	gotNegFn, ok := gotNeg.(http.HandlerFunc)
+	require.True(t, ok, "wrapPromHandler with negative handlerTimeout must return the input handler type")
+	require.Equal(t, innerPC, reflect.ValueOf(gotNegFn).Pointer(),
+		"wrapPromHandler must return its input unchanged when handlerTimeout is negative")
+}
+
+// TestWrapPromHandler_FiresOn503 asserts the integration: a real
+// httptest listener, a deliberately slow handler, GET via the standard
+// HTTP client, and a 503 + the canned timeout body. Gated by
+// testing.Short because it sleeps ~150ms total.
+func TestWrapPromHandler_FiresOn503(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: real listener + 150ms wait for timeout handler to fire")
+	}
+	slow := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Sleep well past the handlerTimeout to guarantee the wrap fires.
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("would-have-been-the-real-body"))
+	})
+	wrapped := wrapPromHandler(slow, 50*time.Millisecond)
+	srv := httptest.NewServer(wrapped)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode,
+		"a slow handler must surface as 503 via TimeoutHandler")
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Contains(t, string(body), promScrapeTimeoutBody,
+		"the canned timeout body must reach the client")
+	assert.NotContains(t, string(body), "would-have-been-the-real-body",
+		"the slow handler's body must NOT leak through the wrap")
+}
+
+// TestWrapPromHandler_NoWrap_ResponseFlowsThrough asserts that when
+// handlerTimeout is 0 the real response body reaches the client even
+// when the handler is slightly slow. Cheap (no sleep needed) and proves
+// the conditional in wrapPromHandler did the right thing end-to-end.
+func TestWrapPromHandler_NoWrap_ResponseFlowsThrough(t *testing.T) {
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("real-body"))
+	})
+	wrapped := wrapPromHandler(inner, 0)
+	srv := httptest.NewServer(wrapped)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, "real-body", string(body),
+		"with handlerTimeout=0 the real response body must reach the client")
+}
+
+// TestStatsServer_Slowloris_ReadHeaderTimeout proves the slowloris
+// defense end-to-end: configure a tight ReadHeaderTimeout, start the
+// real listener, open a raw TCP connection, write a partial header
+// line, and assert the server closes the connection before our read
+// deadline. Gated by testing.Short because it waits ~250ms for the
+// server-side timeout to fire.
+func TestStatsServer_Slowloris_ReadHeaderTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration: real listener + 250ms wait for ReadHeaderTimeout to fire")
+	}
+	port := freeTCPPort(t)
+	s, c := newTestStatsServer(t)
+	setStatsConfig(c, map[string]any{
+		"type":                "prometheus",
+		"interval":            "1s",
+		"listen":              "127.0.0.1:" + port,
+		"path":                "/metrics",
+		"read_header_timeout": "200ms",
+	})
+	require.NoError(t, s.reload(c, true))
+
+	done := make(chan struct{})
+	go func() {
+		s.Start()
+		close(done)
+	}()
+	t.Cleanup(func() {
+		s.Stop()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("stats server did not stop")
+		}
+	})
+	waitForListening(t, "127.0.0.1:"+port)
+
+	conn, err := net.Dial("tcp", "127.0.0.1:"+port)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Write a request line + one header but no terminating CRLF, then
+	// stop. A non-defended server would block here forever; this server
+	// must tear down the connection within ReadHeaderTimeout (200ms).
+	_, err = conn.Write([]byte("GET /metrics HTTP/1.1\r\nHost: localhost"))
+	require.NoError(t, err)
+
+	// Give the server slightly more than ReadHeaderTimeout to react.
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(1*time.Second)))
+	buf := make([]byte, 1)
+	_, readErr := conn.Read(buf)
+	require.Error(t, readErr,
+		"server must close the partial-header connection within ReadHeaderTimeout")
 }

--- a/stats_test.go
+++ b/stats_test.go
@@ -408,3 +408,51 @@ func freeTCPPort(t *testing.T) string {
 	require.NoError(t, ln.Close())
 	return strconv.Itoa(port)
 }
+
+// TestStatsServer_buildRuntime_AppliesDefaultTimeouts pins the four
+// http.Server timeout fields to their default constants, so a future
+// edit that drops a field is caught at the source rather than only
+// surfacing as a missing slowloris defense in production.
+func TestStatsServer_buildRuntime_AppliesDefaultTimeouts(t *testing.T) {
+	s, _ := newTestStatsServer(t)
+	cfg := statsConfig{
+		typ:      "prometheus",
+		interval: time.Second,
+		prom: promConfig{
+			listen: "127.0.0.1:0",
+			path:   "/metrics",
+		},
+	}
+
+	_, server := s.buildRuntime(cfg)
+	require.NotNil(t, server, "prometheus config must produce an *http.Server")
+
+	tests := []struct {
+		name string
+		got  time.Duration
+		want time.Duration
+	}{
+		{"ReadHeaderTimeout", server.ReadHeaderTimeout, defaultStatsReadHeaderTimeout},
+		{"ReadTimeout", server.ReadTimeout, defaultStatsReadTimeout},
+		{"WriteTimeout", server.WriteTimeout, defaultStatsWriteTimeout},
+		{"IdleTimeout", server.IdleTimeout, defaultStatsIdleTimeout},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.got,
+				"%s must be set to its default constant", tc.name)
+		})
+	}
+}
+
+// TestStatsTimeoutDefaults_AreConsistent guards the invariant that
+// ReadTimeout must be at least as large as ReadHeaderTimeout. If a
+// future edit shortens ReadTimeout below ReadHeaderTimeout, the read
+// phase would terminate before headers had a chance to finish - giving
+// a generic i/o-timeout instead of the more useful slowloris-shaped
+// failure.
+func TestStatsTimeoutDefaults_AreConsistent(t *testing.T) {
+	require.GreaterOrEqual(t,
+		defaultStatsReadTimeout, defaultStatsReadHeaderTimeout,
+		"defaultStatsReadTimeout must be >= defaultStatsReadHeaderTimeout")
+}


### PR DESCRIPTION

### Hi 👋

The Prometheus stats `*http.Server` is currently constructed bare: `&http.Server{Addr: cfg.prom.listen, Handler: mux}`. Every timeout field is the zero value, which `net/http` reads as "no limit". That means the server accepts connections that send headers one byte per minute forever (slowloris), bodies that never end (slowpost), responses that drain one byte per minute (slow read), and keep-alive idle connections that never close. On a listener bound to a public interface — either deliberately (cross-host scraping by a central Prometheus) or by accident (operator types `0.0.0.0` instead of an overlay address) — a single attacker can park thousands of FDs at near-zero cost. Some operators may already be running with these issues now: this PR closes the gap, with conservative defaults and full reload-aware configurability.

### How we found this

Downstream of this fork we run [`gosec`](https://github.com/securego/gosec) via golangci-lint as part of a strict static-analysis pipeline. The relevant finding was:

```
stats.go:304  G112 (CWE-400): Potential Slowloris Attack because
               ReadHeaderTimeout is not configured in the http.Server
               (Confidence: LOW, Severity: MEDIUM)
```

`ReadHeaderTimeout` is the floor; this PR fixes the floor and the three siblings (`ReadTimeout`, `WriteTimeout`, `IdleTimeout`) at the same time so the gap is closed cleanly rather than just silencing the lint.

### What lands in this PR

Three commits, each focused on one concern, all bisect-safe (`go test ./...` passes at every SHA).

**Commit 1 — `Set timeouts on the Prometheus stats HTTP listener`**

The security floor. Adds four `defaultStatsXxxTimeout` constants in a single `const ( )` block, following the repo's existing `defaultPromoteEvery` / `defaultReQueryEvery` / `defaultReQueryWait` convention from `hostmap.go`. Plumbs them into the `http.Server` literal. Adds a table-driven test that pins each field to its constant, plus an invariant test that guards `ReadTimeout >= ReadHeaderTimeout` so a future careless edit can't silently degrade slowloris defense into a generic i/o-timeout.

Defaults:

| Field | Default | Reasoning |
|---|---|---|
| `ReadHeaderTimeout` | 10s | Slowloris defense. Real clients send all headers in <100ms; 10s is loose enough to survive bad networks, tight enough to deny attackers. |
| `ReadTimeout` | 15s | Bounds the entire request read. Prom scrapes are body-less GETs so this rarely matters, but it adds a cheap second layer for slowpost-style attacks. |
| `WriteTimeout` | 30s | A large registry (10k metrics × keep-alive) can take seconds to serialize. 30s gives headroom well beyond any plausible scrape size. |
| `IdleTimeout` | 120s | Default Prometheus scrape interval is ~15s; keep-alive across multiple scrapes saves TCP/TLS setup. 120s comfortably spans 8 scrapes. |

**Commit 2 — `Make Prometheus listener timeouts configurable`**

Five new optional `stats.*` yaml keys override the defaults. The whole `stats:` section is already reload-aware, so the new keys are picked up on SIGHUP without restart:

```yaml
stats:
  type: prometheus
  listen: 127.0.0.1:8080
  path: /metrics
  #read_header_timeout: 10s
  #read_timeout: 15s
  #write_timeout: 30s
  #idle_timeout: 120s
  #handler_timeout: 30s    # 0 disables the TimeoutHandler wrap (commit 3)
```

`loadStatsConfig` reads each key via `c.GetDuration` with the default constant as the fallback. Validation rejects any negative duration with an error naming the offending key. Zero is allowed (operator explicit opt-out); the example config documents that `read_header_timeout: 0` defeats slowloris defense.

Two new table-driven tests:
- `TestLoadStatsConfig_PromTimeouts_Overrides` — 6 rows covering each key individually plus all-five-overridden-together (the latter catches plumbing mistakes where one key's value lands in another field).
- `TestLoadStatsConfig_PromTimeouts_NegativeRejected` — 5 rows asserting `loadStatsConfig` errors AND the error message names the key so an operator can grep their config for it.

**Commit 3 — `Wrap Prometheus handler with http.TimeoutHandler for clean 503`**

The existing `WriteTimeout` does its job by abruptly closing the TCP connection when the server exceeds its budget — the scraper sees `io.UnexpectedEOF` with no body and no status, which is hostile to triage. `http.TimeoutHandler` observes the request context and substitutes a 503 response with a configurable body once the per-request budget elapses, giving the scraper something to log and the operator something to grep for.

A small `wrapPromHandler` helper conditionally applies the wrap when `handler_timeout > 0` and returns the inner handler unchanged otherwise. The wrap is the Layer-3 expression of the Go context model: the inner handler's request context is cancelled by the middleware when the budget elapses, so any handler that honors `r.Context()` aborts cleanly. `promhttp.HandlerFor` already honors it for its gatherer iteration.

Two integration tests cover the wrap, both gated by `testing.Short` so the `-short` CI matrix isn't slowed:
- `TestWrapPromHandler_FiresOn503` — slow handler + `httptest.NewServer` + `handler_timeout=50ms`; asserts 503 + canned body + slow handler's body did NOT leak through.
- `TestStatsServer_Slowloris_ReadHeaderTimeout` — the headline security test. Real listener with `read_header_timeout: 200ms`, raw TCP, partial header line, asserts the server closes the connection within 1s.

Two unit tests cover the cheap path:
- `TestWrapPromHandler_ZeroTimeoutPassesThrough` — fast assertion via `reflect.ValueOf().Pointer()` that the wrap conditional is real (handler value identity preserved for `handler_timeout = 0` and negative).
- `TestWrapPromHandler_NoWrap_ResponseFlowsThrough` — end-to-end via `httptest.NewServer` that the real response body reaches the client when the wrap is disabled.

### How to run the new tests locally

```
# Fast - what -short CI runs (skips the two integration tests):
go test -count=1 -short -run 'TestStatsServer_buildRuntime|TestLoadStatsConfig_PromTimeouts|TestStatsTimeoutDefaults|TestWrapPromHandler' .

# Full - runs everything including the two ~200ms integration tests:
go test -count=1 -run 'TestStatsServer_buildRuntime|TestLoadStatsConfig_PromTimeouts|TestStatsTimeoutDefaults|TestWrapPromHandler|TestStatsServer_Slowloris' .
```

### Why the values we picked

The four `http.Server` defaults are sized for typical Prometheus deployments. None are tight enough to break a real scraper on a slow network; none are loose enough to be a useful slowloris vector. The 30s `handler_timeout` matches `WriteTimeout` so the 503 path fires before the abrupt-close path.

Every value is operator-overridable. We considered adding a hard floor on `handler_timeout` (rejecting e.g. <100ms as "probably a typo") but decided against it: nebula's existing validation rejects only structurally-invalid values, and adding strictness only here would be inconsistent with the rest of the codebase. An operator who configures `handler_timeout: 1ms` and gets nothing but 503s will notice via their alerting and fix the typo.

### Performance impact on tests

The two integration tests in commit 3 add ~270ms to a full `go test ./...` run of the nebula package (392ms vs the prior 112ms). Both are gated by `testing.Short` so `go test -short ./...` is unaffected (~100ms). If maintainers prefer to gate them behind a build tag instead, the change is trivial.

### Backward compatibility

No CLI flag changes. No public API changes. The five new yaml keys are optional and default to the new constants. Existing configs continue to work unchanged. The behavior change is that the server now rejects slow-client connection patterns it previously held open; legitimate scrapers will not notice.

