### PR TITLE
Add <nebula> self-token for bind addresses

### DIFF
--- a/dns_server.go
+++ b/dns_server.go
@@ -37,14 +37,23 @@ type dnsServer struct {
 	enabled atomic.Bool
 
 	serverMu sync.Mutex
-	server   *dns.Server
-	// started is closed once `server` has finished binding (or after
-	// ListenAndServe returns on a bind failure). Stop waits on it before
-	// calling Shutdown to avoid the miekg/dns "server not started" race
-	// where a Shutdown that arrives before bind completes is silently
-	// ignored, leaving the listener running forever.
+	// listeners holds one entry per bound address. A single listen address
+	// yields one entry; a "<nebula>" self-token expands to one per VPN
+	// address (bind-ALL). addr keeps the RAW joined config string so reload's
+	// sameAddr comparison is unaffected by expansion.
+	listeners []*dnsListener
+	addr      string
+}
+
+// dnsListener pairs a dns.Server with its started channel. The channel is
+// closed once the server has finished binding (or after ListenAndServe returns
+// on a bind failure). Stop waits on it before calling Shutdown to avoid the
+// miekg/dns "server not started" race where a Shutdown that arrives before bind
+// completes is silently ignored, leaving the listener running forever. Each
+// listener carries its own channel so the race fix holds per bound address.
+type dnsListener struct {
+	server  *dns.Server
 	started chan struct{}
-	addr    string
 }
 
 // newDnsServerFromConfig builds a dnsServer, applies the initial config, and
