### PR TITLE
disallow negative stats intervals

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -331,7 +331,7 @@ func loadStatsConfig(c *config.C) (statsConfig, error) {
 	}
 
 	cfg.interval = c.GetDuration("stats.interval", 0)
-	if cfg.interval == 0 {
+	if cfg.interval <= 0 {
 		return cfg, fmt.Errorf("stats.interval was an invalid duration: %s", c.GetString("stats.interval", ""))
 	}
 


### PR DESCRIPTION
You might think this is a breaking config file change, however, because it would cause a panic, I'd argue it isn't