### PR TITLE
Fix panic in create-tunnel ssh command when -address is provided

### DIFF
--- a/ssh.go
+++ b/ssh.go
@@ -686,6 +686,13 @@ func sshCreateTunnel(ifce *Interface, fs any, a []string, w sshd.StringWriter) e
 
 	hostInfo = ifce.handshakeManager.StartHandshake(vpnAddr, nil)
 	if addr.IsValid() {
+		// A freshly started handshake has no RemoteList yet (the handshake
+		// worker populates it lazily). Initialize it the same way the worker
+		// does before learning the operator-provided remote; otherwise
+		// SetRemote dereferences a nil hostInfo.remotes and panics.
+		if hostInfo.remotes == nil {
+			hostInfo.remotes = ifce.lightHouse.QueryCache([]netip.Addr{vpnAddr})
+		}
 		hostInfo.SetRemote(addr)
 	}
 

--- a/ssh_test.go
+++ b/ssh_test.go
@@ -1,0 +1,59 @@
+package nebula
+
+import (
+	"io"
+	"net/netip"
+	"strings"
+	"testing"
+
+	"github.com/slackhq/nebula/sshd"
+	"github.com/slackhq/nebula/test"
+	"github.com/slackhq/nebula/udp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sshStringRecorder is a minimal sshd.StringWriter that captures output.
+type sshStringRecorder struct{ buf strings.Builder }
+
+func (s *sshStringRecorder) WriteLine(v string) error  { s.buf.WriteString(v + "\n"); return nil }
+func (s *sshStringRecorder) Write(v string) error      { s.buf.WriteString(v); return nil }
+func (s *sshStringRecorder) WriteBytes(b []byte) error { s.buf.Write(b); return nil }
+func (s *sshStringRecorder) GetWriter() io.Writer      { return io.Discard }
+
+var _ sshd.StringWriter = (*sshStringRecorder)(nil)
+
+// Regression test: `create-tunnel -address <ip:port> <vpn>` used to crash the
+// daemon. StartHandshake returns a HostInfo whose remotes (*RemoteList) is nil
+// (it is populated lazily by the handshake worker), so SetRemote dereferenced
+// nil and SIGSEGV'd. The handler must initialize remotes first — and the
+// operator-provided address must actually be applied.
+func TestSSHCreateTunnelWithAddress(t *testing.T) {
+	l := test.NewLogger()
+	mainHM := newHostMap(l)
+	preferredRanges := []netip.Prefix{netip.MustParsePrefix("10.1.1.1/24")}
+	mainHM.preferredRanges.Store(&preferredRanges)
+	lh := newTestLighthouse()
+	hm := NewHandshakeManager(l, mainHM, lh, &udp.NoopConn{}, defaultHandshakeConfig)
+
+	ifce := &Interface{
+		hostMap:          mainHM,
+		handshakeManager: hm,
+		lightHouse:       lh,
+		l:                l,
+	}
+	hm.f = ifce
+
+	vpn := netip.MustParseAddr("172.1.1.2")
+	flags := &sshCreateTunnelFlags{Address: "198.51.100.97:4242"}
+	w := &sshStringRecorder{}
+
+	require.NoError(t, sshCreateTunnel(ifce, flags, []string{vpn.String()}, w))
+	assert.Equal(t, "Created", strings.TrimSpace(w.buf.String()))
+
+	// The new handshake must carry a RemoteList and the operator-provided remote.
+	hi := hm.QueryVpnAddr(vpn)
+	require.NotNil(t, hi)
+	require.NotNil(t, hi.remotes)
+	assert.Equal(t, netip.MustParseAddrPort("198.51.100.97:4242"), hi.remote)
+}


### PR DESCRIPTION
## Summary

`create-tunnel -address <ip:port> <vpn>` on the sshd debug server crashes the daemon with a nil pointer dereference.

`handshakeManager.StartHandshake` returns a `HostInfo` whose `remotes` (`*RemoteList`) is populated lazily by the handshake worker, so it is `nil` at the point `sshCreateTunnel` runs. With `-address` set, the handler calls `hostInfo.SetRemote(addr)`, which dereferences the nil `remotes` in `LearnRemote`:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0]
github.com/slackhq/nebula/sshd.(*session).dispatchCommand .../sshd/session.go:172
```

`change-remote -address ...` is unaffected because it operates on an already-established `HostInfo` whose `remotes` is set.

## Fix

Initialize `remotes` the same way the handshake worker and the inbound-handshake path do — `lightHouse.QueryCache(...)`, guarded by the same `remotes == nil` check — before calling `SetRemote`. This both stops the crash and lets the operator-provided address actually take effect (otherwise it would be lost).

## Test Plan

- [x] `go test ./...` passes
- [x] Added `TestSSHCreateTunnelWithAddress`, which fails with the SIGSEGV above without the fix and passes with it
- [x] Reproduced live on nebula 1.10.3: `create-tunnel -address 198.51.100.97:4242 <vpn>` crashed a running daemon before the fix; after it, the tunnel is created with the provided remote

🤖 Generated with [Claude Code](https://claude.com/claude-code)