### PR TITLE
Log and meter previously-swallowed dns_server WriteMsg failures

### DIFF
--- a/dns_server.go
+++ b/dns_server.go
@@ -10,10 +10,45 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/miekg/dns"
+	"github.com/rcrowley/go-metrics"
 	"github.com/slackhq/nebula/config"
 )
+
+// dnsWriteWarnLogWindow rate-limits the WriteMsg-failure Warn so a
+// network-wide problem cannot flood the log. The counter is always
+// incremented; only the log emission is throttled.
+const dnsWriteWarnLogWindow = 10 * time.Second
+
+// dnsWriteWarnLimiter logs the first failure in each window and counts
+// the rest. Concurrent-safe via CompareAndSwap on lastLogged.
+type dnsWriteWarnLimiter struct {
+	suppressed atomic.Int64
+	lastLogged atomic.Int64
+	windowNs   int64
+}
+
+func newDNSWriteWarnLimiter(window time.Duration) *dnsWriteWarnLimiter {
+	l := &dnsWriteWarnLimiter{windowNs: window.Nanoseconds()}
+	// Seed lastLogged so the first call always logs regardless of clock value.
+	l.lastLogged.Store(-l.windowNs)
+	return l
+}
+
+// shouldLog reports whether the caller should emit a Warn now, and the
+// number of failures that were suppressed since the previous log.
+func (l *dnsWriteWarnLimiter) shouldLog(now int64) (bool, int64) {
+	last := l.lastLogged.Load()
+	if now-last >= l.windowNs {
+		if l.lastLogged.CompareAndSwap(last, now) {
+			return true, l.suppressed.Swap(0)
+		}
+	}
+	l.suppressed.Add(1)
+	return false, 0
+}
 
 type dnsServer struct {
 	sync.RWMutex
@@ -45,6 +80,11 @@ type dnsServer struct {
 	// ignored, leaving the listener running forever.
 	started chan struct{}
 	addr    string
+
+	// metricWriteFailures counts every dns.ResponseWriter.WriteMsg error.
+	metricWriteFailures metrics.Counter
+	// warnLimiter throttles the WriteMsg-failure Warn log.
+	warnLimiter *dnsWriteWarnLimiter
 }
 
 // newDnsServerFromConfig builds a dnsServer, applies the initial config, and
@@ -59,12 +99,14 @@ type dnsServer struct {
 // pointer is always non-nil, even on error.
 func newDnsServerFromConfig(ctx context.Context, l *slog.Logger, pki *PKI, hostMap *HostMap, c *config.C) (*dnsServer, error) {
 	ds := &dnsServer{
-		l:       l,
-		ctx:     ctx,
-		dnsMap4: make(map[string]netip.Addr),
-		dnsMap6: make(map[string]netip.Addr),
-		hostMap: hostMap,
-		pki:     pki,
+		l:                   l,
+		ctx:                 ctx,
+		dnsMap4:             make(map[string]netip.Addr),
+		dnsMap6:             make(map[string]netip.Addr),
+		hostMap:             hostMap,
+		pki:                 pki,
+		metricWriteFailures: metrics.GetOrRegisterCounter("dns.responses.write_failures", nil),
+		warnLimiter:         newDNSWriteWarnLimiter(dnsWriteWarnLogWindow),
 	}
 	ds.mux = dns.NewServeMux()
 	ds.mux.HandleFunc(".", ds.handleDnsRequest)
@@ -436,7 +478,15 @@ func (d *dnsServer) handleDnsRequest(w dns.ResponseWriter, r *dns.Msg) {
 		d.parseQuery(m, w)
 	}
 
-	w.WriteMsg(m)
+	if err := w.WriteMsg(m); err != nil {
+		d.metricWriteFailures.Inc(1)
+		if log, suppressed := d.warnLimiter.shouldLog(time.Now().UnixNano()); log {
+			d.l.Warn("dns: failed to write response",
+				"error", err,
+				"client", w.RemoteAddr().String(),
+				"suppressed_since_last_log", suppressed)
+		}
+	}
 }
 
 func getDnsServerAddr(c *config.C) string {

--- a/dns_server_test.go
+++ b/dns_server_test.go
@@ -1,7 +1,9 @@
 package nebula
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"log/slog"
 	"net"
 	"net/netip"
@@ -11,6 +13,7 @@ import (
 
 	"github.com/gaissmai/bart"
 	"github.com/miekg/dns"
+	"github.com/rcrowley/go-metrics"
 	"github.com/slackhq/nebula/cert"
 	"github.com/slackhq/nebula/cert_test"
 	"github.com/slackhq/nebula/config"
@@ -426,4 +429,100 @@ func waitFor(t *testing.T, cond func() bool) {
 		time.Sleep(5 * time.Millisecond)
 	}
 	t.Fatal("timed out waiting for condition")
+}
+
+// failingDNSWriter wraps stubDNSWriter and always errors from WriteMsg.
+type failingDNSWriter struct{ stubDNSWriter }
+
+func (failingDNSWriter) WriteMsg(*dns.Msg) error { return errors.New("injected WriteMsg failure") }
+
+func TestDNSWriteWarnLimiter(t *testing.T) {
+	const sec = int64(time.Second)
+	tests := []struct {
+		name        string
+		windowNs    int64
+		calls       []int64
+		wantLogged  []bool
+		wantPrevSup []int64
+	}{
+		{
+			name:        "first call always logs with zero suppressed",
+			windowNs:    10 * sec,
+			calls:       []int64{1},
+			wantLogged:  []bool{true},
+			wantPrevSup: []int64{0},
+		},
+		{
+			name:        "second call inside window is suppressed",
+			windowNs:    10 * sec,
+			calls:       []int64{1, 1 + 5*sec},
+			wantLogged:  []bool{true, false},
+			wantPrevSup: []int64{0, 0},
+		},
+		{
+			name:        "call past window emits with the suppressed count",
+			windowNs:    10 * sec,
+			calls:       []int64{1, 1 + 5*sec, 1 + 11*sec},
+			wantLogged:  []bool{true, false, true},
+			wantPrevSup: []int64{0, 0, 1},
+		},
+		{
+			name:        "tied exactly at the window edge logs",
+			windowNs:    10 * sec,
+			calls:       []int64{1, 1 + 10*sec},
+			wantLogged:  []bool{true, true},
+			wantPrevSup: []int64{0, 0},
+		},
+		{
+			name:        "many suppressed in a row then one log gets accumulated count",
+			windowNs:    10 * sec,
+			calls:       []int64{1, 2, 3, 4, 5, 1 + 11*sec},
+			wantLogged:  []bool{true, false, false, false, false, true},
+			wantPrevSup: []int64{0, 0, 0, 0, 0, 4},
+		},
+		{
+			name:        "non-monotonic clock keeps suppressing",
+			windowNs:    10 * sec,
+			calls:       []int64{1 + 100*sec, 50 * sec},
+			wantLogged:  []bool{true, false},
+			wantPrevSup: []int64{0, 0},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lim := newDNSWriteWarnLimiter(time.Duration(tc.windowNs))
+			require.Len(t, tc.wantLogged, len(tc.calls))
+			require.Len(t, tc.wantPrevSup, len(tc.calls))
+			for i, now := range tc.calls {
+				gotLog, gotSup := lim.shouldLog(now)
+				assert.Equal(t, tc.wantLogged[i], gotLog, "call %d at now=%d", i, now)
+				if tc.wantLogged[i] {
+					assert.Equal(t, tc.wantPrevSup[i], gotSup, "call %d at now=%d", i, now)
+				}
+			}
+		})
+	}
+}
+
+func TestDnsServer_HandleDnsRequest_WriteMsgFailure_LogsAndMeters(t *testing.T) {
+	var logBuf bytes.Buffer
+	l := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	counter := metrics.NewCounter()
+	ds := &dnsServer{
+		l:                   l,
+		dnsMap4:             make(map[string]netip.Addr),
+		dnsMap6:             make(map[string]netip.Addr),
+		hostMap:             &HostMap{},
+		metricWriteFailures: counter,
+		warnLimiter:         newDNSWriteWarnLimiter(dnsWriteWarnLogWindow),
+	}
+	ds.enabled.Store(true)
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.test.", dns.TypeA)
+
+	ds.handleDnsRequest(failingDNSWriter{}, q)
+
+	assert.Equal(t, int64(1), counter.Count())
+	assert.Contains(t, logBuf.String(), "dns: failed to write response")
 }


### PR DESCRIPTION
### Hi 👋

This PR splits the DNS subsystem changes out of #1726 per @JackDoan's review ("Separate PRs for config, ssh, and DNS improvements are easier to review").

One bisect-safe commit at the previously-swallowed `WriteMsg` site in `handleDnsRequest`:

- Increment a `rcrowley/go-metrics` counter (`dns.responses.write_failures`) on every `WriteMsg` error.
- Emit a rate-limited `slog.Warn` line including the wrapped error, the client address, and the count of suppressed failures since the last log line.
- No retry: UDP DNS responses are stateless, retrying the same transaction ID would violate the protocol, and FD exhaustion is not solvable by retry.

### Rate limiter

A small atomic-int rate limiter (10s window, concurrent-safe via `CompareAndSwap`) prevents a runaway client from flooding the log. No new dependencies — built from `sync/atomic` only. The counter is always incremented; only the log emission is throttled, so an operator graphing the counter never loses visibility into the failure rate even when log lines are suppressed.

### How to run the new tests locally

```
go test -count=1 -v -run 'TestDNSWriteWarnLimiter|TestDnsServer_HandleDnsRequest_WriteMsgFailure' .
```

`TestDNSWriteWarnLimiter` is a 6-row table that walks the limiter state machine deterministically with explicit unix-nano timestamps (no real clock). `TestDnsServer_HandleDnsRequest_WriteMsgFailure_LogsAndMeters` wires `handleDnsRequest` against a `failingDNSWriter` and asserts the counter incremented and the Warn message landed in the captured log buffer.

### Backward compatibility

No CLI flag, config key, or public API changes. The only observable behaviour change is that previously-silent `WriteMsg` failures now appear in the metrics export and the journal. All existing tests continue to pass with no edits.

Companion PRs (subsystem-split from #1725/#1726): config is #1737. SSH PR to follow.