### PR TITLE
fix tunnels that could permanently escape connection-manager monitoring

### DIFF
--- a/connection_manager.go
+++ b/connection_manager.go
@@ -136,14 +136,6 @@ func (cm *connectionManager) getAndResetTrafficCheck(h *HostInfo, now time.Time)
 	return in, out
 }
 
-// AddTrafficWatch must be called for every new HostInfo.
-// We will continue to monitor the HostInfo until the tunnel is dropped.
-func (cm *connectionManager) AddTrafficWatch(h *HostInfo) {
-	if h.out.Swap(true) == false {
-		cm.trafficTimer.Add(h.localIndexId, cm.checkInterval)
-	}
-}
-
 func (cm *connectionManager) Start(ctx context.Context) {
 	clockSource := time.NewTicker(cm.trafficTimer.t.tickDuration)
 	defer clockSource.Stop()

--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -796,7 +796,6 @@ func (hm *HandshakeManager) beginHandshake(via ViaSender, packet []byte, h *head
 	}
 
 	hm.sendHandshakeResponse(via, response, hostinfo, false)
-	f.connectionManager.AddTrafficWatch(hostinfo)
 	hostinfo.remotes.RefreshFromHandshake(vpnAddrs)
 
 	// Don't wait for UpdateWorker
@@ -963,7 +962,6 @@ func (hm *HandshakeManager) continueHandshake(via ViaSender, hh *HandshakeHostIn
 	hostinfo.buildNetworks(f.myVpnNetworksTable, remoteCert.Certificate)
 
 	hm.Complete(hostinfo, f)
-	f.connectionManager.AddTrafficWatch(hostinfo)
 
 	if len(hh.packetStore) > 0 {
 		if f.l.Enabled(context.Background(), slog.LevelDebug) {

--- a/hostmap.go
+++ b/hostmap.go
@@ -623,6 +623,11 @@ func (hm *HostMap) unlockedAddHostInfo(hostinfo *HostInfo, f *Interface) {
 	hm.Indexes[hostinfo.localIndexId] = hostinfo
 	hm.RemoteIndexes[hostinfo.remoteIndexId] = hostinfo
 
+	hostinfo.out.Store(true)
+	if f.connectionManager != nil { // f.connectionManager is only nil in some unit tests
+		f.connectionManager.trafficTimer.Add(hostinfo.localIndexId, f.connectionManager.checkInterval)
+	}
+
 	if hm.l.Enabled(context.Background(), slog.LevelDebug) {
 		hm.l.Debug("Hostmap vpnIp added",
 			"hostMap", m{"vpnAddrs": hostinfo.vpnAddrs, "mapTotalSize": len(hm.Hosts),


### PR DESCRIPTION
There is technically a window here where outbound traffic _could_ be sent before getting added to the connection manager. Avoid this by registering with the connection manager while we're still holding the hostmap write lock, so a mistake can never be made

An alternative would be to add a dedicated atomic.Bool for `AddTrafficWatch` to check, rather than sharing the `out` flag.