### PR TITLE
wireshark: fix Lua 5.4 bitwise operation

### DIFF
--- a/dist/wireshark/nebula.lua
+++ b/dist/wireshark/nebula.lua
@@ -62,7 +62,7 @@ function nebula.dissector(tvbuf, pktinfo, root)
     tree:add(pf_version, tvbuf:range(0,1))
     local type = tree:add(pf_type,    tvbuf:range(0,1))
 
-    local nebula_type = bit32.band(tvbuf:range(0,1):uint(), 0x0F)
+    local nebula_type = bit.band(tvbuf:range(0,1):uint(), 0x0F)
     if nebula_type == 0 then
         local stage = tvbuf(8,8):uint64()
         tree:add(pf_subtype_handshake, tvbuf:range(1,1))


### PR DESCRIPTION
The Nebula Wireshark dissector uses `bit32.band()` when parsing the
Nebula packet type.

On Wireshark builds using Lua 5.4, `bit32` is not available. This causes
packet dissection to fail with the following runtime error, reproduced
with Wireshark 4.6.6:

```text
Lua Error: nebula.lua:65: attempt to index a nil value (global 'bit32')
```

Wireshark provides Lua BitOp globally as `bit` for Lua dissectors, and
documents it as the API to use for maximum backwards compatibility across
supported Lua versions.

Reference: https://www.wireshark.org/docs/wsdg_html_chunked/_bitwise_operations.html

This replaces `bit32.band()` with `bit.band()`.