@@ -97,8 +106,8 @@ func (d *dnsServer) reload(c *config.C, initial bool) error {
 	newAddr := getDnsServerAddr(c)
 
 	d.serverMu.Lock()
-	running := d.server
-	runningStarted := d.started
+	runningListeners := d.listeners
+	running := len(runningListeners) > 0
 	sameAddr := d.addr == newAddr
 	d.addr = newAddr
 	d.enabled.Store(enabled)
@@ -112,7 +121,7 @@ func (d *dnsServer) reload(c *config.C, initial bool) error {
 	}
 
 	if !enabled {
-		if running != nil {
+		if running {
 			d.Stop()
 		}
 		// Drop any records that accumulated while enabled; a later re-enable
@@ -121,11 +130,11 @@ func (d *dnsServer) reload(c *config.C, initial bool) error {
 		return nil
 	}
 
-	if running == nil {
+	if !running {
 		// Was disabled (or never started); bring it up now.
 		go d.Start()
 	} else if !sameAddr {
-		d.shutdownServer(running, runningStarted, "reload")
+		d.shutdownListeners(runningListeners, "reload")
 		// Old Start goroutine has now exited; bring up a fresh listener on the new address.
 		go d.Start()
 	}
@@ -133,6 +142,14 @@ func (d *dnsServer) reload(c *config.C, initial bool) error {
 	// Refresh the self entry every enabled reload so cert renewals that change our name or VPN addresses are picked up.
 	d.seedSelf()
 	return nil
+}
+
+// shutdownListeners shuts down every listener in the slice, waiting for each to
+// finish binding first so Shutdown actually stops it rather than no-oping.
+func (d *dnsServer) shutdownListeners(listeners []*dnsListener, reason string) {
+	for _, ln := range listeners {
+		d.shutdownServer(ln.server, ln.started, reason)
+	}
 }
 
 // shutdownServer waits for the server to finish binding (so Shutdown actually
@@ -149,71 +166,106 @@ func (d *dnsServer) shutdownServer(srv *dns.Server, started chan struct{}, reaso
 	}
 }
 
-// Start binds and serves the DNS responder. Blocks until Stop is called or
-// the listener errors. Safe to call when DNS is disabled (returns
-// immediately). This is what Control.dnsStart points at.
+// Start binds and serves the DNS responder. Blocks until Stop is called or the
+// listeners error. Safe to call when DNS is disabled (returns immediately).
+// This is what Control.dnsStart points at.
 //
 // Must be invoked after the tun device is active so that lighthouse.dns.host
-// may bind to a nebula IP.
+// may bind to a nebula IP. That timing is also what lets the "<nebula>"
+// self-token expand to this host's VPN addresses (bind-ALL): expansion happens
+// here, at listener-start, reading the reload-safe cert state.
 func (d *dnsServer) Start() {
 	if !d.enabled.Load() {
 		return
 	}
 
-	started := make(chan struct{})
 	d.serverMu.Lock()
 	if d.ctx.Err() != nil {
 		d.serverMu.Unlock()
 		return
 	}
-	addr := d.addr
-	server := &dns.Server{
-		Addr:              addr,
-		Net:               "udp",
-		Handler:           d.mux,
-		NotifyStartedFunc: func() { close(started) },
-	}
-	d.server = server
-	d.started = started
+	rawAddr := d.addr
 	d.serverMu.Unlock()
 
-	// Per-invocation ctx watcher. Exits when Start does, so we don't leak a
-	// watcher per reload-driven restart.
+	addrs, err := resolveSelfListenAddrs(rawAddr, d.pki.vpnAddrs())
+	if err != nil {
+		d.l.Warn("Failed to run the DNS responder", "error", err)
+		return
+	}
+	d.startListeners(addrs)
+}
+
+// startListeners binds and serves one dns.Server per already-expanded address,
+// blocking until all of them return. Split from Start so tests can drive the
+// multi-listener machinery with concrete addresses. A bind failure on one
+// address is logged and the remaining listeners keep serving (log-and-continue,
+// matching the single-listener behavior this refactor grew out of).
+func (d *dnsServer) startListeners(addrs []string) {
+	listeners := make([]*dnsListener, len(addrs))
+	for i, a := range addrs {
+		started := make(chan struct{})
+		listeners[i] = &dnsListener{
+			started: started,
+			server: &dns.Server{
+				Addr:              a,
+				Net:               "udp",
+				Handler:           d.mux,
+				NotifyStartedFunc: func() { close(started) },
+			},
+		}
+	}
+
+	d.serverMu.Lock()
+	if d.ctx.Err() != nil {
+		d.serverMu.Unlock()
+		return
+	}
+	d.listeners = listeners
+	d.serverMu.Unlock()
+
+	// Per-invocation ctx watcher. Exits when startListeners does, so we don't
+	// leak a watcher per reload-driven restart.
 	done := make(chan struct{})
 	go func() {
 		select {
 		case <-d.ctx.Done():
-			d.shutdownServer(server, started, "shutdown")
+			d.shutdownListeners(listeners, "shutdown")
 		case <-done:
 		}
 	}()
 
-	d.l.Info("Starting DNS responder", "dnsListener", addr)
-	err := server.ListenAndServe()
+	var wg sync.WaitGroup
+	for _, ln := range listeners {
+		wg.Add(1)
+		go func(ln *dnsListener) {
+			defer wg.Done()
+			d.l.Info("Starting DNS responder", "dnsListener", ln.server.Addr)
+			err := ln.server.ListenAndServe()
+
+			// If the listener never bound (bind error) NotifyStartedFunc never
+			// fires, so close started here to release any waiter on it.
+			select {
+			case <-ln.started:
+			default:
+				close(ln.started)
+			}
+
+			if err != nil {
+				d.l.Warn("Failed to run the DNS responder", "error", err, "dnsListener", ln.server.Addr)
+			}
+		}(ln)
+	}
+	wg.Wait()
 	close(done)
-
-	// If the listener never bound (bind error) NotifyStartedFunc never fires,
-	// so close started here to release any Stop caller waiting on it.
-	select {
-	case <-started:
-	default:
-		close(started)
-	}
-
-	if err != nil {
-		d.l.Warn("Failed to run the DNS responder", "error", err)
-	}
 }
 
-// Stop shuts down the active server, if any. Idempotent.
+// Stop shuts down all active listeners, if any. Idempotent.
 func (d *dnsServer) Stop() {
 	d.serverMu.Lock()
-	srv := d.server
-	started := d.started
-	d.server = nil
-	d.started = nil
+	listeners := d.listeners
+	d.listeners = nil
 	d.serverMu.Unlock()
-	d.shutdownServer(srv, started, "stop")
+	d.shutdownListeners(listeners, "stop")
 }
 
 // Query returns the address for the given name and query type. The second

--- a/dns_server.go
+++ b/dns_server.go
@@ -43,6 +43,12 @@ type dnsServer struct {
 	// sameAddr comparison is unaffected by expansion.
 	listeners []*dnsListener
 	addr      string
+	// startGen tags each Start attempt so the one that stops serving (or bails
+	// before binding) only clears d.listeners if a newer Start hasn't taken
+	// over. Without this, a Start that fails to bind (or expands to zero VPN
+	// addrs) would leave stale dead listeners in d.listeners, making reload see
+	// running==true and no-op every same-addr SIGHUP, wedging DNS permanently.
+	startGen uint64
 }
 
 // dnsListener pairs a dns.Server with its started channel. The channel is
@@ -185,14 +191,30 @@ func (d *dnsServer) Start() {
 		return
 	}
 	rawAddr := d.addr
+	d.startGen++
+	myGen := d.startGen
 	d.serverMu.Unlock()
 
 	addrs, err := resolveSelfListenAddrs(rawAddr, d.pki.vpnAddrs())
 	if err != nil {
 		d.l.Warn("Failed to run the DNS responder", "error", err)
+		// Drop the now-defunct listeners a prior reload shut down, so a later
+		// same-addr SIGHUP retries instead of no-oping on stale state.
+		d.clearListenersIfCurrent(myGen)
 		return
 	}
-	d.startListeners(addrs)
+	d.startListeners(addrs, myGen)
+}
+
+// clearListenersIfCurrent nils out d.listeners, but only if no newer Start has
+// superseded this one (identified by gen). This lets the Start that stopped
+// serving reset the running state without clobbering a concurrent restart.
+func (d *dnsServer) clearListenersIfCurrent(gen uint64) {
+	d.serverMu.Lock()
+	if d.startGen == gen {
+		d.listeners = nil
+	}
+	d.serverMu.Unlock()
 }
 
 // startListeners binds and serves one dns.Server per already-expanded address,
@@ -200,7 +222,7 @@ func (d *dnsServer) Start() {
 // multi-listener machinery with concrete addresses. A bind failure on one
 // address is logged and the remaining listeners keep serving (log-and-continue,
 // matching the single-listener behavior this refactor grew out of).
-func (d *dnsServer) startListeners(addrs []string) {
+func (d *dnsServer) startListeners(addrs []string, myGen uint64) {
 	listeners := make([]*dnsListener, len(addrs))
 	for i, a := range addrs {
 		started := make(chan struct{})
@@ -216,7 +238,8 @@ func (d *dnsServer) startListeners(addrs []string) {
 	}
 
 	d.serverMu.Lock()
-	if d.ctx.Err() != nil {
+	if d.ctx.Err() != nil || d.startGen != myGen {
+		// Shutting down, or a newer Start has superseded us; don't install.
 		d.serverMu.Unlock()
 		return
 	}
@@ -257,6 +280,11 @@ func (d *dnsServer) startListeners(addrs []string) {
 	}
 	wg.Wait()
 	close(done)
+
+	// All listeners have stopped serving. Clear the running state (unless a
+	// newer Start took over) so a same-addr reload re-runs Start instead of
+	// treating the dead listeners as live. Matches stats' retry-on-unclean-exit.
+	d.clearListenersIfCurrent(myGen)
 }
 
 // Stop shuts down all active listeners, if any. Idempotent.

--- a/dns_server_test.go
+++ b/dns_server_test.go
@@ -135,6 +135,16 @@ func Test_getDnsServerAddr(t *testing.T) {
 		},
 	}
 	assert.Equal(t, "[::]:1", getDnsServerAddr(c))
+
+	// The "<nebula>" self-token must pass through raw here; expansion happens
+	// later at listener start, not during addr construction.
+	c.Settings["lighthouse"] = map[string]any{
+		"dns": map[string]any{
+			"host": "<nebula>",
+			"port": "53",
+		},
+	}
+	assert.Equal(t, "<nebula>:53", getDnsServerAddr(c))
 }
 
 func newTestDnsServer(t *testing.T) (*dnsServer, *config.C) {
@@ -170,7 +180,7 @@ func TestDnsServer_reload_initial_disabled(t *testing.T) {
 	require.NoError(t, ds.reload(c, true))
 	assert.False(t, ds.enabled.Load())
 	assert.Equal(t, "127.0.0.1:0", ds.addr)
-	assert.Nil(t, ds.server)
+	assert.Empty(t, ds.listeners)
 }
 
 func TestDnsServer_reload_initial_enabled(t *testing.T) {
@@ -181,7 +191,7 @@ func TestDnsServer_reload_initial_enabled(t *testing.T) {
 	assert.True(t, ds.enabled.Load())
 	assert.Equal(t, "127.0.0.1:0", ds.addr)
 	// initial never starts a runner; that's Control.Start's job
-	assert.Nil(t, ds.server)
+	assert.Empty(t, ds.listeners)
 }
 
 func TestDnsServer_reload_initial_serveDnsWithoutLighthouse(t *testing.T) {
@@ -194,14 +204,39 @@ func TestDnsServer_reload_initial_serveDnsWithoutLighthouse(t *testing.T) {
 }
 
 func TestDnsServer_reload_sameAddr_noOp(t *testing.T) {
+	port := freeUDPPort(t)
 	ds, c := newTestDnsServer(t)
-	setDnsConfig(c, "127.0.0.1", "0", true, true)
-
+	setDnsConfig(c, "127.0.0.1", port, true, true)
 	require.NoError(t, ds.reload(c, true))
-	// No server running yet, no addr change. Reload should not spawn anything.
+
+	done := make(chan struct{})
+	go func() {
+		ds.Start()
+		close(done)
+	}()
+	waitForBind(t, ds)
+
+	ds.serverMu.Lock()
+	before := ds.listeners
+	ds.serverMu.Unlock()
+	require.Len(t, before, 1)
+
+	// Same address: reload must not tear down and rebuild the listener.
 	require.NoError(t, ds.reload(c, false))
 	assert.True(t, ds.enabled.Load())
-	assert.Nil(t, ds.server)
+
+	ds.serverMu.Lock()
+	after := ds.listeners
+	ds.serverMu.Unlock()
+	require.Len(t, after, 1)
+	assert.Same(t, before[0], after[0], "same-addr reload should not restart the listener")
+
+	ds.Stop()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after Stop")
+	}
 }
 
 func TestDnsServer_StartStop_lifecycle(t *testing.T) {
@@ -219,20 +254,7 @@ func TestDnsServer_StartStop_lifecycle(t *testing.T) {
 		close(done)
 	}()
 
-	waitFor(t, func() bool {
-		ds.serverMu.Lock()
-		started := ds.started
-		ds.serverMu.Unlock()
-		if started == nil {
-			return false
-		}
-		select {
-		case <-started:
-			return true
-		default:
-			return false
-		}
-	})
+	waitForBind(t, ds)
 
 	ds.Stop()
 	select {
@@ -389,6 +411,96 @@ func TestDnsServer_reload_disable_stopsRunningServer(t *testing.T) {
 	assert.False(t, ds.enabled.Load())
 }
 
+func TestDnsServer_reload_tokenHost_sameAddr(t *testing.T) {
+	ds, c := newTestDnsServer(t)
+	setDnsConfig(c, "<nebula>", "53", true, true)
+	require.NoError(t, ds.reload(c, true))
+	// The raw token string is what gets stored and compared, so expansion
+	// never confuses reload's change detection.
+	assert.Equal(t, "<nebula>:53", ds.addr)
+
+	// An identical reload is a no-op: no restart, nothing bound.
+	require.NoError(t, ds.reload(c, false))
+	assert.Empty(t, ds.listeners)
+}
+
+func TestDnsServer_Start_tokenNoVpnAddrs_noListeners(t *testing.T) {
+	ds, c := newTestDnsServer(t)
+	// No pki -> nil cert state -> nil VPN addrs, so the token cannot expand and
+	// Start must log-and-return without binding anything.
+	setDnsConfig(c, "<nebula>", "0", true, true)
+	require.NoError(t, ds.reload(c, true))
+	ds.enabled.Store(true)
+
+	ds.Start()
+	assert.Empty(t, ds.listeners)
+}
+
+// TestDnsServer_startListeners_multiAddr is the regression test for the
+// per-listener started-chan machinery: several servers bind, each answers
+// queries via the shared mux, and Stop tears all of them down without hanging.
+func TestDnsServer_startListeners_multiAddr(t *testing.T) {
+	ds, _ := newTestDnsServer(t)
+	ds.enabled.Store(true)
+	ds.Add("multi.example.", []netip.Addr{netip.MustParseAddr("10.9.8.7")})
+
+	addrs := []string{freeUDPPortOn(t, "127.0.0.1")}
+	if v6LoopbackAvailable() {
+		// Exercises IPv6 bracketing end-to-end (the bind-ALL shape a token
+		// with a v6 VPN address produces).
+		addrs = append(addrs, freeUDPPortOn(t, "::1"))
+	}
+
+	done := make(chan struct{})
+	go func() {
+		ds.startListeners(addrs)
+		close(done)
+	}()
+	waitForBind(t, ds)
+	require.Len(t, ds.listeners, len(addrs))
+
+	for _, a := range addrs {
+		resp := queryDNS(t, a, "multi.example.", dns.TypeA)
+		require.NotEmpty(t, resp.Answer, "listener %s should answer", a)
+		assert.Equal(t, "10.9.8.7", resp.Answer[0].(*dns.A).A.String())
+	}
+
+	ds.Stop()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("startListeners did not return after Stop")
+	}
+}
+
+func queryDNS(t *testing.T, addr, name string, qtype uint16) *dns.Msg {
+	t.Helper()
+	m := new(dns.Msg)
+	m.SetQuestion(name, qtype)
+	c := &dns.Client{Net: "udp", Timeout: 2 * time.Second}
+	resp, _, err := c.Exchange(m, addr)
+	require.NoError(t, err)
+	return resp
+}
+
+func v6LoopbackAvailable() bool {
+	conn, err := net.ListenPacket("udp", "[::1]:0")
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+func freeUDPPortOn(t *testing.T, host string) string {
+	t.Helper()
+	conn, err := net.ListenPacket("udp", net.JoinHostPort(host, "0"))
+	require.NoError(t, err)
+	port := conn.LocalAddr().(*net.UDPAddr).Port
+	require.NoError(t, conn.Close())
+	return net.JoinHostPort(host, strconv.Itoa(port))
+}
+
 func freeUDPPort(t *testing.T) string {
 	t.Helper()
 	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
@@ -402,17 +514,19 @@ func waitForBind(t *testing.T, ds *dnsServer) {
 	t.Helper()
 	waitFor(t, func() bool {
 		ds.serverMu.Lock()
-		started := ds.started
+		listeners := ds.listeners
 		ds.serverMu.Unlock()
-		if started == nil {
+		if len(listeners) == 0 {
 			return false
 		}
-		select {
-		case <-started:
-			return true
-		default:
-			return false
+		for _, ln := range listeners {
+			select {
+			case <-ln.started:
+			default:
+				return false
+			}
 		}
+		return true
 	})
 }
 

--- a/dns_server_test.go
+++ b/dns_server_test.go
@@ -419,9 +419,13 @@ func TestDnsServer_reload_tokenHost_sameAddr(t *testing.T) {
 	// never confuses reload's change detection.
 	assert.Equal(t, "<nebula>:53", ds.addr)
 
-	// An identical reload is a no-op: no restart, nothing bound.
+	// An identical reload binds nothing here (nil pki => the token can't expand),
+	// and reload's Start attempt runs in a goroutine, so read under the lock.
 	require.NoError(t, ds.reload(c, false))
-	assert.Empty(t, ds.listeners)
+	ds.serverMu.Lock()
+	got := len(ds.listeners)
+	ds.serverMu.Unlock()
+	assert.Zero(t, got)
 }
 
 func TestDnsServer_Start_tokenNoVpnAddrs_noListeners(t *testing.T) {
@@ -451,9 +455,11 @@ func TestDnsServer_startListeners_multiAddr(t *testing.T) {
 		addrs = append(addrs, freeUDPPortOn(t, "::1"))
 	}
 
+	ds.startGen++
+	gen := ds.startGen
 	done := make(chan struct{})
 	go func() {
-		ds.startListeners(addrs)
+		ds.startListeners(addrs, gen)
 		close(done)
 	}()
 	waitForBind(t, ds)
@@ -471,6 +477,53 @@ func TestDnsServer_startListeners_multiAddr(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("startListeners did not return after Stop")
 	}
+}
+
+// TestDnsServer_Start_resolveError_clearsListeners is the regression test for
+// the reload-wedge: a Start that bails before binding (here, "<nebula>" with no
+// VPN addresses) must clear the defunct listeners a prior reload left behind,
+// otherwise reload sees running==true and no-ops every subsequent same-addr
+// SIGHUP, leaving DNS dead forever.
+func TestDnsServer_Start_resolveError_clearsListeners(t *testing.T) {
+	ds, _ := newTestDnsServer(t)
+	ds.enabled.Store(true)
+	// nil pki => vpnAddrs() is empty => "<nebula>" expansion errors.
+	ds.addr = nebulaSelfToken + ":53"
+	// Simulate the stale state a prior reload's shutdownListeners leaves: the
+	// slice still references now-defunct listeners.
+	ds.listeners = []*dnsListener{{server: &dns.Server{}, started: make(chan struct{})}}
+
+	ds.Start()
+
+	require.Nil(t, ds.listeners, "resolve-error Start must clear stale listeners so reload retries")
+}
+
+// TestDnsServer_startListeners_allBindsFail_clearsListeners covers the other
+// staleness path: when every expanded address fails to bind, startListeners
+// must not leave the dead listeners installed.
+func TestDnsServer_startListeners_allBindsFail_clearsListeners(t *testing.T) {
+	ds, _ := newTestDnsServer(t)
+	ds.enabled.Store(true)
+
+	// Occupy a UDP port, then try to bind it so ListenAndServe fails.
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer conn.Close()
+	busy := conn.LocalAddr().String()
+
+	ds.startGen++
+	gen := ds.startGen
+	done := make(chan struct{})
+	go func() {
+		ds.startListeners([]string{busy}, gen)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("startListeners did not return after all binds failed")
+	}
+	require.Nil(t, ds.listeners, "all-binds-failed must clear listeners so reload retries")
 }
 
 func queryDNS(t *testing.T, addr, name string, qtype uint16) *dns.Msg {

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -50,6 +50,7 @@ lighthouse:
   #serve_dns: false
   #dns:
     # The DNS host defines the IP to bind the dns listener to. This also allows binding to the nebula node IP.
+    # Use "<nebula>" as the host to bind every one of this node's nebula (overlay) addresses.
     #host: 0.0.0.0
     #port: 53
   # interval is the number of seconds between updates from this node to a lighthouse.

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -345,6 +345,7 @@ logging:
   #interval: 10s
 
   #type: prometheus
+  # Use "<nebula>" as the host to bind every one of this node's nebula (overlay) addresses, e.g. "<nebula>:8080".
   #listen: 127.0.0.1:8080
   #path: /metrics
   #namespace: prometheusns

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -203,6 +203,7 @@ punchy:
   # Toggles the feature
   #enabled: true
   # Host and port to listen on, port 22 is not allowed for your safety
+  # Use "<nebula>" as the host to bind every one of this node's nebula (overlay) addresses, e.g. "<nebula>:2222".
   #listen: 127.0.0.1:2222
   # A file containing the ssh host private key to use
   # A decent way to generate one: ssh-keygen -t ed25519 -f ssh_host_ed25519_key -N "" < /dev/null

--- a/main.go
+++ b/main.go
@@ -255,7 +255,7 @@ func Main(c *config.C, configTest bool, buildVersion string, l *slog.Logger, dev
 		punchy.Start(ctx, ifce, hostMap, lightHouse)
 	}
 
-	stats, err := newStatsServerFromConfig(ctx, l, c, buildVersion, configTest)
+	stats, err := newStatsServerFromConfig(ctx, l, c, pki, buildVersion, configTest)
 	if err != nil {
 		return nil, util.ContextualizeIfNeeded("Failed to start stats emitter", err)
 	}

--- a/main.go
+++ b/main.go
@@ -44,6 +44,8 @@ func Main(c *config.C, configTest bool, buildVersion string, l *slog.Logger, dev
 		l.Info(string(b))
 	}
 
+	warnSelfTokenWithTunDisabled(l, c)
+
 	pki, err := NewPKIFromConfig(l, c)
 	if err != nil {
 		return nil, util.ContextualizeIfNeeded("Failed to load PKI from config", err)

--- a/main.go
+++ b/main.go
@@ -59,10 +59,10 @@ func Main(c *config.C, configTest bool, buildVersion string, l *slog.Logger, dev
 	if err != nil {
 		return nil, util.ContextualizeIfNeeded("Error while creating SSH server", err)
 	}
-	wireSSHReload(l, ssh, c)
+	wireSSHReload(l, ssh, c, pki)
 	var sshStart func()
 	if c.GetBool("sshd.enabled", false) {
-		sshStart, err = configSSH(l, ssh, c)
+		sshStart, err = configSSH(l, ssh, c, pki)
 		if err != nil {
 			l.Warn("Failed to configure sshd, ssh debugging will not be available", "error", err)
 			sshStart = nil

--- a/pki.go
+++ b/pki.go
@@ -74,6 +74,22 @@ func (p *PKI) getCertState() *CertState {
 	return p.cs.Load()
 }
 
+// vpnAddrs returns this host's overlay/VPN addresses, used to expand the
+// "<nebula>" self-token in listener configs (see resolveSelfListenAddrs), or
+// nil when the PKI or its cert state isn't available yet. Nil-safe on the
+// receiver so every listener call site (and tests that build a server without a
+// PKI) can call it without its own guard.
+func (p *PKI) vpnAddrs() []netip.Addr {
+	if p == nil {
+		return nil
+	}
+	cs := p.getCertState()
+	if cs == nil {
+		return nil
+	}
+	return cs.myVpnAddrs
+}
+
 func (p *PKI) reload(c *config.C, initial bool) error {
 	err := p.reloadCerts(c, initial)
 	if err != nil {

--- a/self_listen.go
+++ b/self_listen.go
@@ -2,9 +2,12 @@ package nebula
 
 import (
 	"fmt"
+	"log/slog"
 	"net"
 	"net/netip"
 	"strings"
+
+	"github.com/slackhq/nebula/config"
 )
 
 // nebulaSelfToken is a magic host value usable in the host position of a
@@ -84,4 +87,21 @@ func (p *PKI) vpnAddrs() []netip.Addr {
 		return nil
 	}
 	return cs.myVpnAddrs
+}
+
+// warnSelfTokenWithTunDisabled logs a warning for each listener whose config
+// uses the "<nebula>" self-token while tun.disabled is set. The token expands
+// to this host's overlay addresses, which no interface carries when the tun is
+// disabled, so those listeners cannot bind. The common footgun is enabling DNS
+// with "<nebula>" on a tun-disabled lighthouse.
+func warnSelfTokenWithTunDisabled(l *slog.Logger, c *config.C) {
+	if !c.GetBool("tun.disabled", false) {
+		return
+	}
+	for _, key := range []string{"lighthouse.dns.host", "sshd.listen", "stats.listen"} {
+		if strings.Contains(c.GetString(key, ""), nebulaSelfToken) {
+			l.Warn(`Listener uses the "<nebula>" self-token but tun.disabled is set; overlay addresses are not bindable without a tun interface, so this listener will fail to bind`,
+				"configKey", key)
+		}
+	}
 }

--- a/self_listen.go
+++ b/self_listen.go
@@ -40,10 +40,23 @@ func resolveSelfListenAddrs(listenAddr string, vpnAddrs []netip.Addr) ([]string,
 	}
 
 	if host != nebulaSelfToken {
+		// The token as a substring of a larger host (e.g. "<nebula>.corp") is
+		// almost certainly a typo. It can't resolve ("<"/">" are illegal in
+		// hostnames) so it would fail loud at bind anyway, but erroring here
+		// gives a clear message instead of an opaque resolver failure.
+		if strings.Contains(host, nebulaSelfToken) {
+			return nil, fmt.Errorf("%q must be the entire host to expand, got host %q in %q", nebulaSelfToken, host, listenAddr)
+		}
 		// Return the original string byte-for-byte so every existing config
 		// behaves exactly as before, including the "[::]" special cases that
 		// callers handle independently of this helper.
 		return []string{listenAddr}, nil
+	}
+
+	if port == "" {
+		// SplitHostPort accepts an empty port (binding an ephemeral port), but
+		// for the token that is never intended, so require one explicitly.
+		return nil, fmt.Errorf("%q requires an explicit port, got %q", nebulaSelfToken, listenAddr)
 	}
 
 	if len(vpnAddrs) == 0 {

--- a/self_listen.go
+++ b/self_listen.go
@@ -74,21 +74,6 @@ func resolveSelfListenAddrs(listenAddr string, vpnAddrs []netip.Addr) ([]string,
 	return addrs, nil
 }
 
-// vpnAddrs returns this host's overlay/VPN addresses for expanding the
-// "<nebula>" self-token, or nil when the PKI or its cert state isn't available
-// yet. Nil-safe on the receiver so every listener call site (and tests that
-// build a server without a PKI) can call it without its own guard.
-func (p *PKI) vpnAddrs() []netip.Addr {
-	if p == nil {
-		return nil
-	}
-	cs := p.getCertState()
-	if cs == nil {
-		return nil
-	}
-	return cs.myVpnAddrs
-}
-
 // warnSelfTokenWithTunDisabled logs a warning for each listener whose config
 // uses the "<nebula>" self-token while tun.disabled is set. The token expands
 // to this host's overlay addresses, which no interface carries when the tun is

--- a/self_listen.go
+++ b/self_listen.go
@@ -1,0 +1,74 @@
+package nebula
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"strings"
+)
+
+// nebulaSelfToken is a magic host value usable in the host position of a
+// listener config (e.g. "<nebula>:8080"). It expands to every one of this
+// host's overlay/VPN addresses, giving bind-ALL semantics across the VPN.
+//
+// "<" and ">" are illegal in hostnames, so the token is safe by construction:
+// it must be intercepted and expanded before any resolver call, and if a call
+// site ever forgets to expand it, name resolution fails loud rather than
+// silently resolving to something unexpected.
+const nebulaSelfToken = "<nebula>"
+
+// resolveSelfListenAddrs expands the "<nebula>" self-token in a listener
+// address into one host:port string per VPN address, or returns the original
+// address unchanged when the token is absent.
+//
+// Callers pass the current set of VPN addresses at LISTENER-START time, read
+// reload-safe from pki.getCertState().myVpnAddrs. Note that because expansion
+// happens when a listener starts, a cert reload that changes myVpnAddrs does
+// NOT by itself rebind an already-bound listener; the previously expanded
+// addresses stay bound until that listener restarts (its config section
+// changes, its feature toggles, or the process restarts).
+func resolveSelfListenAddrs(listenAddr string, vpnAddrs []netip.Addr) ([]string, error) {
+	host, port, err := net.SplitHostPort(listenAddr)
+	if err != nil {
+		// If the token is present but the value isn't host:port form, the user
+		// clearly meant to use it, so fail loud. Otherwise defer to the bind,
+		// matching today's behavior for malformed values.
+		if strings.Contains(listenAddr, nebulaSelfToken) {
+			return nil, fmt.Errorf("%q must be used in host:port form, got %q", nebulaSelfToken, listenAddr)
+		}
+		return []string{listenAddr}, nil
+	}
+
+	if host != nebulaSelfToken {
+		// Return the original string byte-for-byte so every existing config
+		// behaves exactly as before, including the "[::]" special cases that
+		// callers handle independently of this helper.
+		return []string{listenAddr}, nil
+	}
+
+	if len(vpnAddrs) == 0 {
+		return nil, fmt.Errorf("cannot expand %q in listen address %q: host has no VPN addresses", nebulaSelfToken, listenAddr)
+	}
+
+	addrs := make([]string, len(vpnAddrs))
+	for i, a := range vpnAddrs {
+		// JoinHostPort brackets IPv6 automatically.
+		addrs[i] = net.JoinHostPort(a.Unmap().String(), port)
+	}
+	return addrs, nil
+}
+
+// vpnAddrs returns this host's overlay/VPN addresses for expanding the
+// "<nebula>" self-token, or nil when the PKI or its cert state isn't available
+// yet. Nil-safe on the receiver so every listener call site (and tests that
+// build a server without a PKI) can call it without its own guard.
+func (p *PKI) vpnAddrs() []netip.Addr {
+	if p == nil {
+		return nil
+	}
+	cs := p.getCertState()
+	if cs == nil {
+		return nil
+	}
+	return cs.myVpnAddrs
+}

--- a/self_listen_test.go
+++ b/self_listen_test.go
@@ -1,9 +1,12 @@
 package nebula
 
 import (
+	"bytes"
+	"log/slog"
 	"net/netip"
 	"testing"
 
+	"github.com/slackhq/nebula/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -107,4 +110,30 @@ func TestResolveSelfListenAddrs_TokenEmptyPortErrors(t *testing.T) {
 	_, err := resolveSelfListenAddrs("<nebula>:", []netip.Addr{netip.MustParseAddr("100.64.0.5")})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "explicit port")
+}
+
+func TestWarnSelfTokenWithTunDisabled(t *testing.T) {
+	warnings := func(c *config.C) string {
+		var buf bytes.Buffer
+		l := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+		warnSelfTokenWithTunDisabled(l, c)
+		return buf.String()
+	}
+
+	// tun.disabled + token: warn per token-using key, and only those.
+	c := config.NewC(nil)
+	c.Settings["tun"] = map[string]any{"disabled": true}
+	c.Settings["lighthouse"] = map[string]any{"dns": map[string]any{"host": "<nebula>"}}
+	c.Settings["stats"] = map[string]any{"listen": "<nebula>:8080"}
+	c.Settings["sshd"] = map[string]any{"listen": "127.0.0.1:2222"} // no token
+	out := warnings(c)
+	assert.Contains(t, out, "configKey=lighthouse.dns.host")
+	assert.Contains(t, out, "configKey=stats.listen")
+	assert.NotContains(t, out, "configKey=sshd.listen")
+
+	// tun enabled: never warn, even with the token present.
+	c2 := config.NewC(nil)
+	c2.Settings["tun"] = map[string]any{"disabled": false}
+	c2.Settings["stats"] = map[string]any{"listen": "<nebula>:8080"}
+	assert.Empty(t, warnings(c2))
 }

--- a/self_listen_test.go
+++ b/self_listen_test.go
@@ -1,0 +1,86 @@
+package nebula
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveSelfListenAddrs_TokenExpansion(t *testing.T) {
+	vpnAddrs := []netip.Addr{
+		netip.MustParseAddr("100.64.0.5"),
+		netip.MustParseAddr("fd00::5"),
+	}
+
+	addrs, err := resolveSelfListenAddrs("<nebula>:8080", vpnAddrs)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"100.64.0.5:8080", "[fd00::5]:8080"}, addrs)
+}
+
+func TestResolveSelfListenAddrs_TokenPreservesCertOrder(t *testing.T) {
+	vpnAddrs := []netip.Addr{
+		netip.MustParseAddr("fd00::5"),
+		netip.MustParseAddr("100.64.0.5"),
+		netip.MustParseAddr("100.64.0.6"),
+	}
+
+	addrs, err := resolveSelfListenAddrs("<nebula>:53", vpnAddrs)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"[fd00::5]:53", "100.64.0.5:53", "100.64.0.6:53"}, addrs)
+}
+
+func TestResolveSelfListenAddrs_TokenUnmapsV4in6(t *testing.T) {
+	// A 4-in-6 mapped address must render as plain IPv4, not [::ffff:...].
+	vpnAddrs := []netip.Addr{netip.MustParseAddr("::ffff:100.64.0.5")}
+
+	addrs, err := resolveSelfListenAddrs("<nebula>:8080", vpnAddrs)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"100.64.0.5:8080"}, addrs)
+}
+
+func TestResolveSelfListenAddrs_NonTokenPassthrough(t *testing.T) {
+	// Non-token values must be returned as the exact original string, so every
+	// existing config behaves exactly as before.
+	cases := []string{
+		"127.0.0.1:8080",
+		"0.0.0.0:53",
+		"[::]:53",
+		"[fd00::5]:2222",
+		"example.com:443",
+	}
+	for _, in := range cases {
+		addrs, err := resolveSelfListenAddrs(in, nil)
+		require.NoError(t, err, in)
+		require.Len(t, addrs, 1, in)
+		assert.Equal(t, in, addrs[0], in)
+	}
+}
+
+func TestResolveSelfListenAddrs_MalformedPassthrough(t *testing.T) {
+	// Values that don't parse as host:port and don't contain the token defer to
+	// the bind, matching today's behavior (they keep failing at bind time).
+	cases := []string{
+		"8080",        // bare port
+		"::",          // host only, no port
+		"not a valid", // garbage
+	}
+	for _, in := range cases {
+		addrs, err := resolveSelfListenAddrs(in, nil)
+		require.NoError(t, err, in)
+		assert.Equal(t, []string{in}, addrs, in)
+	}
+}
+
+func TestResolveSelfListenAddrs_TokenWithoutPortErrors(t *testing.T) {
+	// The token present but not in host:port form must fail loud.
+	_, err := resolveSelfListenAddrs("<nebula>", []netip.Addr{netip.MustParseAddr("100.64.0.5")})
+	assert.Error(t, err)
+}
+
+func TestResolveSelfListenAddrs_TokenNoVpnAddrsErrors(t *testing.T) {
+	_, err := resolveSelfListenAddrs("<nebula>:8080", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no VPN addresses")
+}

--- a/self_listen_test.go
+++ b/self_listen_test.go
@@ -84,3 +84,27 @@ func TestResolveSelfListenAddrs_TokenNoVpnAddrsErrors(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no VPN addresses")
 }
+
+func TestResolveSelfListenAddrs_TokenSubstringErrors(t *testing.T) {
+	// The token embedded in a larger host is a typo, not passthrough: it can't
+	// resolve, so we error clearly instead of letting it hit the resolver.
+	vpnAddrs := []netip.Addr{netip.MustParseAddr("100.64.0.5")}
+	cases := []string{
+		"<nebula>.corp:8080",
+		"x<nebula>:2222",
+		"my-<nebula>-host:53",
+	}
+	for _, in := range cases {
+		_, err := resolveSelfListenAddrs(in, vpnAddrs)
+		require.Error(t, err, in)
+		assert.Contains(t, err.Error(), "entire host", in)
+	}
+}
+
+func TestResolveSelfListenAddrs_TokenEmptyPortErrors(t *testing.T) {
+	// "<nebula>:" parses (empty port) but binding ephemeral ports is never the
+	// intent for the token, so require an explicit port.
+	_, err := resolveSelfListenAddrs("<nebula>:", []netip.Addr{netip.MustParseAddr("100.64.0.5")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "explicit port")
+}

--- a/ssh.go
+++ b/ssh.go
@@ -57,10 +57,10 @@ type sshDeviceInfoFlags struct {
 	Pretty bool
 }
 
-func wireSSHReload(l *slog.Logger, ssh *sshd.SSHServer, c *config.C) {
+func wireSSHReload(l *slog.Logger, ssh *sshd.SSHServer, c *config.C, pki *PKI) {
 	c.RegisterReloadCallback(func(c *config.C) {
 		if c.GetBool("sshd.enabled", false) {
-			sshRun, err := configSSH(l, ssh, c)
+			sshRun, err := configSSH(l, ssh, c, pki)
 			if err != nil {
 				l.Error("Failed to reconfigure the sshd", "error", err)
 				ssh.Stop()
@@ -78,7 +78,7 @@ func wireSSHReload(l *slog.Logger, ssh *sshd.SSHServer, c *config.C) {
 // updates the passed-in SSHServer. On success, it returns a function
 // that callers may invoke to run the configured ssh server. On
 // failure, it returns nil, error.
-func configSSH(l *slog.Logger, ssh *sshd.SSHServer, c *config.C) (func(), error) {
+func configSSH(l *slog.Logger, ssh *sshd.SSHServer, c *config.C, pki *PKI) (func(), error) {
 	listen := c.GetString("sshd.listen", "")
 	if listen == "" {
 		return nil, fmt.Errorf("sshd.listen must be provided")
@@ -187,7 +187,15 @@ func configSSH(l *slog.Logger, ssh *sshd.SSHServer, c *config.C) (func(), error)
 	if c.GetBool("sshd.enabled", false) {
 		ssh.Stop()
 		runner = func() {
-			if err := ssh.Run(listen); err != nil {
+			// Expand at run time so the "<nebula>" self-token binds this host's
+			// current VPN addresses (present once the tun is up). wireSSHReload
+			// restarts the server on every reload, so this re-expands each SIGHUP.
+			addrs, err := resolveSelfListenAddrs(listen, pki.vpnAddrs())
+			if err != nil {
+				l.Warn("Failed to run the SSH server", "error", err)
+				return
+			}
+			if err := ssh.Run(addrs); err != nil {
 				l.Warn("Failed to run the SSH server", "error", err)
 			}
 		}

--- a/ssh_test.go
+++ b/ssh_test.go
@@ -1,0 +1,65 @@
+package nebula
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/slackhq/nebula/config"
+	"github.com/slackhq/nebula/sshd"
+	"github.com/slackhq/nebula/test"
+)
+
+// TestConfigSSH_SelfTokenParseValidation pins that the "<nebula>" self-token is
+// treated like any other host at config-parse time: net.SplitHostPort splits it
+// cleanly, so the port-22 rejection still fires and a valid port passes through
+// to the later (host_key) validation. Expansion itself happens at run time, not
+// here, so no PKI is needed.
+func TestConfigSSH_SelfTokenParseValidation(t *testing.T) {
+	l := test.NewLogger()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	newConf := func(listen string) *config.C {
+		c := config.NewC(l)
+		if err := c.LoadString("sshd:\n  enabled: true\n  listen: '" + listen + "'\n"); err != nil {
+			t.Fatalf("LoadString: %v", err)
+		}
+		return c
+	}
+
+	t.Run("token with a valid port passes listen validation", func(t *testing.T) {
+		ssh, err := sshd.NewSSHServer(ctx, l)
+		if err != nil {
+			t.Fatalf("NewSSHServer: %v", err)
+		}
+		_, err = configSSH(l, ssh, newConf("<nebula>:2222"), nil)
+		// It must get PAST listen validation and fail on the missing host key,
+		// proving the token was accepted exactly like a normal host would be.
+		if err == nil || !strings.Contains(err.Error(), "host_key") {
+			t.Fatalf("expected host_key error, got: %v", err)
+		}
+	})
+
+	t.Run("token with port 22 is still rejected", func(t *testing.T) {
+		ssh, err := sshd.NewSSHServer(ctx, l)
+		if err != nil {
+			t.Fatalf("NewSSHServer: %v", err)
+		}
+		_, err = configSSH(l, ssh, newConf("<nebula>:22"), nil)
+		if err == nil || !strings.Contains(err.Error(), "port 22") {
+			t.Fatalf("expected port 22 rejection, got: %v", err)
+		}
+	})
+
+	t.Run("token without a port is rejected", func(t *testing.T) {
+		ssh, err := sshd.NewSSHServer(ctx, l)
+		if err != nil {
+			t.Fatalf("NewSSHServer: %v", err)
+		}
+		_, err = configSSH(l, ssh, newConf("<nebula>"), nil)
+		if err == nil || !strings.Contains(err.Error(), "invalid sshd.listen") {
+			t.Fatalf("expected invalid sshd.listen error, got: %v", err)
+		}
+	})
+}

--- a/sshd/server.go
+++ b/sshd/server.go
@@ -28,7 +28,14 @@ type SSHServer struct {
 	// List of available commands
 	helpCommand *Command
 	commands    *radix.Tree
-	listener    net.Listener
+	// listenerMu guards listeners against a Run/Stop (or Run/Run reload) race:
+	// the slice header is multiple words, so an unsynchronized read during a
+	// write could observe a torn value.
+	listenerMu sync.Mutex
+	// listeners holds the sockets the current Run owns. Stop closes whatever is
+	// here; a fast reload may overwrite this before a prior run's watcher fires,
+	// so each run also closes its own locals (see Run).
+	listeners []net.Listener
 
 	// ctx parents per-Run contexts. Cancelling it (e.g. via Control.Stop) tears the server down even
 	// across reloads, since each Run derives a fresh child rather than reusing this one directly.
@@ -165,42 +172,65 @@ func (s *SSHServer) RegisterCommand(c *Command) {
 	s.commands.Insert(c.Name, c)
 }
 
-// Run begins listening and accepting connections. Each invocation derives a fresh per-Run context
-// from the constructor-supplied ctx so a Stop+Run sequence (used by config reload) starts clean
-// rather than carrying a permanently-cancelled context across runs.
-func (s *SSHServer) Run(addr string) error {
+// Run begins listening and accepting connections on every address in addrs. Each invocation derives a
+// fresh per-Run context from the constructor-supplied ctx so a Stop+Run sequence (used by config
+// reload) starts clean rather than carrying a permanently-cancelled context across runs.
+//
+// Binding is all-or-nothing: if any address fails to bind, the already-bound listeners for this run
+// are closed and the error is returned so the failure surfaces loudly.
+func (s *SSHServer) Run(addrs []string) error {
 	if s.ctx.Err() != nil {
 		return s.ctx.Err()
 	}
 
-	listener, err := net.Listen("tcp", addr)
-	if err != nil {
-		return err
+	listeners := make([]net.Listener, 0, len(addrs))
+	for _, addr := range addrs {
+		listener, err := net.Listen("tcp", addr)
+		if err != nil {
+			for _, ln := range listeners {
+				ln.Close()
+			}
+			return err
+		}
+		listeners = append(listeners, listener)
 	}
-	// s.listener is the public handle Stop uses to interrupt the active run; listener (the local) is what
-	// this run owns. They start equal but a fast reload may overwrite s.listener with the next run's
-	// listener before this run's watcher fires, so each run must close its own listener via the local
-	// reference.
-	s.listener = listener
+
+	// s.listeners is the public handle Stop uses to interrupt the active run; listeners (the locals) are
+	// what this run owns. They start equal but a fast reload may overwrite s.listeners with the next
+	// run's listeners before this run's watcher fires, so each run must close its own listeners via the
+	// local references.
+	s.listenerMu.Lock()
+	s.listeners = listeners
+	s.listenerMu.Unlock()
 
 	runCtx, cancel := context.WithCancel(s.ctx)
 	defer cancel()
 
-	// Close the listener when this run's context is cancelled. That can come from the parent
+	// Close this run's listeners when its context is cancelled. That can come from the parent
 	// (Control.Stop), from Run returning normally (defer cancel above), or transitively when a sibling
-	// run cancels through Stop closing the listener. net.Listener.Close is idempotent so a duplicate
+	// run cancels through Stop closing the listeners. net.Listener.Close is idempotent so a duplicate
 	// close from Stop is benign.
 	go func() {
 		<-runCtx.Done()
-		if err := listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
-			s.l.Warn("Failed to close the sshd listener", "error", err)
+		for _, ln := range listeners {
+			if err := ln.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+				s.l.Warn("Failed to close the sshd listener", "error", err)
+			}
 		}
 	}()
 
-	s.l.Info("SSH server is listening", "sshListener", addr)
+	s.l.Info("SSH server is listening", "sshListeners", addrs)
 
-	// Run loops until there is an error
-	s.run(runCtx, listener)
+	// Serve every listener until its accept loop exits, then wait for them all.
+	var wg sync.WaitGroup
+	for _, listener := range listeners {
+		wg.Add(1)
+		go func(listener net.Listener) {
+			defer wg.Done()
+			s.run(runCtx, listener)
+		}(listener)
+	}
+	wg.Wait()
 
 	s.l.Info("SSH server stopped listening")
 	// We don't return an error because run logs for us
@@ -264,8 +294,11 @@ func (s *SSHServer) run(ctx context.Context, listener net.Listener) {
 }
 
 func (s *SSHServer) Stop() {
-	if s.listener != nil {
-		if err := s.listener.Close(); err != nil {
+	s.listenerMu.Lock()
+	listeners := s.listeners
+	s.listenerMu.Unlock()
+	for _, ln := range listeners {
+		if err := ln.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
 			s.l.Warn("Failed to close the sshd listener", "error", err)
 		}
 	}

--- a/sshd/server_test.go
+++ b/sshd/server_test.go
@@ -1,0 +1,153 @@
+package sshd
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
+// waitAccept dials addr and confirms the server accepts a TCP connection.
+func waitAccept(t *testing.T, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("could not connect to %s: %v", addr, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// startServer binds the requested addresses on ephemeral ports and returns the
+// server plus the resolved concrete addresses Run is listening on.
+func startServer(t *testing.T, addrs []string) (*SSHServer, []string) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	s, err := NewSSHServer(ctx, testLogger())
+	if err != nil {
+		t.Fatalf("NewSSHServer: %v", err)
+	}
+
+	// Pre-bind to learn the ephemeral ports, then hand the concrete addresses
+	// to Run so tests can dial them.
+	resolved := make([]string, len(addrs))
+	for i, a := range addrs {
+		ln, err := net.Listen("tcp", a)
+		if err != nil {
+			t.Fatalf("probe listen %s: %v", a, err)
+		}
+		resolved[i] = ln.Addr().String()
+		ln.Close()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := s.Run(resolved); err != nil {
+			t.Errorf("Run returned error: %v", err)
+		}
+	}()
+	t.Cleanup(func() {
+		s.Stop()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("Run did not return after Stop")
+		}
+	})
+
+	for _, a := range resolved {
+		waitAccept(t, a)
+	}
+	return s, resolved
+}
+
+// TestSSHServer_Run_MultipleListeners pins the bind-ALL behavior: every address
+// in the slice accepts connections, and Stop closes all of them.
+func TestSSHServer_Run_MultipleListeners(t *testing.T) {
+	s, resolved := startServer(t, []string{"127.0.0.1:0", "[::1]:0"})
+
+	for _, a := range resolved {
+		waitAccept(t, a)
+	}
+
+	s.Stop()
+
+	// After Stop every listener should be closed; a fresh dial must fail.
+	deadline := time.Now().Add(2 * time.Second)
+	for _, a := range resolved {
+		for {
+			conn, err := net.DialTimeout("tcp", a, 100*time.Millisecond)
+			if err != nil {
+				break
+			}
+			conn.Close()
+			if time.Now().After(deadline) {
+				t.Fatalf("listener %s still accepting after Stop", a)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}
+
+// TestSSHServer_Run_SingleListener pins legacy single-address behavior.
+func TestSSHServer_Run_SingleListener(t *testing.T) {
+	_, resolved := startServer(t, []string{"127.0.0.1:0"})
+	if len(resolved) != 1 {
+		t.Fatalf("expected 1 listener, got %d", len(resolved))
+	}
+	waitAccept(t, resolved[0])
+}
+
+// TestSSHServer_Run_BindFailureIsAllOrNothing verifies that if any address in
+// the slice fails to bind, Run returns the error and leaves nothing listening.
+func TestSSHServer_Run_BindFailureIsAllOrNothing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Occupy a port so the second bind in Run fails.
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("occupy listen: %v", err)
+	}
+	defer occupied.Close()
+	occupiedAddr := occupied.Addr().String()
+
+	// A free address that Run should bind first, then have to tear down.
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	freeAddr := probe.Addr().String()
+	probe.Close()
+
+	s, err := NewSSHServer(ctx, testLogger())
+	if err != nil {
+		t.Fatalf("NewSSHServer: %v", err)
+	}
+
+	if err := s.Run([]string{freeAddr, occupiedAddr}); err == nil {
+		t.Fatal("expected Run to fail when an address cannot bind")
+	}
+
+	// The successfully-bound first address must have been closed on the failure
+	// path, so it is available to bind again.
+	ln, err := net.Listen("tcp", freeAddr)
+	if err != nil {
+		t.Fatalf("first listener leaked (still bound): %v", err)
+	}
+	ln.Close()
+}

--- a/stats.go
+++ b/stats.go
@@ -28,6 +28,7 @@ import (
 type statsServer struct {
 	l            *slog.Logger
 	ctx          context.Context
+	pki          *PKI
 	buildVersion string
 	configTest   bool
 
@@ -82,10 +83,11 @@ type promConfig struct {
 //
 // Start is safe to call unconditionally: it no-ops when stats are disabled.
 // The returned pointer is always non-nil, even on error.
-func newStatsServerFromConfig(ctx context.Context, l *slog.Logger, c *config.C, buildVersion string, configTest bool) (*statsServer, error) {
+func newStatsServerFromConfig(ctx context.Context, l *slog.Logger, c *config.C, pki *PKI, buildVersion string, configTest bool) (*statsServer, error) {
 	s := &statsServer{
 		l:            l,
 		ctx:          ctx,
+		pki:          pki,
 		buildVersion: buildVersion,
 		configTest:   configTest,
 	}
@@ -166,7 +168,7 @@ func (s *statsServer) Start() {
 		// Graphite: no HTTP listener to serve; block until teardown.
 		<-runCtx.Done()
 	} else {
-		cleanExit = s.serveListener(listener)
+		cleanExit = s.servePrometheus(cfg, listener)
 	}
 
 	// Clear our runtime only if nothing has replaced it. Stop races through
@@ -186,20 +188,50 @@ func (s *statsServer) Start() {
 	s.runMu.Unlock()
 }
 
-// serveListener runs ListenAndServe and ensures ctx cancellation unblocks it.
-// Returns true if the listener exited cleanly (Stop, ctx cancellation, or any
-// other http.ErrServerClosed path), false on an unexpected error.
-func (s *statsServer) serveListener(listener *http.Server) bool {
-	// Per-invocation watcher: ctx cancellation triggers a listener shutdown
-	// which in turn unblocks ListenAndServe. Closing `done` on exit keeps
-	// the watcher from outliving this call.
+// servePrometheus expands the configured listen address (handling the
+// "<nebula>" self-token) and serves the HTTP handler on the result. An ordinary
+// config yields one listener; the token expands to one per VPN address, all
+// served by the same server.
+func (s *statsServer) servePrometheus(cfg statsConfig, srv *http.Server) bool {
+	addrs, err := resolveSelfListenAddrs(cfg.prom.listen, s.pki.vpnAddrs())
+	if err != nil {
+		s.l.Error("Failed to expand prometheus stats listen address", "error", err)
+		return false
+	}
+
+	return s.serveListeners(srv, addrs)
+}
+
+// serveListeners binds every expanded address up front and serves them all
+// from one http.Server (bind-ALL for the "<nebula>" token). Binding is
+// all-or-nothing: a single bind failure closes the already-bound listeners and
+// reports an unclean exit, so a same-config SIGHUP can retry. ctx cancellation
+// (or Stop) shuts the server down, which closes every listener it is serving,
+// unblocking all the Serve goroutines.
+func (s *statsServer) serveListeners(srv *http.Server, addrs []string) bool {
+	listeners := make([]net.Listener, 0, len(addrs))
+	for _, a := range addrs {
+		ln, err := net.Listen("tcp", a)
+		if err != nil {
+			s.l.Error("Failed to bind prometheus stats listener", "addr", a, "error", err)
+			for _, l := range listeners {
+				_ = l.Close()
+			}
+			return false
+		}
+		listeners = append(listeners, ln)
+	}
+
+	// Per-invocation watcher: ctx cancellation triggers a server shutdown that
+	// closes all served listeners. Closing `done` on exit keeps the watcher
+	// from outliving this call.
 	done := make(chan struct{})
 	go func() {
 		select {
 		case <-s.ctx.Done():
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			if err := listener.Shutdown(shutdownCtx); err != nil {
+			if err := srv.Shutdown(shutdownCtx); err != nil {
 				s.l.Warn("Failed to shut down prometheus stats listener", "error", err)
 			}
 		case <-done:
@@ -207,13 +239,26 @@ func (s *statsServer) serveListener(listener *http.Server) bool {
 	}()
 	defer close(done)
 
-	s.l.Info("Starting prometheus stats listener", "addr", listener.Addr)
-	err := listener.ListenAndServe()
-	if err == nil || errors.Is(err, http.ErrServerClosed) {
-		return true
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	cleanExit := true
+	for _, ln := range listeners {
+		s.l.Info("Starting prometheus stats listener", "addr", ln.Addr())
+		wg.Add(1)
+		go func(ln net.Listener) {
+			defer wg.Done()
+			err := srv.Serve(ln)
+			if err == nil || errors.Is(err, http.ErrServerClosed) {
+				return
+			}
+			s.l.Error("Prometheus stats listener exited", "addr", ln.Addr(), "error", err)
+			mu.Lock()
+			cleanExit = false
+			mu.Unlock()
+		}(ln)
 	}
-	s.l.Error("Prometheus stats listener exited", "error", err)
-	return false
+	wg.Wait()
+	return cleanExit
 }
 
 // Stop tears down the active runtime, if any. Idempotent.
@@ -301,7 +346,9 @@ func (s *statsServer) buildRuntime(cfg statsConfig) ([]func(), *http.Server) {
 		errLog := slog.NewLogLogger(s.l.Handler(), slog.LevelError)
 		mux := http.NewServeMux()
 		mux.Handle(cfg.prom.path, promhttp.HandlerFor(pr, promhttp.HandlerOpts{ErrorLog: errLog}))
-		return captureFns, &http.Server{Addr: cfg.prom.listen, Handler: mux}
+		// Addr is unused: serveListeners binds each address explicitly via
+		// net.Listen and serves them with srv.Serve.
+		return captureFns, &http.Server{Handler: mux}
 	}
 	return captureFns, nil
 }

--- a/stats_test.go
+++ b/stats_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"net/http"
 	"strconv"
 	"testing"
 	"time"
@@ -357,6 +358,128 @@ func TestStatsServer_listenerBindFailure_sameCfgReloadRetries(t *testing.T) {
 	require.NotNil(t, currentRuntime(s))
 
 	s.Stop()
+}
+
+// TestStatsServer_nonToken_singleListener verifies an ordinary (non-token)
+// listen value binds and serves on its single configured address through the
+// same serveListeners path the token uses.
+func TestStatsServer_nonToken_singleListener(t *testing.T) {
+	port := freeTCPPort(t)
+	s, c := newTestStatsServer(t)
+	setStatsConfig(c, map[string]any{
+		"type":     "prometheus",
+		"interval": "1s",
+		"listen":   "127.0.0.1:" + port,
+		"path":     "/metrics",
+	})
+	require.NoError(t, s.reload(c, true))
+
+	done := make(chan struct{})
+	go func() {
+		s.Start()
+		close(done)
+	}()
+	waitForListening(t, "127.0.0.1:"+port)
+
+	rt := currentRuntime(s)
+	require.NotNil(t, rt)
+	require.NotNil(t, rt.listener)
+
+	s.Stop()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after Stop")
+	}
+}
+
+// TestStatsServer_serveListeners_multiBind drives the bind-ALL multi-listener
+// path directly (as the "<nebula>" token would after expansion): every address
+// binds and answers the handler, and ctx cancellation unblocks the call.
+func TestStatsServer_serveListeners_multiBind(t *testing.T) {
+	l := slog.New(slog.DiscardHandler)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := &statsServer{l: l, ctx: ctx}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/metrics", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	})
+	srv := &http.Server{Handler: mux}
+
+	addrs := []string{reserveTCPAddr(t, "127.0.0.1")}
+	if v6, ok := tryReserveTCPAddr(t, "[::1]"); ok {
+		addrs = append(addrs, v6)
+	}
+
+	result := make(chan bool, 1)
+	go func() { result <- s.serveListeners(srv, addrs) }()
+
+	for _, a := range addrs {
+		waitForListening(t, a)
+		resp, err := http.Get("http://" + a + "/metrics")
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		assert.Equal(t, "ok", string(body))
+	}
+
+	cancel()
+	select {
+	case clean := <-result:
+		assert.True(t, clean, "serveListeners should report a clean exit on ctx cancel")
+	case <-time.After(5 * time.Second):
+		t.Fatal("serveListeners did not return after ctx cancel")
+	}
+}
+
+// TestStatsServer_serveListeners_partialBindFailure ensures a failed bind on
+// one address closes the already-bound listeners (no leak) and reports an
+// unclean exit.
+func TestStatsServer_serveListeners_partialBindFailure(t *testing.T) {
+	l := slog.New(slog.DiscardHandler)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := &statsServer{l: l, ctx: ctx}
+
+	// Hold a port so the second bind fails; the first (ephemeral) succeeds.
+	blocker, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer blocker.Close()
+	taken := blocker.Addr().String()
+
+	free := reserveTCPAddr(t, "127.0.0.1")
+
+	srv := &http.Server{Handler: http.NewServeMux()}
+	clean := s.serveListeners(srv, []string{free, taken})
+	assert.False(t, clean, "partial bind failure should be an unclean exit")
+
+	// The first listener must have been closed: its address is bindable again.
+	ln, err := net.Listen("tcp", free)
+	require.NoError(t, err, "first listener was not closed on partial bind failure")
+	require.NoError(t, ln.Close())
+}
+
+// reserveTCPAddr returns a free host:port on the given host by briefly binding
+// and releasing an ephemeral port.
+func reserveTCPAddr(t *testing.T, host string) string {
+	t.Helper()
+	addr, ok := tryReserveTCPAddr(t, host)
+	require.True(t, ok, "could not reserve a TCP address on %s", host)
+	return addr
+}
+
+func tryReserveTCPAddr(t *testing.T, host string) (string, bool) {
+	t.Helper()
+	ln, err := net.Listen("tcp", host+":0")
+	if err != nil {
+		return "", false
+	}
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+	return addr, true
 }
 
 func waitForListening(t *testing.T, addr string) {


### PR DESCRIPTION
Problem: It is not possible to listen _only_ on _every_ Nebula IP. You can listen on `0.0.0.0` or `[::]` but this will also listen publicly. You can listen on a specific Nebula IP, but Nebula does not support listing multiple.

Solution:

Introduce a "<nebula>" host token usable in the host position of a listener
config value (e.g. `stats.listen: "<nebula>:8080"`). It expands to every one of
this host's overlay/VPN addresses, binding all of them (one listener each).

"<" and ">" are illegal in hostnames, so the token is safe by construction: it
is always intercepted and expanded before any name resolution, and a call site
that ever forgot to expand it would fail loud rather than silently resolve.

This commit adds the shared resolveSelfListenAddrs helper and wires the first
consumer, stats.listen (Prometheus), refactoring it to serve one listener per
expanded address. Non-token values are unchanged.

Caveats:

- A cert update with new addresses will not reload listeners. I believe this is best solved as a followup PR.
- A tun.disabled host will fail to listen on its nebula IPs - so log warnings if the token is used with them

Explicitly excluded:
- Indexed reference to IPs (e.g. <nebula[0]>) - these could appear in any order, and are not stable
- IPv4 / IPv6 (e.g. <nebula.ipv4>) only listens: this could make sense as a followup.

Alternatives:

- Change the listen fields to accept string or array of string. In the case of array, listen on all. (This would actually be more flexible, but requires the config writer to set the config based on the addresses in the cert.)