### PR TITLE
Surface previously-swallowed errors from config path resolution

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -340,8 +340,7 @@ func (c *C) resolve(path string, direct bool) error {
 	}
 
 	if !i.IsDir() {
-		c.addFile(path, direct)
-		return nil
+		return c.addFile(path, direct)
 	}
 
 	paths, err := readDirNames(path)
@@ -366,7 +365,7 @@ func (c *C) addFile(path string, direct bool) error {
 		return nil
 	}
 
-	ap, err := filepath.Abs(path)
+	ap, err := filepathAbs(path)
 	if err != nil {
 		return err
 	}
@@ -374,6 +373,9 @@ func (c *C) addFile(path string, direct bool) error {
 	c.files = append(c.files, ap)
 	return nil
 }
+
+// filepathAbs is swappable so tests can exercise the addFile error path.
+var filepathAbs = filepath.Abs
 
 func (c *C) parseRaw(b []byte) error {
 	var m map[string]any

--- a/config/config.go
+++ b/config/config.go
@@ -331,6 +331,11 @@ func (c *C) get(k string, v any) any {
 func (c *C) resolve(path string, direct bool) error {
 	i, err := os.Stat(path)
 	if err != nil {
+		if direct {
+			return fmt.Errorf("failed to stat config file at %s: %w", path, err)
+		}
+		// log and skip so one bad entry does not abort a multi-file config reload.
+		c.l.Warn("failed to stat config entry, skipping", "path", path, "error", err)
 		return nil
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -40,6 +40,15 @@ func TestConfig_Load(t *testing.T) {
 	assert.Equal(t, expected, c.Settings)
 }
 
+func TestC_Load_StatErrorReturned(t *testing.T) {
+	l := test.NewLogger()
+	c := NewC(l)
+	dir := filepath.Join(os.TempDir(), "nebula-config-does-not-exist-1bf6f0a0")
+	_ = os.RemoveAll(dir)
+
+	require.Error(t, c.Load(dir))
+}
+
 func TestConfig_Get(t *testing.T) {
 	l := test.NewLogger()
 	// test simple type

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -47,6 +48,18 @@ func TestC_Load_StatErrorReturned(t *testing.T) {
 	_ = os.RemoveAll(dir)
 
 	require.Error(t, c.Load(dir))
+}
+
+func TestC_Load_AddFileErrorPropagates(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "x.yml")
+	require.NoError(t, os.WriteFile(target, []byte("k: v\n"), 0o644))
+
+	origAbs := filepathAbs
+	t.Cleanup(func() { filepathAbs = origAbs })
+	filepathAbs = func(string) (string, error) { return "", errors.New("injected") }
+
+	require.Error(t, NewC(test.NewLogger()).Load(target))
 }
 
 func TestConfig_Get(t *testing.T) {


### PR DESCRIPTION
### Hi 👋

This PR folds the config-only changes out of #1725 and #1726 into a single subsystem PR, per @JackDoan's review on #1726 ("Separate PRs for config, ssh, and DNS improvements are easier to review").

Two small, independently bisect-safe commits, each fixing one previously-swallowed error inside `(*C).resolve`:

1. **Return stat errors from config path resolution** — when `os.Stat` fails on the user-specified `--config` path, return the underlying error (ENOENT/EACCES/ELOOP) wrapped via `%w` instead of letting `Load` fall through to its generic `"no config files found at %s"` message. Stat failures on recursed descendants of a directory still log+skip via `c.l.Warn` so one bad entry does not abort a multi-file reload.
2. **Return addFile errors from config.resolve** — `resolve()` now propagates the error from `c.addFile()` rather than discarding it. `addFile` calls a package-level `filepathAbs` var so a test can inject a failure.

### Feedback addressed (vs. #1725)

- Error message uses your exact suggested phrasing: `"failed to stat config file at %s: %w"`.
- Dropped the multi-line "essay" comments — only a single one-liner remains on the log+skip branch.
- Dropped the error-string-content assertions — tests now only assert `require.Error`, per your "testing the contents of errors is not idiomatic in Go" note.

### How to run the new tests locally

```
go test -count=1 -v -run 'TestC_Load_StatErrorReturned|TestC_Load_AddFileErrorPropagates' ./config
```

### Backward compatibility

No CLI flag, config key, or public API changes. The only observable behaviour change is that previously-silent failures (missing config path, `filepath.Abs` failures) now return descriptive errors at the failing call site instead of an empty `"no config files found at %s"` diagnostic. All existing tests continue to pass with no edits.

Companion PRs (subsystem-split from #1725/#1726): DNS and SSH PRs to follow.