### PR TITLE
Add OCI image labels with version info

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,10 @@ jobs:
           mkdir -p build/linux-{amd64,arm64}
           tar -zxvf artifacts/nebula-linux-amd64.tar.gz -C build/linux-amd64/
           tar -zxvf artifacts/nebula-linux-arm64.tar.gz -C build/linux-arm64/
-          docker buildx build . --push -f docker/Dockerfile --platform linux/amd64,linux/arm64 --tag "${DOCKER_IMAGE_REPO}:${DOCKER_IMAGE_TAG}" --tag "${DOCKER_IMAGE_REPO}:${GITHUB_REF#refs/tags/v}"
+          docker buildx build . --push -f docker/Dockerfile --platform linux/amd64,linux/arm64 \
+            --build-arg VERSION="${GITHUB_REF#refs/tags/v}" \
+            --build-arg REVISION="${GITHUB_SHA}" \
+            --tag "${DOCKER_IMAGE_REPO}:${DOCKER_IMAGE_TAG}" --tag "${DOCKER_IMAGE_REPO}:${GITHUB_REF#refs/tags/v}"
 
   release:
     name: Create and Upload Release

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,16 @@
 FROM gcr.io/distroless/static:latest
 
 ARG TARGETOS TARGETARCH
+
+ARG VERSION=dev
+ARG REVISION=unknown
+LABEL org.opencontainers.image.title="nebula" \
+      org.opencontainers.image.description="A scalable overlay networking tool with a focus on performance, simplicity and security" \
+      org.opencontainers.image.vendor="Nebula OSS" \
+      org.opencontainers.image.source="https://github.com/slackhq/nebula" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${REVISION}"
+
 COPY build/$TARGETOS-$TARGETARCH/nebula /nebula
 COPY build/$TARGETOS-$TARGETARCH/nebula-cert /nebula-cert
 


### PR DESCRIPTION
In some Docker tooling it's not easy to determine which version is running. This is because if you are pulling the latest tag, nothing indicates the version of the image.

Fix this by adding Docker image labels.