### PR TITLE
fix: nil pointer dereference in protoAddrToNetAddr

### DIFF
--- a/lighthouse.go
+++ b/lighthouse.go
@@ -1438,10 +1438,13 @@ func (lhh *LightHouseHandler) handleHostPunchNotification(n *NebulaMeta, fromVpn
 }
 
 func protoAddrToNetAddr(addr *Addr) netip.Addr {
-	b := [16]byte{}
-	binary.BigEndian.PutUint64(b[:8], addr.Hi)
-	binary.BigEndian.PutUint64(b[8:], addr.Lo)
-	return netip.AddrFrom16(b).Unmap()
+    if addr == nil {
+        return netip.Addr{}
+    }
+    b := [16]byte{}
+    binary.BigEndian.PutUint64(b[:8], addr.Hi)
+    binary.BigEndian.PutUint64(b[8:], addr.Lo)
+    return netip.AddrFrom16(b).Unmap()
 }
 
 func protoV4AddrPortToNetAddrPort(ap *V4AddrPort) netip.AddrPort {


### PR DESCRIPTION
## Summary

`protoAddrToNetAddr` in `lighthouse.go` does not check for a nil addr 
before dereferencing it, causing a SIGSEGV that terminates the entire 
nebula process.

## Root Cause

When a `NebulaControl_CreateRelayRequest` message is received with absent
`RelayFromAddr`/`RelayToAddr` fields (the proto3 default when not set),
`HandleControlMsg` in `relay_manager.go` takes the Version2 path and
leaves both fields as nil pointers. The subsequent call to
`protoAddrToNetAddr` immediately dereferences them with no nil check,
causing a panic.

Since the nebula codebase has no `recover()` calls in the production
path, the panic propagates directly to the Go runtime and kills the
process.

## Impact

- Any authenticated peer can terminate the nebula process on any node
  with a single 2-byte packet
- Lighthouses are equally vulnerable — crashing one disrupts routing
  for the entire nebula deployment
- All active tunnels on the crashed node drop simultaneously
- No flooding required — one packet, 100% reproducible

## Fix

Added a nil guard to `protoAddrToNetAddr` that returns a zero 
`netip.Addr` when addr is nil, which is safe and prevents the panic.

## References

- Affected files: `lighthouse.go:1440`, `relay_manager.go:403`
- CWE-476: Null Pointer Dereference
- Reported via HackerOne: https://hackerone.com/reports/3792601
