### PR TITLE
Drop dead bounds-check comparisons in cert and metrics paths

### DIFF
--- a/cert/crypto.go
+++ b/cert/crypto.go
@@ -227,17 +227,15 @@ func UnmarshalNebulaEncryptedData(b []byte) (*NebulaEncryptedData, error) {
 }
 
 func unmarshalArgon2Parameters(params *RawNebulaArgon2Parameters) (*Argon2Parameters, error) {
-	if params.Version < math.MinInt32 || params.Version > math.MaxInt32 {
-		return nil, fmt.Errorf("Argon2Parameters Version must be at least %d and no more than %d", math.MinInt32, math.MaxInt32)
+	if params.Memory == 0 {
+		return nil, fmt.Errorf("Argon2Parameters Memory must be greater than 0")
 	}
-	if params.Memory <= 0 || params.Memory > math.MaxUint32 {
-		return nil, fmt.Errorf("Argon2Parameters Memory must be be greater than 0 and no more than %d KiB", uint32(math.MaxUint32))
+	// Parallelism is uint32 in the proto but uint8 in the struct cast below.
+	if params.Parallelism == 0 || params.Parallelism > math.MaxUint8 {
+		return nil, fmt.Errorf("Argon2Parameters Parallelism must be greater than 0 and no more than %d", math.MaxUint8)
 	}
-	if params.Parallelism <= 0 || params.Parallelism > math.MaxUint8 {
-		return nil, fmt.Errorf("Argon2Parameters Parallelism must be be greater than 0 and no more than %d", math.MaxUint8)
-	}
-	if params.Iterations <= 0 || params.Iterations > math.MaxUint32 {
-		return nil, fmt.Errorf("-argon-iterations must be be greater than 0 and no more than %d", uint32(math.MaxUint32))
+	if params.Iterations == 0 {
+		return nil, fmt.Errorf("-argon-iterations must be greater than 0")
 	}
 
 	return &Argon2Parameters{

--- a/cert/crypto_test.go
+++ b/cert/crypto_test.go
@@ -1,6 +1,7 @@
 package cert
 
 import (
+	"encoding/pem"
 	"math"
 	"strings"
 	"testing"
@@ -8,23 +9,32 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/argon2"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestNewArgon2Parameters(t *testing.T) {
-	p := NewArgon2Parameters(64*1024, 4, 3)
-	assert.Equal(t, &Argon2Parameters{
-		version:     argon2.Version,
-		Memory:      64 * 1024,
-		Parallelism: 4,
-		Iterations:  3,
-	}, p)
-	p = NewArgon2Parameters(2*1024*1024, 2, 1)
-	assert.Equal(t, &Argon2Parameters{
-		version:     argon2.Version,
-		Memory:      2 * 1024 * 1024,
-		Parallelism: 2,
-		Iterations:  1,
-	}, p)
+	tests := []struct {
+		name        string
+		memory      uint32
+		parallelism uint8
+		iterations  uint32
+	}{
+		{"typical / RFC-9106 second-recommended", 64 * 1024, 4, 3},
+		{"larger / RFC-9106 first-recommended", 2 * 1024 * 1024, 2, 1},
+		{"zero values pass through (NewArgon2Parameters does not validate)", 0, 0, 0},
+		{"max-of-each-type passes through", math.MaxUint32, math.MaxUint8, math.MaxUint32},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NewArgon2Parameters(tc.memory, tc.parallelism, tc.iterations)
+			assert.Equal(t, &Argon2Parameters{
+				version:     argon2.Version,
+				Memory:      tc.memory,
+				Parallelism: tc.parallelism,
+				Iterations:  tc.iterations,
+			}, got)
+		})
+	}
 }
 
 func TestDecryptAndUnmarshalSigningPrivateKey(t *testing.T) {
@@ -95,25 +105,6 @@ qrlJ69wer3ZUHFXA
 	assert.Equal(t, []byte{}, rest)
 }
 
-func TestEncryptAndMarshalSigningPrivateKey(t *testing.T) {
-	// Having proved that decryption works correctly above, we can test the
-	// encryption function produces a value which can be decrypted
-	passphrase := []byte("passphrase")
-	bytes := []byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
-	kdfParams := NewArgon2Parameters(64*1024, 4, 3)
-	key, err := EncryptAndMarshalSigningPrivateKey(Curve_CURVE25519, bytes, passphrase, kdfParams)
-	require.NoError(t, err)
-
-	// Verify the "key" can be decrypted successfully
-	curve, k, rest, err := DecryptAndUnmarshalSigningPrivateKey(passphrase, key)
-	assert.Len(t, k, 64)
-	assert.Equal(t, Curve_CURVE25519, curve)
-	assert.Equal(t, []byte{}, rest)
-	require.NoError(t, err)
-
-	// EncryptAndMarshalEd25519PrivateKey does not create any errors itself
-}
-
 func TestUnmarshalArgon2Parameters_Validation(t *testing.T) {
 	salt := []byte{1, 2, 3, 4}
 
@@ -121,7 +112,7 @@ func TestUnmarshalArgon2Parameters_Validation(t *testing.T) {
 		name             string
 		params           *RawNebulaArgon2Parameters
 		wantErr          bool
-		wantErrSubstring string
+		wantErrSubstring string // present iff wantErr; lowercase substring
 		wantOut          *Argon2Parameters
 	}{
 		{
@@ -214,6 +205,447 @@ func TestUnmarshalArgon2Parameters_Validation(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.Equal(t, tc.wantOut, got)
+		})
+	}
+}
+
+func TestEncryptAndMarshalSigningPrivateKey(t *testing.T) {
+	passphrase := []byte("passphrase")
+	ed25519Bytes := []byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA") // 64 bytes
+	p256Bytes := []byte("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB")                                    // 32 bytes
+	kdfParams := NewArgon2Parameters(64*1024, 4, 3)
+
+	tests := []struct {
+		name         string
+		curve        Curve
+		plaintext    []byte
+		wantBanner   string
+		wantErr      bool
+		wantErrPart  string // lowercase substring expected in the error
+		wantKeyBytes int    // expected len(k) after a round-trip decrypt
+	}{
+		{
+			name:         "Ed25519 happy round-trip",
+			curve:        Curve_CURVE25519,
+			plaintext:    ed25519Bytes,
+			wantBanner:   EncryptedEd25519PrivateKeyBanner,
+			wantKeyBytes: 64,
+		},
+		{
+			name:         "P256 happy round-trip",
+			curve:        Curve_P256,
+			plaintext:    p256Bytes,
+			wantBanner:   EncryptedECDSAP256PrivateKeyBanner,
+			wantKeyBytes: 32,
+		},
+		{
+			name:        "invalid curve is rejected",
+			curve:       Curve(99),
+			plaintext:   ed25519Bytes,
+			wantErr:     true,
+			wantErrPart: "invalid curve",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			key, err := EncryptAndMarshalSigningPrivateKey(tc.curve, tc.plaintext, passphrase, kdfParams)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, strings.ToLower(err.Error()), tc.wantErrPart)
+				require.Nil(t, key)
+				return
+			}
+			require.NoError(t, err)
+			require.Contains(t, string(key), tc.wantBanner,
+				"emitted PEM must use the curve-specific banner")
+
+			gotCurve, k, rest, err := DecryptAndUnmarshalSigningPrivateKey(passphrase, key)
+			require.NoError(t, err)
+			assert.Len(t, k, tc.wantKeyBytes)
+			assert.Equal(t, tc.curve, gotCurve)
+			assert.Equal(t, []byte{}, rest)
+		})
+	}
+}
+
+func TestUnmarshalNebulaEncryptedData_RejectsBadInput(t *testing.T) {
+	validArgon := &RawNebulaArgon2Parameters{
+		Version: 0x13, Memory: 65536, Parallelism: 4, Iterations: 3, Salt: []byte{1, 2, 3, 4},
+	}
+
+	missingMetadata, err := proto.Marshal(&RawNebulaEncryptedData{
+		Ciphertext: []byte{1, 2, 3},
+	})
+	require.NoError(t, err)
+	missingParams, err := proto.Marshal(&RawNebulaEncryptedData{
+		EncryptionMetadata: &RawNebulaEncryptionMetadata{EncryptionAlgorithm: "AES-256-GCM"},
+		Ciphertext:         []byte{1, 2, 3},
+	})
+	require.NoError(t, err)
+	valid, err := proto.Marshal(&RawNebulaEncryptedData{
+		EncryptionMetadata: &RawNebulaEncryptionMetadata{
+			EncryptionAlgorithm: "AES-256-GCM",
+			Argon2Parameters:    validArgon,
+		},
+		Ciphertext: []byte{1, 2, 3},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		in          []byte
+		wantErr     bool
+		wantErrPart string
+	}{
+		{
+			name:        "empty bytes rejected",
+			in:          nil,
+			wantErr:     true,
+			wantErrPart: "nil byte array",
+		},
+		{
+			name:        "garbage non-proto bytes rejected",
+			in:          []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			wantErr:     true,
+			wantErrPart: "", // proto.Unmarshal error wording is libversion-dependent; existence suffices
+		},
+		{
+			name:        "missing EncryptionMetadata rejected",
+			in:          missingMetadata,
+			wantErr:     true,
+			wantErrPart: "encryptionmetadata was nil",
+		},
+		{
+			name:        "missing Argon2Parameters rejected",
+			in:          missingParams,
+			wantErr:     true,
+			wantErrPart: "argon2parameters was nil",
+		},
+		{
+			name: "well-formed input accepted and fields forwarded",
+			in:   valid,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := UnmarshalNebulaEncryptedData(tc.in)
+			if tc.wantErr {
+				require.Error(t, err)
+				if tc.wantErrPart != "" {
+					require.Contains(t, strings.ToLower(err.Error()), tc.wantErrPart)
+				}
+				require.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, "AES-256-GCM", got.EncryptionMetadata.EncryptionAlgorithm)
+			assert.Equal(t, uint32(65536), got.EncryptionMetadata.Argon2Parameters.Memory)
+			assert.Equal(t, []byte{1, 2, 3}, got.Ciphertext)
+		})
+	}
+}
+
+func TestSplitNonceCiphertext(t *testing.T) {
+	const nonceSize = 12
+
+	tests := []struct {
+		name         string
+		blob         []byte
+		nonceSize    int
+		wantErr      bool
+		wantNonceLen int
+		wantCipher   []byte
+	}{
+		{
+			name:         "blob = nonce + 1 byte ciphertext: smallest valid input",
+			blob:         []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0xCC},
+			nonceSize:    nonceSize,
+			wantNonceLen: nonceSize,
+			wantCipher:   []byte{0xCC},
+		},
+		{
+			name:         "blob = nonce + many bytes ciphertext: typical case",
+			blob:         append(make([]byte, nonceSize), []byte("ciphertext-payload-bytes")...),
+			nonceSize:    nonceSize,
+			wantNonceLen: nonceSize,
+			wantCipher:   []byte("ciphertext-payload-bytes"),
+		},
+		{
+			name:      "blob exactly nonce length: rejected (no room for ciphertext)",
+			blob:      make([]byte, nonceSize),
+			nonceSize: nonceSize,
+			wantErr:   true,
+		},
+		{
+			name:      "blob shorter than nonce: rejected",
+			blob:      make([]byte, nonceSize-1),
+			nonceSize: nonceSize,
+			wantErr:   true,
+		},
+		{
+			name:      "blob empty: rejected",
+			blob:      []byte{},
+			nonceSize: nonceSize,
+			wantErr:   true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			nonce, ciphertext, err := splitNonceCiphertext(tc.blob, tc.nonceSize)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Nil(t, nonce)
+				assert.Nil(t, ciphertext)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, nonce, tc.wantNonceLen)
+			assert.Equal(t, tc.wantCipher, ciphertext)
+		})
+	}
+}
+
+func TestDeriveKey_Validation(t *testing.T) {
+	const keySize = uint32(32)
+	const minSaltBytes = 16
+	goodSalt := make([]byte, minSaltBytes)
+	for i := range goodSalt {
+		goodSalt[i] = byte(i)
+	}
+
+	tests := []struct {
+		name        string
+		params      *Argon2Parameters
+		wantErr     bool
+		wantErrPart string
+	}{
+		{
+			name: "incompatible argon version is rejected",
+			params: &Argon2Parameters{
+				version: argon2.Version - 1, Memory: 1, Parallelism: 1, Iterations: 1, salt: goodSalt,
+			},
+			wantErr:     true,
+			wantErrPart: "incompatible argon2 version",
+		},
+		{
+			name: "nil salt is rejected",
+			params: &Argon2Parameters{
+				version: argon2.Version, Memory: 1, Parallelism: 1, Iterations: 1, salt: nil,
+			},
+			wantErr:     true,
+			wantErrPart: "salt must be set",
+		},
+		{
+			name: "salt below 128 bits is rejected",
+			params: &Argon2Parameters{
+				version: argon2.Version, Memory: 1, Parallelism: 1, Iterations: 1, salt: make([]byte, minSaltBytes-1),
+			},
+			wantErr:     true,
+			wantErrPart: "at least 128",
+		},
+		{
+			name: "happy path returns a key of the requested size",
+			params: &Argon2Parameters{
+				version: argon2.Version, Memory: 1, Parallelism: 1, Iterations: 1, salt: goodSalt,
+			},
+		},
+		{
+			name: "boundary: exactly 128-bit salt is accepted",
+			params: &Argon2Parameters{
+				version: argon2.Version, Memory: 1, Parallelism: 1, Iterations: 1, salt: make([]byte, minSaltBytes),
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := deriveKey([]byte("passphrase"), keySize, tc.params)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, strings.ToLower(err.Error()), tc.wantErrPart,
+					"error message must name the offending field so operators can find it")
+				require.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Len(t, got, int(keySize),
+				"happy path must return a key of exactly keySize bytes")
+		})
+	}
+}
+
+func TestAes256Decrypt_RejectsBadInput(t *testing.T) {
+	passphrase := []byte("passphrase")
+	plaintext := []byte("attack at dawn")
+	kdfParams := NewArgon2Parameters(1, 1, 1)
+
+	// Encrypt once so we have a known-valid blob to corrupt.
+	validBlob, err := aes256Encrypt(passphrase, kdfParams, plaintext)
+	require.NoError(t, err)
+	require.NotEmpty(t, validBlob)
+
+	// gcm.NonceSize() returns 12 bytes for AES-GCM. The blob is
+	// nonce || ciphertext || tag, so total len > 12.
+	const gcmNonceSize = 12
+	require.Greater(t, len(validBlob), gcmNonceSize)
+
+	tamperedCiphertext := append([]byte(nil), validBlob...)
+	tamperedCiphertext[gcmNonceSize+1] ^= 0x01 // flip a bit in the ciphertext
+
+	tamperedNonce := append([]byte(nil), validBlob...)
+	tamperedNonce[0] ^= 0x01 // flip a bit in the nonce
+
+	tests := []struct {
+		name        string
+		blob        []byte
+		passphrase  []byte
+		wantErr     bool
+		wantErrPart string
+	}{
+		{
+			name:        "empty blob rejected (splitNonceCiphertext)",
+			blob:        nil,
+			passphrase:  passphrase,
+			wantErr:     true,
+			wantErrPart: "shorter than nonce length",
+		},
+		{
+			name:        "blob shorter than nonce rejected",
+			blob:        []byte{0, 1, 2, 3, 4, 5},
+			passphrase:  passphrase,
+			wantErr:     true,
+			wantErrPart: "shorter than nonce length",
+		},
+		{
+			name:        "blob equal to nonce length rejected (no room for ciphertext)",
+			blob:        make([]byte, gcmNonceSize),
+			passphrase:  passphrase,
+			wantErr:     true,
+			wantErrPart: "shorter than nonce length",
+		},
+		{
+			name:        "tampered ciphertext rejected by GCM auth",
+			blob:        tamperedCiphertext,
+			passphrase:  passphrase,
+			wantErr:     true,
+			wantErrPart: "invalid passphrase or corrupt private key",
+		},
+		{
+			name:        "tampered nonce rejected by GCM auth",
+			blob:        tamperedNonce,
+			passphrase:  passphrase,
+			wantErr:     true,
+			wantErrPart: "invalid passphrase or corrupt private key",
+		},
+		{
+			name:        "wrong passphrase rejected by GCM auth",
+			blob:        validBlob,
+			passphrase:  []byte("wrong"),
+			wantErr:     true,
+			wantErrPart: "invalid passphrase or corrupt private key",
+		},
+		{
+			name:       "round-trip with correct passphrase recovers plaintext",
+			blob:       validBlob,
+			passphrase: passphrase,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Each row gets a fresh params object so any salt mutation
+			// inside aes256DeriveKey on the wrong-passphrase row does not
+			// leak into other rows. Same minimal params as the outer block.
+			rowParams := NewArgon2Parameters(1, 1, 1)
+			rowParams.salt = kdfParams.salt
+			got, err := aes256Decrypt(tc.passphrase, rowParams, tc.blob)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, strings.ToLower(err.Error()), strings.ToLower(tc.wantErrPart))
+				require.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, plaintext, got, "round-trip must recover the original plaintext")
+		})
+	}
+}
+
+func TestDecryptAndUnmarshalSigningPrivateKey_AlgorithmAndCurveCases(t *testing.T) {
+	passphrase := []byte("passphrase")
+
+	// Build the salt + Argon2 params we'll embed in the proto.
+	kdfParams := NewArgon2Parameters(1, 1, 1)
+	kdfParams.salt = make([]byte, 32)
+	for i := range kdfParams.salt {
+		kdfParams.salt[i] = byte(i)
+	}
+	rawArgon := &RawNebulaArgon2Parameters{
+		Version:     kdfParams.version,
+		Memory:      kdfParams.Memory,
+		Parallelism: uint32(kdfParams.Parallelism),
+		Iterations:  kdfParams.Iterations,
+		Salt:        kdfParams.salt,
+	}
+
+	// Encrypt a 31-byte payload with the P256 banner: aes256Decrypt
+	// will succeed (the ciphertext is valid AES-GCM), but the curve-
+	// specific length check will fail because P256 expects 32 bytes.
+	shortP256Plain := []byte("BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB") // 31 bytes
+	shortP256Cipher, err := aes256Encrypt(passphrase, kdfParams, shortP256Plain)
+	require.NoError(t, err)
+	shortP256Proto, err := proto.Marshal(&RawNebulaEncryptedData{
+		EncryptionMetadata: &RawNebulaEncryptionMetadata{
+			EncryptionAlgorithm: "AES-256-GCM",
+			Argon2Parameters:    rawArgon,
+		},
+		Ciphertext: shortP256Cipher,
+	})
+	require.NoError(t, err)
+	shortP256PEM := pem.EncodeToMemory(&pem.Block{
+		Type: EncryptedECDSAP256PrivateKeyBanner, Bytes: shortP256Proto,
+	})
+
+	// Build a valid-looking proto but with an algorithm we don't
+	// support. Decrypt should hit the algorithm-switch default branch.
+	unsupportedProto, err := proto.Marshal(&RawNebulaEncryptedData{
+		EncryptionMetadata: &RawNebulaEncryptionMetadata{
+			EncryptionAlgorithm: "DES-EDE-CBC", // arbitrary unsupported value
+			Argon2Parameters:    rawArgon,
+		},
+		Ciphertext: []byte{1, 2, 3},
+	})
+	require.NoError(t, err)
+	unsupportedPEM := pem.EncodeToMemory(&pem.Block{
+		Type: EncryptedEd25519PrivateKeyBanner, Bytes: unsupportedProto,
+	})
+
+	tests := []struct {
+		name        string
+		in          []byte
+		wantCurve   Curve
+		wantErrPart string
+	}{
+		{
+			name:        "unsupported EncryptionAlgorithm is rejected by the default switch branch",
+			in:          unsupportedPEM,
+			wantCurve:   Curve_CURVE25519,
+			wantErrPart: "unsupported encryption algorithm",
+		},
+		{
+			name:        "P256 banner with wrong-length plaintext is rejected by the curve length check",
+			in:          shortP256PEM,
+			wantCurve:   Curve_P256,
+			wantErrPart: "key was not 32 bytes",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			curve, k, rest, err := DecryptAndUnmarshalSigningPrivateKey(passphrase, tc.in)
+			require.Error(t, err)
+			require.Contains(t, strings.ToLower(err.Error()), tc.wantErrPart)
+			assert.Equal(t, tc.wantCurve, curve, "curve must still be set for diagnostics")
+			assert.Nil(t, k, "no key bytes returned on the error path")
+			assert.Equal(t, []byte{}, rest, "rest must be empty because the single PEM block was consumed")
 		})
 	}
 }

