### PR TITLE
v1.11.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ See the [v1.11.0](https://github.com/slackhq/nebula/milestone/25?closed=1) miles
   (`level=INFO`), trace prints as `level=DEBUG-4`, timestamps are always RFC3339Nano and `logging.timestamp_format`
   is ignored, and some messages were reworded. Review any log parsing before upgrading. This is also an API break
   for embedders, as constructors now take a `*slog.Logger`. (#1672, #1734, #1621)
-- `firewall.inbound_action` and `firewall.outbound_action` were each being applied to the opposite direction, that
-  is now corrected. If you set either of these you are getting the behavior of the other one today and likely want
-  to swap them before upgrading. (#1798)
+- `firewall.inbound_action` and `firewall.outbound_action` (used to set reject vs. drop policy) were each being
+  applied to the opposite direction, that is now corrected. This only affects how blocked packets are answered, not
+  which packets the firewall allows or denies. If you set either of these you are getting the behavior of the other
+  one today and likely want to swap them before upgrading. (#1798)
 - On Windows, Nebula now installs WFP PERMIT filters for the nebula adapter and the listener port by default. WFP
   sits below Windows Defender Firewall, so any WDF inbound rules you rely on for either will no longer apply. Set
   `tun.windows_bypass_wdf` and `listen.windows_bypass_wdf` to false to leave WDF in charge. (#1710)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ See the [v1.11.0](https://github.com/slackhq/nebula/milestone/25?closed=1) miles
 - Search for both `config.yml` and `config.yaml` in service and command line modes. (#1717)
 - Add version labels to the Docker/OCI images. (#1772)
 - Add an `sshd.sandbox_dir` option to confine the SSH debug server's file writes to a directory. (#1622)
+- Rebind the listener and re-query lighthouses on macOS when the underlay network changes, so devices moving
+  between wifi and wired or between networks recover without waiting for dead tunnel detection. Controlled by
+  `listen.rebind_on_network_change` (default `true`, not reloadable). (#1816)
 
 ### Changed
 
@@ -37,25 +40,37 @@ See the [v1.11.0](https://github.com/slackhq/nebula/milestone/25?closed=1) miles
   requested type, so clients that query `AAAA` first (busybox/Alpine) fall through to `A`. (#1668)
 - Record the local host's details in the DNS server. (#1716)
 - Install Windows unsafe routes as link routes. (#1709)
-- Reduce relay handshake log spam. (#1733, #1765)
-- Start, stop, and reload subsystems (DNS, stats, conntrack, ssh, punchy) cleanly without leaking goroutines. (#1640, #1661, #1667, #1669, #1708)
+- Reduce relay handshake log spam, and only log a handshake send error at error level when the remote list
+  changes. (#1733, #1765, #1810)
+- Start, stop, and reload subsystems (DNS, stats, conntrack, ssh, punchy) cleanly without leaking goroutines. (#1640, #1654, #1661, #1667, #1669, #1708, #1806, #1815)
+- `Control` is now safe to stop and wait on from any lifecycle state, and a new `Control.Wait` blocks until nebula
+  has fully stopped and returns the first fatal reader error. Failed starts release the udp sockets and tun fd
+  instead of leaking them. (#1794)
 - Trigger an immediate lighthouse update when reconnecting to or adding a lighthouse instead of waiting for the next update tick. (#1645)
 - Bring the Darwin and OpenBSD tun implementations in line with the other BSDs. (#1703)
-- Various dependency updates. (#1604, #1617, #1618, #1627, #1628, #1652, #1664, #1665, #1697, #1721, #1732, #1742, #1743, #1750, #1763, #1771, #1782)
+- Various dependency updates. (#1586, #1587, #1604, #1617, #1618, #1627, #1628, #1629, #1652, #1664, #1665, #1697, #1721, #1732, #1742, #1743, #1750, #1763, #1771, #1782, #1800, #1807)
 
 ### Fixed
 
 - Fix a data race on a host's remote address that could send packets to the wrong address during a roam. (#1773)
 - Fix tunnels that could permanently escape connection manager monitoring. (#1752)
 - Fix a crash when reloading the SSH server's trusted keys. (#1787)
-- Fix hostmap corruption when deleting a host with multiple overlay addresses. (#1788)
+- Fix hostmap corruption when a host has multiple overlay addresses. Each address now gets its own list instead of
+  a single shared chain, which also fixes two latent bugs on the add and makePrimary paths. (#1788, #1790)
 - Apply `remote_allow_list` IPv4 rules to 4-in-6 mapped addresses. (#1786)
 - Don't panic in the DNS server on a short or empty query name. (#1635)
 - Advance the replay window on relayed packets so a relay drops replayed frames instead of re-forwarding them. (#1751)
 - Fix a race in relay state handling. (#1753)
+- Lock replay window updates so concurrent readers can't corrupt it. (#1802)
 - Reject malformed handshakes more reliably, including invalid ed25519 key lengths. (#1601, #1756)
 - Properly handle `closetunnel` packets. (#1638)
 - Fix an IPv6 extension-header length overflow that could make the firewall parse the wrong protocol and ports. (#1789)
+- Correct the directionality of `firewall.inbound_action` and `firewall.outbound_action`, they were each applied to
+  the opposite direction. If you set either of these you likely want to swap them. (#1798)
+- Fix relay re-establishment when a handshake arrives over a relay entry that a one-sided teardown left
+  `Disestablished`, which silently dropped every send until dead tunnel detection forced a re-handshake. (#1805)
+- Don't build new relay state on a tunnel that was just discarded. (#1796)
+- Don't delete the wrong pending hostinfo in the handshake manager. (#1811)
 - Don't call the packet reader after a UDP error on Darwin. (#1755)
 - Open the FreeBSD tun device non blocking. (#1666)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,17 +20,26 @@ See the [v1.11.0](https://github.com/slackhq/nebula/milestone/25?closed=1) miles
 - `firewall.inbound_action` and `firewall.outbound_action` were each being applied to the opposite direction, that
   is now corrected. If you set either of these you are getting the behavior of the other one today and likely want
   to swap them before upgrading. (#1798)
+- On Windows, Nebula now installs WFP PERMIT filters for the nebula adapter and the listener port by default. WFP
+  sits below Windows Defender Firewall, so any WDF inbound rules you rely on for either will no longer apply. Set
+  `tun.windows_bypass_wdf` and `listen.windows_bypass_wdf` to false to leave WDF in charge. (#1710)
+- On Windows, the nebula device is now set to the `private` network category instead of whatever Windows decided,
+  which is usually `Public`. This makes the host firewall less restrictive on the overlay. Set
+  `tun.network_category` to `unset` to keep the old behavior. (#1710)
+- Reject packets for non-TCP now use ICMP code 13, communication administratively prohibited, instead of code 3,
+  port unreachable. Anything keying off the old code needs updating. (#1766, #1768)
+- The SSH debug server's profiling commands are now confined to `sshd.sandbox_dir`, which defaults to
+  `$TMP/nebula-debug`. Relative paths resolve inside it and absolute paths outside it are rejected, so anything
+  scripting `start-cpu-profile`, `save-heap-profile`, or `save-mutex-profile` with a path elsewhere needs the
+  directory set. The directory is not created for you. (#1622)
 
 ### Added
 
-- Set the network category of the nebula device on Windows so the host firewall no longer treats it as `Public`,
-  with an option (default `true`) to bypass Windows Defender Firewall on the nebula adapter. (#1710)
 - Sign the Windows release binaries. (#1718)
 - Generate IPv6 reject packets, matching the existing IPv4 behavior. (#1766, #1767, #1768)
 - Accept `-` in `nebula-cert` to read from stdin or write to stdout. (#1714)
 - Search for both `config.yml` and `config.yaml` in service and command line modes. (#1717)
 - Add version labels to the Docker/OCI images. (#1772)
-- Add an `sshd.sandbox_dir` option to confine the SSH debug server's file writes to a directory. (#1622)
 - Rebind the listener and re-query lighthouses on macOS when the underlay network changes, so devices moving
   between wifi and wired or between networks recover without waiting for dead tunnel detection. Controlled by
   `listen.rebind_on_network_change` (default `true`, not reloadable). (#1816)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - unreleased
+
+See the [v1.11.0](https://github.com/slackhq/nebula/milestone/25?closed=1) milestone for a complete list of changes.
+
+### Added
+
+- Set the network category of the nebula device on Windows so the host firewall no longer treats it as `Public`,
+  with an option (default `true`) to bypass Windows Defender Firewall on the nebula adapter. (#1710)
+- Sign the Windows release binaries. (#1718)
+- Generate IPv6 reject packets, matching the existing IPv4 behavior. (#1766, #1767, #1768)
+- Accept `-` in `nebula-cert` to read from stdin or write to stdout. (#1714)
+- Search for both `config.yml` and `config.yaml` in service and command line modes. (#1717)
+- Add version labels to the Docker/OCI images. (#1772)
+- Add an `sshd.sandbox_dir` option to confine the SSH debug server's file writes to a directory. (#1622)
+
+### Changed
+
+- **NOTE**: Logging has switched from logrus to Go's structured `slog`. Log output changes: levels are upper case
+  (`level=INFO`), trace prints as `level=DEBUG-4`, timestamps are always RFC3339Nano and `logging.timestamp_format`
+  is ignored, and some messages were reworded. Review any log parsing before upgrading. This is also an API break
+  for embedders, as constructors now take a `*slog.Logger`. (#1672, #1734, #1621)
+- Reload the firewall when the unsafe networks in the certificate change. (#1719)
+- Reconfigure, start, and stop the stats listener on a config reload instead of requiring a restart. (#1670)
+- Update a static host's addresses when they change on reload. (#1713)
+- Don't require a port on ICMP firewall rules. (#1609)
+- Connection track ICMP traffic. (#1602)
+- Return `NODATA` instead of `NXDOMAIN` from the DNS server for a name that exists but has no record of the
+  requested type, so clients that query `AAAA` first (busybox/Alpine) fall through to `A`. (#1668)
+- Record the local host's details in the DNS server. (#1716)
+- Install Windows unsafe routes as link routes. (#1709)
+- Reduce relay handshake log spam. (#1733, #1765)
+- Start, stop, and reload subsystems (DNS, stats, conntrack, ssh, punchy) cleanly without leaking goroutines. (#1640, #1661, #1667, #1669, #1708)
+- Trigger an immediate lighthouse update when reconnecting to or adding a lighthouse instead of waiting for the next update tick. (#1645)
+- Bring the Darwin and OpenBSD tun implementations in line with the other BSDs. (#1703)
+- Various dependency updates. (#1604, #1617, #1618, #1627, #1628, #1652, #1664, #1665, #1697, #1721, #1732, #1742, #1743, #1750, #1763, #1771, #1782)
+
+### Fixed
+
+- Fix a data race on a host's remote address that could send packets to the wrong address during a roam. (#1773)
+- Fix tunnels that could permanently escape connection manager monitoring. (#1752)
+- Fix a crash when reloading the SSH server's trusted keys. (#1787)
+- Fix hostmap corruption when deleting a host with multiple overlay addresses. (#1788)
+- Apply `remote_allow_list` IPv4 rules to 4-in-6 mapped addresses. (#1786)
+- Don't panic in the DNS server on a short or empty query name. (#1635)
+- Advance the replay window on relayed packets so a relay drops replayed frames instead of re-forwarding them. (#1751)
+- Fix a race in relay state handling. (#1753)
+- Reject malformed handshakes more reliably, including invalid ed25519 key lengths. (#1601, #1756)
+- Properly handle `closetunnel` packets. (#1638)
+- Fix an IPv6 extension-header length overflow that could make the firewall parse the wrong protocol and ports. (#1789)
+- Don't call the packet reader after a UDP error on Darwin. (#1755)
+- Open the FreeBSD tun device non blocking. (#1666)
+
 ## [1.10.3] - 2026-02-06
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.11.0] - unreleased
+## [1.11.0] - 2026-07-23
 
 See the [v1.11.0](https://github.com/slackhq/nebula/milestone/25?closed=1) milestone for a complete list of changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 See the [v1.11.0](https://github.com/slackhq/nebula/milestone/25?closed=1) milestone for a complete list of changes.
 
+### Breaking
+
+- Logging has switched from logrus to Go's structured `slog`. Log output changes: levels are upper case
+  (`level=INFO`), trace prints as `level=DEBUG-4`, timestamps are always RFC3339Nano and `logging.timestamp_format`
+  is ignored, and some messages were reworded. Review any log parsing before upgrading. This is also an API break
+  for embedders, as constructors now take a `*slog.Logger`. (#1672, #1734, #1621)
+- `firewall.inbound_action` and `firewall.outbound_action` were each being applied to the opposite direction, that
+  is now corrected. If you set either of these you are getting the behavior of the other one today and likely want
+  to swap them before upgrading. (#1798)
+
 ### Added
 
 - Set the network category of the nebula device on Windows so the host firewall no longer treats it as `Public`,
@@ -27,10 +37,6 @@ See the [v1.11.0](https://github.com/slackhq/nebula/milestone/25?closed=1) miles
 
 ### Changed
 
-- **NOTE**: Logging has switched from logrus to Go's structured `slog`. Log output changes: levels are upper case
-  (`level=INFO`), trace prints as `level=DEBUG-4`, timestamps are always RFC3339Nano and `logging.timestamp_format`
-  is ignored, and some messages were reworded. Review any log parsing before upgrading. This is also an API break
-  for embedders, as constructors now take a `*slog.Logger`. (#1672, #1734, #1621)
 - Reload the firewall when the unsafe networks in the certificate change. (#1719)
 - Reconfigure, start, and stop the stats listener on a config reload instead of requiring a restart. (#1670)
 - Update a static host's addresses when they change on reload. (#1713)
@@ -48,6 +54,7 @@ See the [v1.11.0](https://github.com/slackhq/nebula/milestone/25?closed=1) miles
   instead of leaking them. (#1794)
 - Trigger an immediate lighthouse update when reconnecting to or adding a lighthouse instead of waiting for the next update tick. (#1645)
 - Bring the Darwin and OpenBSD tun implementations in line with the other BSDs. (#1703)
+- Update to build against go v1.26. (#1818)
 - Various dependency updates. (#1586, #1587, #1604, #1617, #1618, #1627, #1628, #1629, #1652, #1664, #1665, #1697, #1721, #1732, #1742, #1743, #1750, #1763, #1771, #1782, #1800, #1807)
 
 ### Fixed
@@ -65,8 +72,6 @@ See the [v1.11.0](https://github.com/slackhq/nebula/milestone/25?closed=1) miles
 - Reject malformed handshakes more reliably, including invalid ed25519 key lengths. (#1601, #1756)
 - Properly handle `closetunnel` packets. (#1638)
 - Fix an IPv6 extension-header length overflow that could make the firewall parse the wrong protocol and ports. (#1789)
-- Correct the directionality of `firewall.inbound_action` and `firewall.outbound_action`, they were each applied to
-  the opposite direction. If you set either of these you likely want to swap them. (#1798)
 - Fix relay re-establishment when a handshake arrives over a relay entry that a one-sided teardown left
   `Disestablished`, which silently dropped every send until dead tunnel detection forced a re-handshake. (#1805)
 - Don't build new relay state on a tunnel that was just discarded. (#1796)


### PR DESCRIPTION
Update changelog for v1.11.0

See the [v1.11.0](https://github.com/slackhq/nebula/milestone/25?closed=1) milestone.

There are six backwards compat breaking changes in this release, all called out in a new `Breaking` section at the
top of the 1.11.0 entry:

- Logging moved from logrus to `slog`, log output format changes and `logging.timestamp_format` is ignored. (#1672, #1734, #1621)
- `firewall.inbound_action` and `firewall.outbound_action` were each applied to the opposite direction, now corrected. (#1798)
- Windows WDF is bypassed by default for the nebula adapter and the listener port. (#1710)
- Windows nebula device is now set to the `private` network category. (#1710)
- Non-TCP reject packets moved from ICMP code 3 to code 13. (#1766, #1768)
- SSH debug server profiling commands are confined to `sshd.sandbox_dir`. (#1622)

v1.11 specific changes
- [x] f8775bb Use go 1.26 (latest 1.26.5) (#1818)
- [x] 7902ce6 Rebind for MacOS (#1816)
- [x] c2fbe21 Fix a test race, make dns server reload/restart safer (#1815)
- [x] a99699e before removing a pending hostinfo in handshake_manager, make sure it's the one we wanted to delete (#1811)
- [x] 15f0f0d Be less verbose with handshake send errors (#1810)
- [x] 147c202 Swap back to a blocking udp socket, test `shutdown(2)` (#1806)
- [x] e290a68 Fix relay re-establishment for handshake on Disestablised entry (#1805)
- [x] 3615a79 add locks around replay window updates (#1802)
- [x] 861d3aa correct directionality of firewall.inbound_action and firewall.outbound_action (#1798)
- [x] 8673386 don't make new relay state on a just-discarded tunnel (#1796)
- [x] ab736e4 Make Control safe to stop and wait on from any lifecycle state (#1794)
- [x] 384610f hostmap: replace the shared next/prev hostinfo chain with independent per-address lists (#1790)
- [x] c1eea11 fix firewall port/proto bypass in parseV6 from uint8 extension-header length overflow (#1789)
- [x] 1e66c0d hostmap: unlink a multi-vpnAddr hostinfo from the shared chain exactly once on delete (#1788)
- [x] e5c0fda Darwin and openbsd in line with the other bsds for tun support (#1703)
- [x] 7bd0bc2 sshd: guard trustedKeys/trustedCAs with a mutex to fix a concurrent map crash on reload (#1787)
- [x] 942ee52 lighthouse: unmap 4-in-6 addresses so remote_allow_list v4 rules apply (#1786)
- [x] 0a95391 Make HostInfo.remote atomic to fix torn reads on the send path (#1773)
- [x] 184cdc8 Add OCI image labels with version info (#1772)
- [x] 7d3166a cleanup ipv6 iputil helpers / skip reject for ICMP error packets and fragments (#1768)
- [x] fe1c568 add IPv6 support to CreateICMPEchoResponse (#1767)
- [x] e4cc80a add IPv6 reject packet generation (#1766)
- [x] 16b302c Relay log fix (#1765)
- [x] 2e9117d fix tunnels that could permanently escape connection-manager monitoring (#1752)
- [x] a690c90 improve rejection of malformed handshakes (#1756)
- [x] 3db406b fix a race in RelayState.CopyRelayIps (#1753)
- [x] eaad489 udp_darwin: don't call the EncReader on a UDP error (#1755)
- [x] e6032f8 correctly record window counters for relayed packets in a tunnel (#1751)
- [x] 3a95495 Fix duplicate log fields which slog duplicates (#1734)
- [x] 873f94f Reduce relay log spam (#1733)
- [x] 04dea41 Make firewall reload when unsafe networks in the cert changes (#1719)
- [x] ffd5249 Search for config.yaml/yml in both service and cli mode (#1717)
- [x] 625f58b Record my local details in the dns server if enabled (#1716)
- [x] 3c121e7 Allow for `-` to stand in for stdin/out (#1714)
- [x] 6c7ebb0 Reset static host list addresses on change (#1713)
- [x] 398d67e Windows code signing (#1718)
- [x] 696903d Add a way to set the network type on windows + tests (#1710)
- [x] c82db21 Change windows unsafe routes to link routes, fix sshd reload bug (#1709)
- [x] a82a8dc don't panic on bad ed25519 key lengths (#1601)
- [x] 213dd46 Stop leaking goroutines past Control.Stop, consolidate punching in Punchy (#1708)
- [x] 1ab1f71 Make stats a server we can reconfigure and start/stop (#1670)
- [x] d0f02ba Switch to slog, remove logrus (#1672)
- [x] db85d61 SSH handshake in goroutine and defer close (#1640)
- [x] b319423 udp_linux: wrap socket operations with syscall.RawConn for clean teardown (#1654)
- [x] 2a1cc62 fix: guard QueryCert against panic on short/empty QNAME (#1635)
- [x] e753e6e Immediate Lighthouse update after reconfig/reconnect (#1645)
- [x] 32a7c04 Return NODATA instead of NXDOMAIN for missing record types (#1668)
- [x] 8c50fc3 Plug the conntrack cache ticker leak and nebula-service log.Fatal calls (#1669)
- [x] 2f4532f No more dns globals, proper cleanup on shutdown (#1667)
- [x] 8c71f2f FreeBSD tun needs to be non blocking as well (#1666)
- [x] e80b983 Remove more os.Exit calls and give a more reliable wait for stop function (#1661)
- [x] f858795 add sshd.sandbox_dir config option (#1622)
- [x] 91d1f46 properly handle closetunnel packets (#1638)
- [x] 7760cce fix logging copy pasta (#1621)
- [x] 51308b8 connection-track ICMP traffic (#1602)
- [x] 353ad1f firewall: icmp no longer requires a port spec (#1609)

PRs I chose not to document in the changelog:

Dependency bumps (covered collectively by the "Various dependency updates" line)
- #1807
- #1800
- #1782
- #1771
- #1763
- #1750
- #1743
- #1742
- #1732
- #1721
- #1697
- #1665
- #1664
- #1652
- #1629
- #1628
- #1627
- #1618
- #1617
- #1604
- #1587
- #1586

Input validation, refactors, tests, CI, and tooling
- #1814 (rootless nebula docs in the example service script)
- #1799
- #1795
- #1793 (removes a stray Println from unreleased #1703)
- #1785
- #1784 (fixes unreleased #1766)
- #1779
- #1778
- #1777
- #1776
- #1764
- #1754
- #1730
- #1728
- #1724
- #1715
- #1711
- #1707
- #1705
- #1702
- #1701
- #1700
- #1691
- #1688
- #1681
- #1663
- #1657
- #1656
- #1655
- #1653
- #1650
- #1644
- #1642
- #1641
- #1632
- #1626
- #1610
- #1608

Still open on the milestone, not yet merged (revisit before tagging):
- #1696 native Golang fips140 mode
