### PR TITLE
relay: guard against nil Addr in protoAddrToNetAddr to avoid panic on malformed Control message

### DIFF
--- a/lighthouse.go
+++ b/lighthouse.go
@@ -1439,8 +1439,8 @@ func (lhh *LightHouseHandler) handleHostPunchNotification(n *NebulaMeta, fromVpn
 
 func protoAddrToNetAddr(addr *Addr) netip.Addr {
 	if addr == nil {
-			return netip.Addr{}
-		}
+		return netip.Addr{}
+	}
 	b := [16]byte{}
 	binary.BigEndian.PutUint64(b[:8], addr.Hi)
 	binary.BigEndian.PutUint64(b[8:], addr.Lo)

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -1438,6 +1438,9 @@ func (lhh *LightHouseHandler) handleHostPunchNotification(n *NebulaMeta, fromVpn
 }
 
 func protoAddrToNetAddr(addr *Addr) netip.Addr {
+	if addr == nil {
+			return netip.Addr{}
+		}
 	b := [16]byte{}
 	binary.BigEndian.PutUint64(b[:8], addr.Hi)
 	binary.BigEndian.PutUint64(b[8:], addr.Lo)

--- a/lighthouse_test.go
+++ b/lighthouse_test.go
@@ -738,3 +738,11 @@ func TestLighthouse_DeletesWork(t *testing.T) {
 	out = lh.Query(testHost)
 	assert.Nil(t, out)
 }
+
+func TestProtoAddrToNetAddr_NilReturnsInvalid(t *testing.T) {
+	var addr *Addr
+	got := protoAddrToNetAddr(addr)
+	if got.IsValid() {
+		t.Fatalf("expected invalid Addr for nil input, got %v", got)
+	}
+}


### PR DESCRIPTION
`protoAddrToNetAddr` dereferences `addr.Hi`/`addr.Lo` without a nil check. The relay Control-message handlers `handleCreateRelayRequest` and `handleCreateRelayResponse` call it directly on `m.RelayFromAddr` / `m.RelayToAddr`. For a Version2 NebulaControl these fields come from the wire and are nil when omitted (proto3 message fields), so a malformed CreateRelay control message causes a nil-pointer dereference panic.

This adds a small defensive nil guard returning a zero (invalid) `netip.Addr`, so a malformed message is handled gracefully (the downstream relay lookups simply fail to match) instead of crashing the node. A stricter alternative would be to drop Version2 control messages with missing `RelayFromAddr`/`RelayToAddr` in `HandleControlMsg`; the helper guard is the minimal change and protects all call sites.

A test (`TestProtoAddrToNetAddr_NilReturnsInvalid`) is included to verify nil input returns an invalid `netip.Addr` without panicking.

Reported via HackerOne and closed Informative (below the program's current severity bar); filing the fix here per the triager's recommendation.