--- a/cert/crypto_test.go
+++ b/cert/crypto_test.go
@@ -1,6 +1,8 @@
 package cert
 
 import (
+	"math"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -110,4 +112,108 @@ func TestEncryptAndMarshalSigningPrivateKey(t *testing.T) {
 	require.NoError(t, err)
 
 	// EncryptAndMarshalEd25519PrivateKey does not create any errors itself
+}
+
+func TestUnmarshalArgon2Parameters_Validation(t *testing.T) {
+	salt := []byte{1, 2, 3, 4}
+
+	tests := []struct {
+		name             string
+		params           *RawNebulaArgon2Parameters
+		wantErr          bool
+		wantErrSubstring string
+		wantOut          *Argon2Parameters
+	}{
+		{
+			name: "memory == 0 is rejected",
+			params: &RawNebulaArgon2Parameters{
+				Version: 0x13, Memory: 0, Parallelism: 4, Iterations: 3, Salt: salt,
+			},
+			wantErr:          true,
+			wantErrSubstring: "memory",
+		},
+		{
+			name: "parallelism == 0 is rejected",
+			params: &RawNebulaArgon2Parameters{
+				Version: 0x13, Memory: 65536, Parallelism: 0, Iterations: 3, Salt: salt,
+			},
+			wantErr:          true,
+			wantErrSubstring: "parallelism",
+		},
+		{
+			name: "parallelism > MaxUint8 is rejected (proto field is uint32, struct field is uint8)",
+			params: &RawNebulaArgon2Parameters{
+				Version: 0x13, Memory: 65536, Parallelism: 256, Iterations: 3, Salt: salt,
+			},
+			wantErr:          true,
+			wantErrSubstring: "parallelism",
+		},
+		{
+			name: "parallelism = 1000 is rejected (mid-range silent-truncation hazard if bounds check were weakened)",
+			params: &RawNebulaArgon2Parameters{
+				Version: 0x13, Memory: 65536, Parallelism: 1000, Iterations: 3, Salt: salt,
+			},
+			wantErr:          true,
+			wantErrSubstring: "parallelism",
+		},
+		{
+			name: "parallelism = MaxUint32 is rejected (extreme overflow case)",
+			params: &RawNebulaArgon2Parameters{
+				Version: 0x13, Memory: 65536, Parallelism: math.MaxUint32, Iterations: 3, Salt: salt,
+			},
+			wantErr:          true,
+			wantErrSubstring: "parallelism",
+		},
+		{
+			name: "iterations == 0 is rejected",
+			params: &RawNebulaArgon2Parameters{
+				Version: 0x13, Memory: 65536, Parallelism: 4, Iterations: 0, Salt: salt,
+			},
+			wantErr:          true,
+			wantErrSubstring: "iterations",
+		},
+		{
+			name: "valid params forward every field through to the Argon2Parameters struct",
+			params: &RawNebulaArgon2Parameters{
+				Version: 0x13, Memory: 65536, Parallelism: 4, Iterations: 3, Salt: salt,
+			},
+			wantErr: false,
+			wantOut: &Argon2Parameters{
+				version:     0x13,
+				Memory:      65536,
+				Parallelism: 4,
+				Iterations:  3,
+				salt:        salt,
+			},
+		},
+		{
+			name: "max-uint8 parallelism is accepted (boundary just below the rejection threshold)",
+			params: &RawNebulaArgon2Parameters{
+				Version: 0x13, Memory: 65536, Parallelism: 255, Iterations: 3, Salt: salt,
+			},
+			wantErr: false,
+			wantOut: &Argon2Parameters{
+				version:     0x13,
+				Memory:      65536,
+				Parallelism: 255,
+				Iterations:  3,
+				salt:        salt,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := unmarshalArgon2Parameters(tc.params)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, strings.ToLower(err.Error()), tc.wantErrSubstring,
+					"error message must name the offending field so operators can find it")
+				require.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantOut, got)
+		})
+	}
 }

