### PR TITLE
Make prometheus stats safe to start more than once per process

### DIFF
--- a/stats_test.go
+++ b/stats_test.go
@@ -1,0 +1,58 @@
+package nebula
+
+import (
+	"testing"
+	"time"
+
+	"github.com/slackhq/nebula/config"
+	"github.com/slackhq/nebula/test"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPrometheusStatsReentrant guards against a regression where starting the
+// prometheus stats listener more than once in the same process panics with
+// `pattern "/metrics" conflicts`. This happens whenever an embedder tears down
+// and re-runs Main()/Control.Start() in the same process — for example on a
+// config change that requires a restart. Each start must get its own HTTP mux.
+func TestPrometheusStatsReentrant(t *testing.T) {
+	l := test.NewLogger()
+
+	makeStartFn := func() func() {
+		c := config.NewC(l)
+		// listen: 127.0.0.1:0 gives each instance its own ephemeral port, so a
+		// successful second start does not collide on the address — isolating
+		// the handler-registration bug from any bind conflict.
+		require.NoError(t, c.LoadString("stats:\n  listen: 127.0.0.1:0\n  path: /metrics\n"))
+		startFn, err := startPrometheusStats(l, time.Second, c, "test", false)
+		require.NoError(t, err)
+		require.NotNil(t, startFn)
+		return startFn
+	}
+
+	first := makeStartFn()
+	second := makeStartFn()
+
+	// A startFn that registers its handler successfully then blocks serving, so
+	// its deferred recover() never fires. A startFn that panics on a duplicate
+	// registration unwinds immediately and sends the recovered value. We only
+	// hear from the broken path.
+	panics := make(chan any, 2)
+	run := func(fn func()) {
+		go func() {
+			defer func() { panics <- recover() }()
+			fn()
+		}()
+	}
+	run(first)
+	run(second)
+
+	select {
+	case p := <-panics:
+		if p != nil {
+			t.Fatalf("startPrometheusStats panicked when started twice in one process: %v", p)
+		}
+	case <-time.After(time.Second):
+		// No panic inside the window: both instances registered their handlers
+		// on independent muxes and are serving. This is the fixed behavior.
+	}
+}


### PR DESCRIPTION
## Problem

Nebula panics if `Main()` / `Control.Start()` run more than once in the same process:

```
panic: pattern "/metrics" ... conflicts with pattern "/metrics"
  at stats.go (startPrometheusStats)
```

`startPrometheusStats` registers its handler on Go's process-global `http.DefaultServeMux` (`http.Handle` + `ListenAndServe(listen, nil)`) and `log.Fatal`s on listener failure. That's fine for the standalone binary (one `Main()` per process), but it makes nebula **non-reentrant** as an embedded library: the second `/metrics` registration panics.

This is observable in production: an embedder that reloads config by tearing down and re-running `Main()`/`Control.Start()` in-process (e.g. on an overlay-network change that requires a restart) crashes the whole process on the reload.

## Fix

- Give each start its own `http.NewServeMux()` and `http.Server` instead of the global `DefaultServeMux`.
- Log on listener failure instead of `log.Fatal`, so a stats problem can't `os.Exit` an embedder.

## Commits (TDD — red then green)

1. **Add failing test** — `TestPrometheusStatsReentrant` starts the stats listener twice in one process and asserts no panic. Fails against current `master` with the exact production panic.
2. **The fix** — per-instance mux/server. Test passes; full root package tests + `go vet` clean.

## Known limitation / follow-on

This kills the *panic*, but it isn't the complete story. On an in-process restart, `Control.Stop()` doesn't own the stats `http.Server`, so the old listener stays bound — the new instance's `ListenAndServe` then gets "address already in use", logs an error, and serves no fresh metrics (the dead instance keeps serving stale ones). So the behavior goes from **hard crash → metrics go stale after a reload** — strictly better, not complete. The full fix threads the server through `Main`→`Control` so `Stop()` closes it; happy to do that here or as a follow-up.