--- a/cmd/nebula-cert/ca.go
+++ b/cmd/nebula-cert/ca.go
@@ -68,14 +68,15 @@ func newCaFlags() *caFlags {
 }
 
 func parseArgonParameters(memory uint, parallelism uint, iterations uint) (*cert.Argon2Parameters, error) {
-	if memory <= 0 || memory > math.MaxUint32 {
-		return nil, newHelpErrorf("-argon-memory must be be greater than 0 and no more than %d KiB", uint32(math.MaxUint32))
+	if memory == 0 || memory > math.MaxUint32 {
+		return nil, newHelpErrorf("-argon-memory must be greater than 0 and no more than %d KiB", uint32(math.MaxUint32))
 	}
-	if parallelism <= 0 || parallelism > math.MaxUint8 {
-		return nil, newHelpErrorf("-argon-parallelism must be be greater than 0 and no more than %d", math.MaxUint8)
+	// Parallelism is uint here but uint8 in the Argon2Parameters struct cast below.
+	if parallelism == 0 || parallelism > math.MaxUint8 {
+		return nil, newHelpErrorf("-argon-parallelism must be greater than 0 and no more than %d", math.MaxUint8)
 	}
-	if iterations <= 0 || iterations > math.MaxUint32 {
-		return nil, newHelpErrorf("-argon-iterations must be be greater than 0 and no more than %d", uint32(math.MaxUint32))
+	if iterations == 0 || iterations > math.MaxUint32 {
+		return nil, newHelpErrorf("-argon-iterations must be greater than 0 and no more than %d", uint32(math.MaxUint32))
 	}
 
 	return cert.NewArgon2Parameters(uint32(memory), uint8(parallelism), uint32(iterations)), nil

--- a/cmd/nebula-cert/ca_test.go
+++ b/cmd/nebula-cert/ca_test.go
@@ -312,3 +312,99 @@ func (pr *trackingPasswordReader) ReadPassword() ([]byte, error) {
 	pr.calls++
 	return []byte(""), nil
 }
+
+func TestParseArgonParameters_Validation(t *testing.T) {
+	tests := []struct {
+		name             string
+		memory           uint
+		parallelism      uint
+		iterations       uint
+		wantErr          bool
+		wantErrSubstring string
+		wantOut          struct {
+			memory      uint32
+			parallelism uint8
+			iterations  uint32
+		}
+	}{
+		{
+			name:             "memory == 0 is rejected",
+			memory:           0,
+			parallelism:      4,
+			iterations:       3,
+			wantErr:          true,
+			wantErrSubstring: "-argon-memory",
+		},
+		{
+			name:             "parallelism == 0 is rejected",
+			memory:           65536,
+			parallelism:      0,
+			iterations:       3,
+			wantErr:          true,
+			wantErrSubstring: "-argon-parallelism",
+		},
+		{
+			name:             "parallelism > MaxUint8 is rejected (cast on next line would truncate)",
+			memory:           65536,
+			parallelism:      256,
+			iterations:       3,
+			wantErr:          true,
+			wantErrSubstring: "-argon-parallelism",
+		},
+		{
+			name:             "parallelism = 1000 is rejected (mid-range silent-truncation hazard)",
+			memory:           65536,
+			parallelism:      1000,
+			iterations:       3,
+			wantErr:          true,
+			wantErrSubstring: "-argon-parallelism",
+		},
+		{
+			name:             "iterations == 0 is rejected",
+			memory:           65536,
+			parallelism:      4,
+			iterations:       0,
+			wantErr:          true,
+			wantErrSubstring: "-argon-iterations",
+		},
+		{
+			name:        "valid params construct an Argon2Parameters",
+			memory:      65536,
+			parallelism: 4,
+			iterations:  3,
+			wantOut: struct {
+				memory      uint32
+				parallelism uint8
+				iterations  uint32
+			}{65536, 4, 3},
+		},
+		{
+			name:        "max-uint8 parallelism is accepted (boundary just below the rejection threshold)",
+			memory:      65536,
+			parallelism: 255,
+			iterations:  3,
+			wantOut: struct {
+				memory      uint32
+				parallelism uint8
+				iterations  uint32
+			}{65536, 255, 3},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseArgonParameters(tc.memory, tc.parallelism, tc.iterations)
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantErrSubstring,
+					"error message must name the offending flag so the user can find it")
+				require.Nil(t, got)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			assert.Equal(t, tc.wantOut.memory, got.Memory)
+			assert.Equal(t, tc.wantOut.parallelism, got.Parallelism)
+			assert.Equal(t, tc.wantOut.iterations, got.Iterations)
+		})
+	}
+}

--- a/message_metrics.go
+++ b/message_metrics.go
@@ -19,7 +19,7 @@ type MessageMetrics struct {
 
 func (m *MessageMetrics) Rx(t header.MessageType, s header.MessageSubType, i int64) {
 	if m != nil {
-		if t >= 0 && int(t) < len(m.rx) && s >= 0 && int(s) < len(m.rx[t]) {
+		if int(t) < len(m.rx) && int(s) < len(m.rx[t]) {
 			m.rx[t][s].Inc(i)
 		} else if m.rxUnknown != nil {
 			m.rxUnknown.Inc(i)
@@ -28,7 +28,7 @@ func (m *MessageMetrics) Rx(t header.MessageType, s header.MessageSubType, i int
 }
 func (m *MessageMetrics) Tx(t header.MessageType, s header.MessageSubType, i int64) {
 	if m != nil {
-		if t >= 0 && int(t) < len(m.tx) && s >= 0 && int(s) < len(m.tx[t]) {
+		if int(t) < len(m.tx) && int(s) < len(m.tx[t]) {
 			m.tx[t][s].Inc(i)
 		} else if m.txUnknown != nil {
 			m.txUnknown.Inc(i)

--- a/message_metrics_test.go
+++ b/message_metrics_test.go
@@ -1,0 +1,245 @@
+package nebula
+
+import (
+	"testing"
+
+	"github.com/rcrowley/go-metrics"
+	"github.com/slackhq/nebula/header"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rxTxFixture builds a MessageMetrics with a known-shape rx/tx grid plus
+// the unknown/invalid sentinel counters wired up to fresh registry slots
+// so each test gets isolated counter values.
+//
+// Shape (len(rx) == len(tx) == 6):
+//
+//	[0] -> 1 sub-counter   (Rx[0][0])
+//	[1] -> nil             (no slots; any subtype is out of range)
+//	[2] -> 1 sub-counter   (Rx[2][0])
+//	[3] -> 1 sub-counter
+//	[4] -> 2 sub-counters  (Rx[4][0], Rx[4][1])
+//	[5] -> 1 sub-counter
+func rxTxFixture(t testing.TB, suffix string) *MessageMetrics {
+	t.Helper()
+	gen := func(dir string) [][]metrics.Counter {
+		return [][]metrics.Counter{
+			{metrics.GetOrRegisterCounter(dir+".0."+suffix, nil)},
+			nil,
+			{metrics.GetOrRegisterCounter(dir+".2."+suffix, nil)},
+			{metrics.GetOrRegisterCounter(dir+".3."+suffix, nil)},
+			{
+				metrics.GetOrRegisterCounter(dir+".4.0."+suffix, nil),
+				metrics.GetOrRegisterCounter(dir+".4.1."+suffix, nil),
+			},
+			{metrics.GetOrRegisterCounter(dir+".5."+suffix, nil)},
+		}
+	}
+	return &MessageMetrics{
+		rx:        gen("rx"),
+		tx:        gen("tx"),
+		rxUnknown: metrics.GetOrRegisterCounter("rxUnknown."+suffix, nil),
+		txUnknown: metrics.GetOrRegisterCounter("txUnknown."+suffix, nil),
+		rxInvalid: metrics.GetOrRegisterCounter("rxInvalid."+suffix, nil),
+	}
+}
+
+func TestMessageMetrics_Rx(t *testing.T) {
+	tests := []struct {
+		name    string
+		t       header.MessageType
+		s       header.MessageSubType
+		inc     int64
+		wantHit string // "specific" | "unknown"
+	}{
+		{"valid (t=0, s=0) increments rx[0][0]", 0, 0, 1, "specific"},
+		{"valid (t=4, s=1) increments rx[4][1] - distinct sub counter", 4, 1, 7, "specific"},
+		{"valid (t=5, s=0) at the last populated type slot", 5, 0, 1, "specific"},
+		{"subtype out of range for non-nil slot routes to unknown", 0, 1, 3, "unknown"},
+		{"subtype out of range for nil slot routes to unknown", 1, 0, 3, "unknown"},
+		{"type past end of rx slice routes to unknown", 6, 0, 5, "unknown"},
+		{"both fields way out of range route to unknown", 255, 255, 9, "unknown"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := rxTxFixture(t, t.Name())
+
+			// Snapshot the relevant counter; we'll compute delta after the call.
+			var watched metrics.Counter
+			switch {
+			case tc.wantHit == "specific" && int(tc.t) < len(m.rx) && int(tc.s) < len(m.rx[tc.t]):
+				watched = m.rx[tc.t][tc.s]
+			default:
+				watched = m.rxUnknown
+			}
+			before := watched.Count()
+
+			m.Rx(tc.t, tc.s, tc.inc)
+
+			assert.Equal(t, tc.inc, watched.Count()-before,
+				"the %q path must increment by exactly the requested delta", tc.wantHit)
+		})
+	}
+}
+
+func TestMessageMetrics_Tx(t *testing.T) {
+	tests := []struct {
+		name    string
+		t       header.MessageType
+		s       header.MessageSubType
+		inc     int64
+		wantHit string
+	}{
+		{"valid (t=0, s=0) increments tx[0][0]", 0, 0, 1, "specific"},
+		{"valid (t=4, s=1) increments tx[4][1] - distinct sub counter", 4, 1, 11, "specific"},
+		{"valid (t=5, s=0) at the last populated type slot", 5, 0, 1, "specific"},
+		{"subtype out of range for non-nil slot routes to unknown", 0, 1, 3, "unknown"},
+		{"subtype out of range for nil slot routes to unknown", 1, 0, 3, "unknown"},
+		{"type past end of tx slice routes to unknown", 6, 0, 5, "unknown"},
+		{"both fields way out of range route to unknown", 255, 255, 13, "unknown"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := rxTxFixture(t, t.Name())
+
+			var watched metrics.Counter
+			switch {
+			case tc.wantHit == "specific" && int(tc.t) < len(m.tx) && int(tc.s) < len(m.tx[tc.t]):
+				watched = m.tx[tc.t][tc.s]
+			default:
+				watched = m.txUnknown
+			}
+			before := watched.Count()
+
+			m.Tx(tc.t, tc.s, tc.inc)
+
+			assert.Equal(t, tc.inc, watched.Count()-before,
+				"the %q path must increment by exactly the requested delta", tc.wantHit)
+		})
+	}
+}
+
+func TestMessageMetrics_RxInvalid(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func(t *testing.T) (*MessageMetrics, metrics.Counter) // returns m and the rxInvalid counter
+		inc         int64
+		wantDelta   int64
+		expectPanic bool
+	}{
+		{
+			name: "nil MessageMetrics is a noop",
+			setup: func(t *testing.T) (*MessageMetrics, metrics.Counter) {
+				return nil, nil
+			},
+			inc:       5,
+			wantDelta: 0,
+		},
+		{
+			name: "nil rxInvalid counter is a noop",
+			setup: func(t *testing.T) (*MessageMetrics, metrics.Counter) {
+				return &MessageMetrics{}, nil
+			},
+			inc:       5,
+			wantDelta: 0,
+		},
+		{
+			name: "non-nil rxInvalid counter is incremented",
+			setup: func(t *testing.T) (*MessageMetrics, metrics.Counter) {
+				c := metrics.GetOrRegisterCounter("rxInvalid.happy."+t.Name(), nil)
+				return &MessageMetrics{rxInvalid: c}, c
+			},
+			inc:       7,
+			wantDelta: 7,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, c := tc.setup(t)
+			var before int64
+			if c != nil {
+				before = c.Count()
+			}
+
+			// All paths must NOT panic - operator-shaped contract.
+			require.NotPanics(t, func() { m.RxInvalid(tc.inc) })
+
+			if c != nil {
+				assert.Equal(t, tc.wantDelta, c.Count()-before)
+			}
+		})
+	}
+}
+
+func TestMessageMetrics_NilReceiverIsSafe(t *testing.T) {
+	var m *MessageMetrics
+	require.NotPanics(t, func() {
+		m.Rx(0, 0, 1)
+		m.Tx(0, 0, 1)
+		m.RxInvalid(1)
+	}, "all three methods must tolerate a nil *MessageMetrics receiver")
+}
+
+// BenchmarkMessageMetrics_Rx_Valid measures the hot path: a valid (t, s)
+// that lands on a specific counter. This is the common case under load
+// (one call per received packet matching a known message type).
+func BenchmarkMessageMetrics_Rx_Valid(b *testing.B) {
+	m := rxTxFixture(b, b.Name())
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Rx(0, 0, 1)
+	}
+}
+
+// BenchmarkMessageMetrics_Rx_Unknown measures the cold path: an out-of-
+// range type lands on the unknown counter. Less common but possible
+// when the peer sends a malformed or future-version message type.
+func BenchmarkMessageMetrics_Rx_Unknown(b *testing.B) {
+	m := rxTxFixture(b, b.Name())
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Rx(100, 0, 1)
+	}
+}
+
+// BenchmarkMessageMetrics_Tx_Valid mirrors the Rx benchmark on the tx
+// grid; Tx is structurally identical to Rx so the numbers are expected
+// to match within noise.
+func BenchmarkMessageMetrics_Tx_Valid(b *testing.B) {
+	m := rxTxFixture(b, b.Name())
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Tx(0, 0, 1)
+	}
+}
+
+func TestMessageMetrics_NilUnknownCounter(t *testing.T) {
+	// A MessageMetrics whose unknown sentinels are nil should swallow
+	// out-of-range hits silently rather than panic. newMessageMetricsOnlyRecvError
+	// produces exactly this shape (no rxUnknown / txUnknown / rxInvalid).
+	m := &MessageMetrics{
+		rx: [][]metrics.Counter{
+			nil,
+			nil,
+			{metrics.GetOrRegisterCounter("nilunknown.rx.recv_error", nil)},
+		},
+		tx: [][]metrics.Counter{
+			nil,
+			nil,
+			{metrics.GetOrRegisterCounter("nilunknown.tx.recv_error", nil)},
+		},
+	}
+
+	require.NotPanics(t, func() {
+		// out-of-range type -> would hit unknown, but unknown is nil
+		m.Rx(100, 0, 1)
+		m.Tx(100, 0, 1)
+		// nil subtype slot in a populated type slot
+		m.Rx(0, 0, 1)
+		m.Tx(0, 0, 1)
+	}, "out-of-range hits must be silent when the unknown counter is nil")
+}


### PR DESCRIPTION

### Hi 👋

Two functions in this codebase had bounds-check comparisons that staticcheck SA4003 flags as "no value of type X can be less than/greater than Y" — the comparison is unreachable by type construction, so the clause is dead code. Removing the dead halves makes the live bounds checks (the ones that do real work) easier to read and prevents a future reviewer wondering "what does this defend against?". Behaviour is preserved: a value the old condition rejected is still rejected by the simplified condition. Each commit pairs the cleanup with a table-driven test that passes against both forms, providing the bisect-time proof of behaviour preservation. A small consistency commit at the end aligns the encrypt-side mirror of the same code to the new style.

### How we found these

Downstream of this fork we run staticcheck (and the same checker via golangci-lint) as part of a strict static-analysis pipeline. The relevant findings:

```
cert/crypto.go:235:5     no value of type int32 is less than math.MinInt32 (SA4003)
cert/crypto.go:235:39    no value of type int32 is greater than math.MaxInt32 (SA4003)
cert/crypto.go:238:27    no value of type uint32 is greater than math.MaxUint32 (SA4003)
cert/crypto.go:244:31    no value of type uint32 is greater than math.MaxUint32 (SA4003)
message_metrics.go:22:6  every value of type uint8 is >= 0 (SA4003)
message_metrics.go:22:38 every value of type uint8 is >= 0 (SA4003)
message_metrics.go:31:6  every value of type uint8 is >= 0 (SA4003)
message_metrics.go:31:38 every value of type uint8 is >= 0 (SA4003)
```

### Commits

**1. `Drop dead bounds-check comparisons in cert.unmarshalArgon2Parameters`** (+113 / -9)

Four bounds-check blocks where six clauses are unreachable:

```
params.Version < math.MinInt32     // int32, always false
params.Version > math.MaxInt32     // int32, always false
params.Memory > math.MaxUint32     // uint32, always false
params.Memory <= 0                 // uint32 <= 0 is just == 0
params.Iterations > math.MaxUint32 // uint32, always false
params.Iterations <= 0             // uint32 <= 0 is just == 0
```

The Version block is wholly unreachable so drop it entirely. Memory and Iterations have one live half each: simplify to `== 0`. The Parallelism block stays as-is for the `> math.MaxUint8` half — that one does real work, because the proto field is `uint32` but the Go struct field is `uint8` (proto3 has no uint8 type), so values > 255 must be caught before the cast on the return statement truncates them. The `<= 0` half of the Parallelism check becomes `== 0` for consistency.

Also fixes the doubled "be be" typo ("must be be greater than 0" → "must be greater than 0") in the error messages.

`TestUnmarshalArgon2Parameters_Validation` (8 rows) is added in this commit and pins the remaining bounds-check behaviour. The Parallelism cast-safety surface gets dedicated rows: 256 (boundary), 1000 (mid-range silent-truncation hazard if the bounds check were weakened), and `math.MaxUint32` (extreme overflow). 255 is asserted to be accepted with exactly that value forwarded, catching off-by-one mutations of `> MaxUint8`. The test passes against both the pre- and post-cleanup forms.

**2. `Expand crypto_test.go coverage to all functions in cert/crypto.go`** (+466 / -34)

Pure test additions — no production-code changes. While in `crypto_test.go` for commit 1, I audited every function in `cert/crypto.go` against the positive / negative / bounds / corner / adversarial axes and added table-driven tests for the gaps.

Six tests touched:

| Test | Rows | Type | Covers |
|---|---:|---|---|
| `TestNewArgon2Parameters` | 4 | refactored | typical / large / zero values / max-of-each-type |
| `TestEncryptAndMarshalSigningPrivateKey` | 3 | refactored | adds previously-missing P256 round-trip + invalid-curve rejection |
| `TestUnmarshalNebulaEncryptedData_RejectsBadInput` | 5 | new | the four early-return guards + happy path |
| `TestSplitNonceCiphertext` | 5 | new | boundary cases (nonce+1, equal, short, empty) for the lone non-trivial helper |
| `TestDeriveKey_Validation` | 5 | new | wrong argon version, nil salt, salt-below-128-bits, happy, 128-bit boundary |
| `TestAes256Decrypt_RejectsBadInput` | 7 | new | adversarial: tampered ciphertext, tampered nonce, wrong passphrase, plus blob-length boundaries |
| `TestDecryptAndUnmarshalSigningPrivateKey_AlgorithmAndCurveCases` | 2 | new | hand-constructed PEMs reaching the error paths the public Encrypt API can't produce |

Negative-path tests use minimal Argon2 params (`Memory=1, Parallelism=1, Iterations=1`) because they exercise error branches, not the KDF; this keeps wall-clock under 10ms instead of ~350ms with realistic params.

After this commit: **39 sub-tests across 9 functions** covering every function in `cert/crypto.go`. `TestDecryptAndUnmarshalSigningPrivateKey` is left unchanged: its sequential `rest`-chaining tests the multi-key-bundle feature, which would not survive a table-driven refactor.

**3. `Drop dead >= 0 comparisons in MessageMetrics.Rx/Tx`** (+247 / -2)

`MessageMetrics.Rx` and `.Tx` both guarded their counter increment with a four-clause condition:

```go
if t >= 0 && int(t) < len(m.rx) && s >= 0 && int(s) < len(m.rx[t]) {
```

`t` is `header.MessageType` and `s` is `header.MessageSubType`, both defined as `uint8`. Every `uint8` value satisfies `>= 0`, so `t >= 0` and `s >= 0` are dead. The surviving `< len(...)` bounds checks stay untouched.

`message_metrics_test.go` is new (19 sub-tests):

| Test | Rows | Covers |
|---|---:|---|
| `TestMessageMetrics_Rx` | 7 | positive (3 valid coords incl. multi-sub-counter slot rx[4][1]) + negative (subtype OOR for nil/non-nil slot, type OOR, way-out-of-range routing to unknown) |
| `TestMessageMetrics_Tx` | 7 | mirror of Rx for the tx grid |
| `TestMessageMetrics_RxInvalid` | 3 | nil receiver / nil counter / happy path |
| `TestMessageMetrics_NilReceiverIsSafe` | 1 | `(*MessageMetrics)(nil)` doesn't panic on any method |
| `TestMessageMetrics_NilUnknownCounter` | 1 | out-of-range hits are silent when `rxUnknown`/`txUnknown` are nil |

Plus three benchmarks (`Rx_Valid`, `Rx_Unknown`, `Tx_Valid`) which empirically confirm the cleanup is **performance-neutral**: ~4.8 ns/op ± 0.4 ns within-sample variance both before and after; 0 B/op, 0 allocs/op. The Go compiler already optimizes away `uint8 >= 0`, so this cleanup is purely for readability. The benchmarks live in the test file forever as a tripwire against any future regression on this per-packet hot path.

**4. `Align parseArgonParameters bounds-check style with cert/crypto.go`** (+103 / -6)

`cmd/nebula-cert.parseArgonParameters` validates the operator-supplied `-argon-memory`, `-argon-parallelism`, `-argon-iterations` CLI flags before casting them down to the `uint32`/`uint8`/`uint32` expected by `cert.NewArgon2Parameters`. It is the encrypt-time mirror of the decrypt-time `cert.unmarshalArgon2Parameters` cleaned up in commit 1.

Bring the encrypt-side into the same shape:

- `<= 0` → `== 0` on all three checks (`uint <= 0` is just `uint == 0`; the simpler form makes the equivalence obvious).
- Keep the `> math.MaxUint32` / `> math.MaxUint8` halves: these are real bounds checks that prevent silent truncation when `uint` (typically `uint64`) is cast down to `uint32`/`uint8` in the next-line call.
- Same one-line comment above the Parallelism check that `cert/crypto.go` got.
- Same doubled "be be" typo fix in all three error messages.

staticcheck SA4003 does not flag this site because `uint` on a 64-bit system is `uint64` and the comparison is technically reachable; but the intent is identical to commit 1's case and we want the two sites to stay in sync stylistically.

`TestParseArgonParameters_Validation` (7 rows) is added. The function had zero direct test coverage before this commit.

### Approach: test-first + behaviour-preserving

Each commit follows the same workflow:

1. Write a table-driven test that pins the **remaining** (non-dead) bounds-check behaviour.
2. Run the test against the unmodified upstream code — it MUST pass (proving the test reflects current behaviour).
3. Apply the SA4003 cleanup.
4. Run the test again — it MUST still pass (proving the cleanup is behaviour-preserving).
5. Mutation test: remove one of the surviving checks, confirm a test row fails. Restore.

The "test passes against both forms" is the bisect-time proof. Every commit is independently bisect-safe (`go test ./...` passes at every SHA on the branch).

### How to run the new tests locally

```
# All the new SA4003-related + coverage tests:
go test -count=1 -v -run 'TestUnmarshalArgon2Parameters_Validation|TestDeriveKey_Validation|TestAes256Decrypt_RejectsBadInput|TestSplitNonceCiphertext|TestUnmarshalNebulaEncryptedData_RejectsBadInput|TestEncryptAndMarshalSigningPrivateKey|TestNewArgon2Parameters|TestDecryptAndUnmarshalSigningPrivateKey_AlgorithmAndCurveCases' ./cert

go test -count=1 -v -run 'TestMessageMetrics' .

go test -count=1 -v -run 'TestParseArgonParameters_Validation' ./cmd/nebula-cert/

# MessageMetrics benchmarks:
go test -bench=BenchmarkMessageMetrics -benchmem -count=10 -run=^$ .
```

### Backward compatibility

No CLI flag, config, public API, or wire-format changes. The only observable changes are:

- Two pairs of error messages no longer say "be be" (the doubled-word typo is fixed in both `cert.unmarshalArgon2Parameters` and `cmd/nebula-cert.parseArgonParameters`). Text content is otherwise identical to upstream.
- The dropped `Version` bounds check in `cert.unmarshalArgon2Parameters` was unreachable, so its removal has no behavioural impact.

All bounds-check behaviour is end-to-end preserved.

