### PR TITLE
Support multiple listen addresses in stats, sshd, and dns

### DIFF
--- a/dns_server.go
+++ b/dns_server.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net"
 	"net/netip"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -37,14 +38,28 @@ type dnsServer struct {
 	enabled atomic.Bool
 
 	serverMu sync.Mutex
-	server   *dns.Server
-	// started is closed once `server` has finished binding (or after
-	// ListenAndServe returns on a bind failure). Stop waits on it before
-	// calling Shutdown to avoid the miekg/dns "server not started" race
-	// where a Shutdown that arrives before bind completes is silently
-	// ignored, leaving the listener running forever.
+	// listeners holds one entry per bound address; addrs holds the configured
+	// "host:port" bind addresses (one per lighthouse.dns.host entry, joined with
+	// the shared port). reload compares addrs to detect a listen-address change.
+	listeners []*dnsListener
+	addrs     []string
+	// startGen tags each Start attempt so the one that stops serving (or bails
+	// before binding) only clears d.listeners if a newer Start hasn't taken
+	// over. Without this, a Start that fails to bind would leave stale dead
+	// listeners in d.listeners, making reload see running==true and no-op every
+	// same-addr SIGHUP, wedging DNS permanently.
+	startGen uint64
+}
+
+// dnsListener pairs a dns.Server with its started channel. The channel is
+// closed once the server has finished binding (or after ListenAndServe returns
+// on a bind failure). Stop waits on it before calling Shutdown to avoid the
+// miekg/dns "server not started" race where a Shutdown that arrives before bind
+// completes is silently ignored, leaving the listener running forever. Each
+// listener carries its own channel so the race fix holds per bound address.
+type dnsListener struct {
+	server  *dns.Server
 	started chan struct{}
-	addr    string
 }
 
 // newDnsServerFromConfig builds a dnsServer, applies the initial config, and
@@ -94,12 +109,12 @@ func (d *dnsServer) reload(c *config.C, initial bool) error {
 	wantsDns := c.GetBool("lighthouse.serve_dns", false)
 	amLighthouse := c.GetBool("lighthouse.am_lighthouse", false)
 	enabled := wantsDns && amLighthouse
-	newAddr := getDnsServerAddr(c)
+	newAddrs := getDnsServerAddrs(c)
 
 	d.serverMu.Lock()
-	running := d.server != nil
-	sameAddr := d.addr == newAddr
-	d.addr = newAddr
+	running := len(d.listeners) > 0
+	sameAddr := slices.Equal(d.addrs, newAddrs)
+	d.addrs = newAddrs
 	d.enabled.Store(enabled)
 	d.serverMu.Unlock()
 
@@ -124,7 +139,7 @@ func (d *dnsServer) reload(c *config.C, initial bool) error {
 		// Was disabled (or never started); bring it up now.
 		go d.Start()
 	} else if !sameAddr {
-		// Stop clears the slot before shutting down, otherwise the Start below can find the dying server and refuse
+		// Stop clears the slots before shutting down, otherwise the Start below can find the dying listeners and refuse
 		d.Stop()
 		go d.Start()
 	}
@@ -132,6 +147,14 @@ func (d *dnsServer) reload(c *config.C, initial bool) error {
 	// Refresh the self entry every enabled reload so cert renewals that change our name or VPN addresses are picked up.
 	d.seedSelf()
 	return nil
+}
+
+// shutdownListeners shuts down every listener in the slice, waiting for each to
+// finish binding first so Shutdown actually stops it rather than no-oping.
+func (d *dnsServer) shutdownListeners(listeners []*dnsListener, reason string) {
+	for _, ln := range listeners {
+		d.shutdownServer(ln.server, ln.started, reason)
+	}
 }
 
 // shutdownServer waits for the server to finish binding (so Shutdown actually
@@ -148,81 +171,125 @@ func (d *dnsServer) shutdownServer(srv *dns.Server, started chan struct{}, reaso
 	}
 }
 
-// Start binds and serves the DNS responder. Blocks until Stop is called or
-// the listener errors. Safe to call when DNS is disabled (returns
-// immediately). This is what Control.dnsStart points at.
+// Start binds and serves the DNS responder. Blocks until Stop is called or the
+// listeners error. Safe to call when DNS is disabled (returns immediately).
+// This is what Control.dnsStart points at.
 //
-// Must be invoked after the tun device is active so that lighthouse.dns.host
-// may bind to a nebula IP.
+// Must be invoked after the tun device is active so that a lighthouse.dns.host
+// pointed at a nebula IP can bind it.
 func (d *dnsServer) Start() {
 	if !d.enabled.Load() {
 		return
 	}
 
-	started := make(chan struct{})
 	d.serverMu.Lock()
-	// Re-check enabled under the lock, a disable that raced our check above snapshots the slot under it too.
-	// Two reloads in quick succession can both spawn a Start, the loser would orphan the live listener past Stop
-	if d.ctx.Err() != nil || d.server != nil || !d.enabled.Load() {
+	// Re-check enabled under the lock, a disable that raced our check above snapshots the slots under it too.
+	// Two reloads in quick succession can both spawn a Start, the loser would orphan the live listeners past Stop
+	if d.ctx.Err() != nil || len(d.listeners) > 0 || !d.enabled.Load() {
 		d.serverMu.Unlock()
 		return
 	}
-	addr := d.addr
-	server := &dns.Server{
-		Addr:              addr,
-		Net:               "udp",
-		Handler:           d.mux,
-		NotifyStartedFunc: func() { close(started) },
-	}
-	d.server = server
-	d.started = started
+	addrs := d.addrs
+	d.startGen++
+	myGen := d.startGen
 	d.serverMu.Unlock()
 
-	// Per-invocation ctx watcher. Exits when Start does, so we don't leak a
-	// watcher per reload-driven restart.
+	if len(addrs) == 0 {
+		d.l.Warn("Failed to run the DNS responder: no listen address configured")
+		// Nothing installed, so the slot stays clear and a later reload retries.
+		return
+	}
+	d.startListeners(addrs, myGen)
+}
+
+// clearListenersIfCurrent nils out d.listeners, but only if no newer Start has
+// superseded this one (identified by gen). This lets the Start that stopped
+// serving reset the running state without clobbering a concurrent restart.
+func (d *dnsServer) clearListenersIfCurrent(gen uint64) {
+	d.serverMu.Lock()
+	if d.startGen == gen {
+		d.listeners = nil
+	}
+	d.serverMu.Unlock()
+}
+
+// startListeners binds and serves one dns.Server per already-expanded address,
+// blocking until all of them return. Split from Start so tests can drive the
+// multi-listener machinery with concrete addresses. A bind failure on one
+// address is logged and the remaining listeners keep serving (log-and-continue,
+// matching the single-listener behavior this refactor grew out of).
+func (d *dnsServer) startListeners(addrs []string, myGen uint64) {
+	listeners := make([]*dnsListener, len(addrs))
+	for i, a := range addrs {
+		started := make(chan struct{})
+		listeners[i] = &dnsListener{
+			started: started,
+			server: &dns.Server{
+				Addr:              a,
+				Net:               "udp",
+				Handler:           d.mux,
+				NotifyStartedFunc: func() { close(started) },
+			},
+		}
+	}
+
+	d.serverMu.Lock()
+	if d.ctx.Err() != nil || d.startGen != myGen {
+		// Shutting down, or a newer Start has superseded us; don't install.
+		d.serverMu.Unlock()
+		return
+	}
+	d.listeners = listeners
+	d.serverMu.Unlock()
+
+	// Per-invocation ctx watcher. Exits when startListeners does, so we don't
+	// leak a watcher per reload-driven restart.
 	done := make(chan struct{})
 	go func() {
 		select {
 		case <-d.ctx.Done():
-			d.shutdownServer(server, started, "shutdown")
+			d.shutdownListeners(listeners, "shutdown")
 		case <-done:
 		}
 	}()
 
-	d.l.Info("Starting DNS responder", "dnsListener", addr)
-	err := server.ListenAndServe()
+	var wg sync.WaitGroup
+	for _, ln := range listeners {
+		wg.Add(1)
+		go func(ln *dnsListener) {
+			defer wg.Done()
+			d.l.Info("Starting DNS responder", "dnsListener", ln.server.Addr)
+			err := ln.server.ListenAndServe()
+
+			// If the listener never bound (bind error) NotifyStartedFunc never
+			// fires, so close started here to release any waiter on it.
+			select {
+			case <-ln.started:
+			default:
+				close(ln.started)
+			}
+
+			if err != nil {
+				d.l.Warn("Failed to run the DNS responder", "error", err, "dnsListener", ln.server.Addr)
+			}
+		}(ln)
+	}
+	wg.Wait()
 	close(done)
 
-	// If the listener never bound (bind error) NotifyStartedFunc never fires,
-	// so close started here to release any Stop caller waiting on it.
-	select {
-	case <-started:
-	default:
-		close(started)
-	}
-
-	// Release our slot, unless a reload already replaced us, so a dead listener can't block a future Start
-	d.serverMu.Lock()
-	if d.server == server {
-		d.server = nil
-		d.started = nil
-	}
-	d.serverMu.Unlock()
-
-	if err != nil {
-		d.l.Warn("Failed to run the DNS responder", "error", err)
-	}
+	// All listeners have stopped serving. Clear the running state (unless a
+	// newer Start took over) so a same-addr reload re-runs Start instead of
+	// treating the dead listeners as live. Matches stats' retry-on-unclean-exit.
+	d.clearListenersIfCurrent(myGen)
 }
 
-// Stop shuts down the active server, if any. Idempotent.
+// Stop shuts down all active listeners, if any. Idempotent.
 func (d *dnsServer) Stop() {
 	d.serverMu.Lock()
-	srv := d.server
-	started := d.started
-	d.server = nil
-	d.started = nil
+	listeners := d.listeners
+	d.listeners = nil
 	d.serverMu.Unlock()
-	d.shutdownServer(srv, started, "stop")
+	d.shutdownListeners(listeners, "stop")
 }
 
 // Query returns the address for the given name and query type. The second
@@ -448,11 +515,25 @@ func (d *dnsServer) handleDnsRequest(w dns.ResponseWriter, r *dns.Msg) {
 	w.WriteMsg(m)
 }
 
-func getDnsServerAddr(c *config.C) string {
-	dnsHost := strings.TrimSpace(c.GetString("lighthouse.dns.host", ""))
-	// Old guidance was to provide the literal `[::]` in `lighthouse.dns.host` but that won't resolve.
-	if dnsHost == "[::]" {
-		dnsHost = "::"
+// getDnsServerAddrs returns the DNS responder bind addresses: each configured
+// lighthouse.dns.host (a single string or a list of them) joined with the
+// shared lighthouse.dns.port. A host list lets the responder bind several
+// addresses, e.g. this node's nebula IPs.
+func getDnsServerAddrs(c *config.C) []string {
+	port := strconv.Itoa(c.GetInt("lighthouse.dns.port", 53))
+	hosts := getListenAddrs(c, "lighthouse.dns.host")
+	if len(hosts) == 0 {
+		// Preserve the historical default of binding every interface.
+		hosts = []string{""}
 	}
-	return net.JoinHostPort(dnsHost, strconv.Itoa(c.GetInt("lighthouse.dns.port", 53)))
+	addrs := make([]string, 0, len(hosts))
+	for _, dnsHost := range hosts {
+		dnsHost = strings.TrimSpace(dnsHost)
+		// Old guidance was to provide the literal `[::]` in `lighthouse.dns.host` but that won't resolve.
+		if dnsHost == "[::]" {
+			dnsHost = "::"
+		}
+		addrs = append(addrs, net.JoinHostPort(dnsHost, port))
+	}
+	return addrs
 }

--- a/dns_server_test.go
+++ b/dns_server_test.go
@@ -100,7 +100,7 @@ func TestParsequery(t *testing.T) {
 	assert.Equal(t, dns.RcodeNameError, m.Rcode)
 }
 
-func Test_getDnsServerAddr(t *testing.T) {
+func Test_getDnsServerAddrs(t *testing.T) {
 	c := config.NewC(nil)
 
 	c.Settings["lighthouse"] = map[string]any{
@@ -109,7 +109,7 @@ func Test_getDnsServerAddr(t *testing.T) {
 			"port": "1",
 		},
 	}
-	assert.Equal(t, "0.0.0.0:1", getDnsServerAddr(c))
+	assert.Equal(t, []string{"0.0.0.0:1"}, getDnsServerAddrs(c))
 
 	c.Settings["lighthouse"] = map[string]any{
 		"dns": map[string]any{
@@ -117,7 +117,7 @@ func Test_getDnsServerAddr(t *testing.T) {
 			"port": "1",
 		},
 	}
-	assert.Equal(t, "[::]:1", getDnsServerAddr(c))
+	assert.Equal(t, []string{"[::]:1"}, getDnsServerAddrs(c))
 
 	c.Settings["lighthouse"] = map[string]any{
 		"dns": map[string]any{
@@ -125,7 +125,7 @@ func Test_getDnsServerAddr(t *testing.T) {
 			"port": "1",
 		},
 	}
-	assert.Equal(t, "[::]:1", getDnsServerAddr(c))
+	assert.Equal(t, []string{"[::]:1"}, getDnsServerAddrs(c))
 
 	// Make sure whitespace doesn't mess us up
 	c.Settings["lighthouse"] = map[string]any{
@@ -134,7 +134,16 @@ func Test_getDnsServerAddr(t *testing.T) {
 			"port": "1",
 		},
 	}
-	assert.Equal(t, "[::]:1", getDnsServerAddr(c))
+	assert.Equal(t, []string{"[::]:1"}, getDnsServerAddrs(c))
+
+	// A list of hosts each gets joined with the shared port, in order.
+	c.Settings["lighthouse"] = map[string]any{
+		"dns": map[string]any{
+			"host": []any{"0.0.0.0", "10.0.0.1", "fd00::1"},
+			"port": "53",
+		},
+	}
+	assert.Equal(t, []string{"0.0.0.0:53", "10.0.0.1:53", "[fd00::1]:53"}, getDnsServerAddrs(c))
 }
 
 func newTestDnsServer(t *testing.T) (*dnsServer, *config.C) {
@@ -169,8 +178,8 @@ func TestDnsServer_reload_initial_disabled(t *testing.T) {
 
 	require.NoError(t, ds.reload(c, true))
 	assert.False(t, ds.enabled.Load())
-	assert.Equal(t, "127.0.0.1:0", ds.addr)
-	assert.Nil(t, ds.server)
+	assert.Equal(t, []string{"127.0.0.1:0"}, ds.addrs)
+	assert.Empty(t, ds.listeners)
 }
 
 func TestDnsServer_reload_initial_enabled(t *testing.T) {
@@ -179,9 +188,9 @@ func TestDnsServer_reload_initial_enabled(t *testing.T) {
 
 	require.NoError(t, ds.reload(c, true))
 	assert.True(t, ds.enabled.Load())
-	assert.Equal(t, "127.0.0.1:0", ds.addr)
+	assert.Equal(t, []string{"127.0.0.1:0"}, ds.addrs)
 	// initial never starts a runner; that's Control.Start's job
-	assert.Nil(t, ds.server)
+	assert.Empty(t, ds.listeners)
 }
 
 func TestDnsServer_reload_initial_serveDnsWithoutLighthouse(t *testing.T) {
@@ -199,24 +208,34 @@ func TestDnsServer_reload_sameAddr_noOp(t *testing.T) {
 	setDnsConfig(c, "127.0.0.1", port, true, true)
 	require.NoError(t, ds.reload(c, true))
 
-	go ds.Start()
+	done := make(chan struct{})
+	go func() {
+		ds.Start()
+		close(done)
+	}()
 	waitForBind(t, ds)
 
 	ds.serverMu.Lock()
-	before := ds.server
+	before := ds.listeners
 	ds.serverMu.Unlock()
-	require.NotNil(t, before)
+	require.Len(t, before, 1)
 
 	// Same address, so the running listener must be left alone rather than rebuilt under live queries
 	require.NoError(t, ds.reload(c, false))
 	assert.True(t, ds.enabled.Load())
 
 	ds.serverMu.Lock()
-	after := ds.server
+	after := ds.listeners
 	ds.serverMu.Unlock()
-	assert.Same(t, before, after, "a same-address reload must not restart the listener")
+	require.Len(t, after, 1)
+	assert.Same(t, before[0], after[0], "a same-address reload must not restart the listener")
 
 	ds.Stop()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after Stop")
+	}
 }
 
 // The branch the old sameAddr test was accidentally hitting: enabled with nothing running means reload starts it.
@@ -228,14 +247,14 @@ func TestDnsServer_reload_whenNotRunning_starts(t *testing.T) {
 	// initial only records config, it never starts anything
 	require.NoError(t, ds.reload(c, true))
 	ds.serverMu.Lock()
-	assert.Nil(t, ds.server, "the initial reload must not start a listener")
+	assert.Empty(t, ds.listeners, "the initial reload must not start a listener")
 	ds.serverMu.Unlock()
 
 	require.NoError(t, ds.reload(c, false))
 	waitForBind(t, ds)
 
 	ds.serverMu.Lock()
-	assert.NotNil(t, ds.server, "a reload with nothing running should bring DNS up")
+	assert.Len(t, ds.listeners, 1, "a reload with nothing running should bring DNS up")
 	ds.serverMu.Unlock()
 
 	ds.Stop()
@@ -256,20 +275,7 @@ func TestDnsServer_StartStop_lifecycle(t *testing.T) {
 		close(done)
 	}()
 
-	waitFor(t, func() bool {
-		ds.serverMu.Lock()
-		started := ds.started
-		ds.serverMu.Unlock()
-		if started == nil {
-			return false
-		}
-		select {
-		case <-started:
-			return true
-		default:
-			return false
-		}
-	})
+	waitForBind(t, ds)
 
 	ds.Stop()
 	select {
@@ -426,6 +432,132 @@ func TestDnsServer_reload_disable_stopsRunningServer(t *testing.T) {
 	assert.False(t, ds.enabled.Load())
 }
 
+func TestDnsServer_reload_multiHost_recordsAllAddrs(t *testing.T) {
+	ds, c := newTestDnsServer(t)
+	c.Settings["lighthouse"] = map[string]any{
+		"am_lighthouse": true,
+		"serve_dns":     true,
+		"dns": map[string]any{
+			"host": []any{"10.0.0.1", "fd00::1"},
+			"port": "53",
+		},
+	}
+	require.NoError(t, ds.reload(c, true))
+	// Each host is joined with the shared port; IPv6 is bracketed.
+	assert.Equal(t, []string{"10.0.0.1:53", "[fd00::1]:53"}, ds.addrs)
+}
+
+// TestDnsServer_startListeners_multiAddr is the regression test for the
+// per-listener started-chan machinery: several servers bind, each answers
+// queries via the shared mux, and Stop tears all of them down without hanging.
+func TestDnsServer_startListeners_multiAddr(t *testing.T) {
+	ds, _ := newTestDnsServer(t)
+	ds.enabled.Store(true)
+	ds.Add("multi.example.", []netip.Addr{netip.MustParseAddr("10.9.8.7")})
+
+	addrs := []string{freeUDPPortOn(t, "127.0.0.1")}
+	if v6LoopbackAvailable() {
+		// Exercises IPv6 bracketing end-to-end (the bind-ALL shape a token
+		// with a v6 VPN address produces).
+		addrs = append(addrs, freeUDPPortOn(t, "::1"))
+	}
+
+	ds.startGen++
+	gen := ds.startGen
+	done := make(chan struct{})
+	go func() {
+		ds.startListeners(addrs, gen)
+		close(done)
+	}()
+	waitForBind(t, ds)
+	require.Len(t, ds.listeners, len(addrs))
+
+	for _, a := range addrs {
+		resp := queryDNS(t, a, "multi.example.", dns.TypeA)
+		require.NotEmpty(t, resp.Answer, "listener %s should answer", a)
+		assert.Equal(t, "10.9.8.7", resp.Answer[0].(*dns.A).A.String())
+	}
+
+	ds.Stop()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("startListeners did not return after Stop")
+	}
+}
+
+// TestDnsServer_Start_noAddrs_leavesSlotClear guards the reload-wedge: a Start
+// that bails before binding (here, no configured listen address) must leave the
+// listener slot empty, otherwise reload sees running==true and no-ops every
+// subsequent same-addr SIGHUP, leaving DNS dead forever.
+func TestDnsServer_Start_noAddrs_leavesSlotClear(t *testing.T) {
+	ds, _ := newTestDnsServer(t)
+	ds.enabled.Store(true)
+	ds.addrs = nil
+
+	ds.Start()
+
+	ds.serverMu.Lock()
+	defer ds.serverMu.Unlock()
+	require.Empty(t, ds.listeners, "Start with no addrs must leave the slot clear so reload retries")
+}
+
+// TestDnsServer_startListeners_allBindsFail_clearsListeners covers the other
+// staleness path: when every expanded address fails to bind, startListeners
+// must not leave the dead listeners installed.
+func TestDnsServer_startListeners_allBindsFail_clearsListeners(t *testing.T) {
+	ds, _ := newTestDnsServer(t)
+	ds.enabled.Store(true)
+
+	// Occupy a UDP port, then try to bind it so ListenAndServe fails.
+	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer conn.Close()
+	busy := conn.LocalAddr().String()
+
+	ds.startGen++
+	gen := ds.startGen
+	done := make(chan struct{})
+	go func() {
+		ds.startListeners([]string{busy}, gen)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("startListeners did not return after all binds failed")
+	}
+	require.Nil(t, ds.listeners, "all-binds-failed must clear listeners so reload retries")
+}
+
+func queryDNS(t *testing.T, addr, name string, qtype uint16) *dns.Msg {
+	t.Helper()
+	m := new(dns.Msg)
+	m.SetQuestion(name, qtype)
+	c := &dns.Client{Net: "udp", Timeout: 2 * time.Second}
+	resp, _, err := c.Exchange(m, addr)
+	require.NoError(t, err)
+	return resp
+}
+
+func v6LoopbackAvailable() bool {
+	conn, err := net.ListenPacket("udp", "[::1]:0")
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+func freeUDPPortOn(t *testing.T, host string) string {
+	t.Helper()
+	conn, err := net.ListenPacket("udp", net.JoinHostPort(host, "0"))
+	require.NoError(t, err)
+	port := conn.LocalAddr().(*net.UDPAddr).Port
+	require.NoError(t, conn.Close())
+	return net.JoinHostPort(host, strconv.Itoa(port))
+}
+
 func freeUDPPort(t *testing.T) string {
 	t.Helper()
 	conn, err := net.ListenPacket("udp", "127.0.0.1:0")
@@ -439,17 +571,19 @@ func waitForBind(t *testing.T, ds *dnsServer) {
 	t.Helper()
 	waitFor(t, func() bool {
 		ds.serverMu.Lock()
-		started := ds.started
+		listeners := ds.listeners
 		ds.serverMu.Unlock()
-		if started == nil {
+		if len(listeners) == 0 {
 			return false
 		}
-		select {
-		case <-started:
-			return true
-		default:
-			return false
+		for _, ln := range listeners {
+			select {
+			case <-ln.started:
+			default:
+				return false
+			}
 		}
+		return true
 	})
 }
 
@@ -476,11 +610,11 @@ func TestDnsServer_Start_isIdempotent(t *testing.T) {
 	waitForBind(t, ds)
 
 	ds.serverMu.Lock()
-	first := ds.server
+	first := ds.listeners
 	ds.serverMu.Unlock()
-	require.NotNil(t, first)
+	require.Len(t, first, 1)
 
-	// If the second Start replaces the tracked server, Stop kills the wrong one and the port leaks
+	// If the second Start replaces the tracked listeners, Stop kills the wrong ones and the port leaks
 	done := make(chan struct{})
 	go func() {
 		ds.Start()
@@ -493,9 +627,10 @@ func TestDnsServer_Start_isIdempotent(t *testing.T) {
 	}
 
 	ds.serverMu.Lock()
-	second := ds.server
+	second := ds.listeners
 	ds.serverMu.Unlock()
-	assert.Same(t, first, second, "a second Start must not replace the running server")
+	require.Len(t, second, 1)
+	assert.Same(t, first[0], second[0], "a second Start must not replace the running server")
 
 	// The real proof, after Stop the port must actually be free
 	ds.Stop()
@@ -533,10 +668,10 @@ func TestDnsServer_reload_addrChange_restarts(t *testing.T) {
 		waitForBind(t, ds)
 
 		ds.serverMu.Lock()
-		srv := ds.server
+		listeners := ds.listeners
 		ds.serverMu.Unlock()
-		require.NotNil(t, srv, "reload left DNS down instead of restarting it")
-		require.Equal(t, "127.0.0.1:"+want, srv.Addr, "reload should be serving the new address")
+		require.Len(t, listeners, 1, "reload left DNS down instead of restarting it")
+		require.Equal(t, "127.0.0.1:"+want, listeners[0].server.Addr, "reload should be serving the new address")
 	}
 
 	// Land back on second so the port assertions below are meaningful
@@ -572,7 +707,7 @@ func TestDnsServer_Start_bindFailure_releasesSlot(t *testing.T) {
 	ds.Start() // returns once the bind fails
 
 	ds.serverMu.Lock()
-	assert.Nil(t, ds.server, "a listener that failed to bind must not stay parked in the slot")
+	assert.Empty(t, ds.listeners, "a listener that failed to bind must not stay parked in the slot")
 	ds.serverMu.Unlock()
 
 	// With the slot released, a reload can retry once the port frees up
@@ -581,7 +716,7 @@ func TestDnsServer_Start_bindFailure_releasesSlot(t *testing.T) {
 	waitForBind(t, ds)
 
 	ds.serverMu.Lock()
-	assert.NotNil(t, ds.server, "a same-addr reload should retry after a failed bind")
+	assert.Len(t, ds.listeners, 1, "a same-addr reload should retry after a failed bind")
 	ds.serverMu.Unlock()
 
 	ds.Stop()
@@ -622,7 +757,7 @@ func TestDnsServer_Start_refusesWhenDisabledUnderLock(t *testing.T) {
 	}
 
 	ds.serverMu.Lock()
-	assert.Nil(t, ds.server, "Start must not install a listener a disable already cancelled")
+	assert.Empty(t, ds.listeners, "Start must not install a listener a disable already cancelled")
 	ds.serverMu.Unlock()
 
 	pc, err := net.ListenPacket("udp", "127.0.0.1:"+port)

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -50,6 +50,8 @@ lighthouse:
   #serve_dns: false
   #dns:
     # The DNS host defines the IP to bind the dns listener to. This also allows binding to the nebula node IP.
+    # host may also be a list of IPs to bind the listener to several addresses (e.g. this node's nebula IPs),
+    # each combined with the port below.
     #host: 0.0.0.0
     #port: 53
   # interval is the number of seconds between updates from this node to a lighthouse.

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -210,7 +210,8 @@ punchy:
 #sshd:
   # Toggles the feature
   #enabled: true
-  # Host and port to listen on, port 22 is not allowed for your safety
+  # Host and port to listen on, port 22 is not allowed for your safety.
+  # listen may also be a list of "host:port" addresses to bind several listeners (e.g. this node's nebula IPs).
   #listen: 127.0.0.1:2222
   # A file containing the ssh host private key to use
   # A decent way to generate one: ssh-keygen -t ed25519 -f ssh_host_ed25519_key -N "" < /dev/null

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -353,6 +353,7 @@ logging:
   #interval: 10s
 
   #type: prometheus
+  # listen may also be a list of "host:port" addresses to bind several listeners (e.g. this node's nebula IPs).
   #listen: 127.0.0.1:8080
   #path: /metrics
   #namespace: prometheusns

--- a/listen_addrs.go
+++ b/listen_addrs.go
@@ -1,0 +1,32 @@
+package nebula
+
+import (
+	"fmt"
+
+	"github.com/slackhq/nebula/config"
+)
+
+// getListenAddrs reads a listener config value that may be either a single
+// "host:port" string or a list of them, returning the addresses in order. A
+// missing or empty value returns nil; blank entries in a list are skipped. This
+// is what lets stats.listen and sshd.listen accept multiple bind addresses
+// while remaining backwards compatible with a single string.
+func getListenAddrs(c *config.C, key string) []string {
+	switch v := c.Get(key).(type) {
+	case nil:
+		return nil
+	case []any:
+		addrs := make([]string, 0, len(v))
+		for _, e := range v {
+			if s := fmt.Sprintf("%v", e); s != "" {
+				addrs = append(addrs, s)
+			}
+		}
+		return addrs
+	default:
+		if s := fmt.Sprintf("%v", v); s != "" {
+			return []string{s}
+		}
+		return nil
+	}
+}

--- a/listen_addrs_test.go
+++ b/listen_addrs_test.go
@@ -1,0 +1,34 @@
+package nebula
+
+import (
+	"testing"
+
+	"github.com/slackhq/nebula/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetListenAddrs(t *testing.T) {
+	get := func(t *testing.T, yaml string) []string {
+		c := config.NewC(nil)
+		if err := c.LoadString(yaml); err != nil {
+			t.Fatalf("LoadString: %v", err)
+		}
+		return getListenAddrs(c, "stats.listen")
+	}
+
+	// A single string yields one address.
+	assert.Equal(t, []string{"127.0.0.1:8080"},
+		get(t, "stats:\n  listen: '127.0.0.1:8080'\n"))
+
+	// A list yields several, in order.
+	assert.Equal(t, []string{"100.64.0.5:8080", "[fd00::5]:8080"},
+		get(t, "stats:\n  listen:\n    - '100.64.0.5:8080'\n    - '[fd00::5]:8080'\n"))
+
+	// Blank list entries are skipped.
+	assert.Equal(t, []string{"127.0.0.1:8080"},
+		get(t, "stats:\n  listen:\n    - '127.0.0.1:8080'\n    - ''\n"))
+
+	// Missing and empty values yield nil.
+	assert.Nil(t, get(t, "stats:\n  path: /metrics\n"))
+	assert.Nil(t, get(t, "stats:\n  listen: ''\n"))
+}

--- a/ssh.go
+++ b/ssh.go
@@ -79,17 +79,18 @@ func wireSSHReload(l *slog.Logger, ssh *sshd.SSHServer, c *config.C) {
 // that callers may invoke to run the configured ssh server. On
 // failure, it returns nil, error.
 func configSSH(l *slog.Logger, ssh *sshd.SSHServer, c *config.C) (func(), error) {
-	listen := c.GetString("sshd.listen", "")
-	if listen == "" {
+	listenAddrs := getListenAddrs(c, "sshd.listen")
+	if len(listenAddrs) == 0 {
 		return nil, fmt.Errorf("sshd.listen must be provided")
 	}
-
-	_, port, err := net.SplitHostPort(listen)
-	if err != nil {
-		return nil, fmt.Errorf("invalid sshd.listen address: %s", err)
-	}
-	if port == "22" {
-		return nil, fmt.Errorf("sshd.listen can not use port 22")
+	for _, listen := range listenAddrs {
+		_, port, err := net.SplitHostPort(listen)
+		if err != nil {
+			return nil, fmt.Errorf("invalid sshd.listen address %q: %s", listen, err)
+		}
+		if port == "22" {
+			return nil, fmt.Errorf("sshd.listen can not use port 22")
+		}
 	}
 
 	hostKeyPathOrKey := c.GetString("sshd.host_key", "")
@@ -98,6 +99,7 @@ func configSSH(l *slog.Logger, ssh *sshd.SSHServer, c *config.C) (func(), error)
 	}
 
 	var hostKeyBytes []byte
+	var err error
 	if strings.Contains(hostKeyPathOrKey, "-----BEGIN") {
 		hostKeyBytes = []byte(hostKeyPathOrKey)
 	} else {
@@ -187,7 +189,7 @@ func configSSH(l *slog.Logger, ssh *sshd.SSHServer, c *config.C) (func(), error)
 	if c.GetBool("sshd.enabled", false) {
 		ssh.Stop()
 		runner = func() {
-			if err := ssh.Run(listen); err != nil {
+			if err := ssh.Run(listenAddrs); err != nil {
 				l.Warn("Failed to run the SSH server", "error", err)
 			}
 		}

--- a/ssh_test.go
+++ b/ssh_test.go
@@ -1,0 +1,70 @@
+package nebula
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/slackhq/nebula/config"
+	"github.com/slackhq/nebula/sshd"
+	"github.com/slackhq/nebula/test"
+)
+
+// TestConfigSSH_listenValidation covers sshd.listen accepting either a single
+// address or a list, with per-address validation (port 22 rejected, malformed
+// rejected, empty rejected).
+func TestConfigSSH_listenValidation(t *testing.T) {
+	l := test.NewLogger()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	attempt := func(t *testing.T, listenYAML string) error {
+		c := config.NewC(l)
+		if err := c.LoadString("sshd:\n  enabled: true\n  listen: " + listenYAML + "\n"); err != nil {
+			t.Fatalf("LoadString: %v", err)
+		}
+		ssh, err := sshd.NewSSHServer(ctx, l)
+		if err != nil {
+			t.Fatalf("NewSSHServer: %v", err)
+		}
+		_, err = configSSH(l, ssh, c)
+		return err
+	}
+
+	// A valid listen config passes listen validation and then fails on the
+	// missing host key, which is how we know the addresses were accepted.
+	t.Run("single address passes listen validation", func(t *testing.T) {
+		err := attempt(t, "'127.0.0.1:2222'")
+		if err == nil || !strings.Contains(err.Error(), "host_key") {
+			t.Fatalf("expected host_key error, got: %v", err)
+		}
+	})
+
+	t.Run("list of addresses passes listen validation", func(t *testing.T) {
+		err := attempt(t, "['127.0.0.1:2222', '[::1]:2223']")
+		if err == nil || !strings.Contains(err.Error(), "host_key") {
+			t.Fatalf("expected host_key error, got: %v", err)
+		}
+	})
+
+	t.Run("port 22 anywhere in the list is rejected", func(t *testing.T) {
+		err := attempt(t, "['127.0.0.1:2222', '0.0.0.0:22']")
+		if err == nil || !strings.Contains(err.Error(), "port 22") {
+			t.Fatalf("expected port 22 rejection, got: %v", err)
+		}
+	})
+
+	t.Run("malformed address is rejected", func(t *testing.T) {
+		err := attempt(t, "'not-host-port'")
+		if err == nil || !strings.Contains(err.Error(), "invalid sshd.listen") {
+			t.Fatalf("expected invalid sshd.listen error, got: %v", err)
+		}
+	})
+
+	t.Run("empty listen is rejected", func(t *testing.T) {
+		err := attempt(t, "''")
+		if err == nil || !strings.Contains(err.Error(), "must be provided") {
+			t.Fatalf("expected must be provided error, got: %v", err)
+		}
+	})
+}

--- a/sshd/server.go
+++ b/sshd/server.go
@@ -28,7 +28,14 @@ type SSHServer struct {
 	// List of available commands
 	helpCommand *Command
 	commands    *radix.Tree
-	listener    net.Listener
+	// listenerMu guards listeners against a Run/Stop (or Run/Run reload) race:
+	// the slice header is multiple words, so an unsynchronized read during a
+	// write could observe a torn value.
+	listenerMu sync.Mutex
+	// listeners holds the sockets the current Run owns. Stop closes whatever is
+	// here; a fast reload may overwrite this before a prior run's watcher fires,
+	// so each run also closes its own locals (see Run).
+	listeners []net.Listener
 
 	// ctx parents per-Run contexts. Cancelling it (e.g. via Control.Stop) tears the server down even
 	// across reloads, since each Run derives a fresh child rather than reusing this one directly.
@@ -165,42 +172,65 @@ func (s *SSHServer) RegisterCommand(c *Command) {
 	s.commands.Insert(c.Name, c)
 }
 
-// Run begins listening and accepting connections. Each invocation derives a fresh per-Run context
-// from the constructor-supplied ctx so a Stop+Run sequence (used by config reload) starts clean
-// rather than carrying a permanently-cancelled context across runs.
-func (s *SSHServer) Run(addr string) error {
+// Run begins listening and accepting connections on every address in addrs. Each invocation derives a
+// fresh per-Run context from the constructor-supplied ctx so a Stop+Run sequence (used by config
+// reload) starts clean rather than carrying a permanently-cancelled context across runs.
+//
+// Binding is all-or-nothing: if any address fails to bind, the already-bound listeners for this run
+// are closed and the error is returned so the failure surfaces loudly.
+func (s *SSHServer) Run(addrs []string) error {
 	if s.ctx.Err() != nil {
 		return s.ctx.Err()
 	}
 
-	listener, err := net.Listen("tcp", addr)
-	if err != nil {
-		return err
+	listeners := make([]net.Listener, 0, len(addrs))
+	for _, addr := range addrs {
+		listener, err := net.Listen("tcp", addr)
+		if err != nil {
+			for _, ln := range listeners {
+				ln.Close()
+			}
+			return err
+		}
+		listeners = append(listeners, listener)
 	}
-	// s.listener is the public handle Stop uses to interrupt the active run; listener (the local) is what
-	// this run owns. They start equal but a fast reload may overwrite s.listener with the next run's
-	// listener before this run's watcher fires, so each run must close its own listener via the local
-	// reference.
-	s.listener = listener
+
+	// s.listeners is the public handle Stop uses to interrupt the active run; listeners (the locals) are
+	// what this run owns. They start equal but a fast reload may overwrite s.listeners with the next
+	// run's listeners before this run's watcher fires, so each run must close its own listeners via the
+	// local references.
+	s.listenerMu.Lock()
+	s.listeners = listeners
+	s.listenerMu.Unlock()
 
 	runCtx, cancel := context.WithCancel(s.ctx)
 	defer cancel()
 
-	// Close the listener when this run's context is cancelled. That can come from the parent
+	// Close this run's listeners when its context is cancelled. That can come from the parent
 	// (Control.Stop), from Run returning normally (defer cancel above), or transitively when a sibling
-	// run cancels through Stop closing the listener. net.Listener.Close is idempotent so a duplicate
+	// run cancels through Stop closing the listeners. net.Listener.Close is idempotent so a duplicate
 	// close from Stop is benign.
 	go func() {
 		<-runCtx.Done()
-		if err := listener.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
-			s.l.Warn("Failed to close the sshd listener", "error", err)
+		for _, ln := range listeners {
+			if err := ln.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
+				s.l.Warn("Failed to close the sshd listener", "error", err)
+			}
 		}
 	}()
 
-	s.l.Info("SSH server is listening", "sshListener", addr)
+	s.l.Info("SSH server is listening", "sshListeners", addrs)
 
-	// Run loops until there is an error
-	s.run(runCtx, listener)
+	// Serve every listener until its accept loop exits, then wait for them all.
+	var wg sync.WaitGroup
+	for _, listener := range listeners {
+		wg.Add(1)
+		go func(listener net.Listener) {
+			defer wg.Done()
+			s.run(runCtx, listener)
+		}(listener)
+	}
+	wg.Wait()
 
 	s.l.Info("SSH server stopped listening")
 	// We don't return an error because run logs for us
@@ -264,8 +294,11 @@ func (s *SSHServer) run(ctx context.Context, listener net.Listener) {
 }
 
 func (s *SSHServer) Stop() {
-	if s.listener != nil {
-		if err := s.listener.Close(); err != nil {
+	s.listenerMu.Lock()
+	listeners := s.listeners
+	s.listenerMu.Unlock()
+	for _, ln := range listeners {
+		if err := ln.Close(); err != nil && !errors.Is(err, net.ErrClosed) {
 			s.l.Warn("Failed to close the sshd listener", "error", err)
 		}
 	}

--- a/sshd/server_test.go
+++ b/sshd/server_test.go
@@ -1,0 +1,153 @@
+package sshd
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
+// waitAccept dials addr and confirms the server accepts a TCP connection.
+func waitAccept(t *testing.T, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		conn, err := net.DialTimeout("tcp", addr, 200*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("could not connect to %s: %v", addr, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// startServer binds the requested addresses on ephemeral ports and returns the
+// server plus the resolved concrete addresses Run is listening on.
+func startServer(t *testing.T, addrs []string) (*SSHServer, []string) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	s, err := NewSSHServer(ctx, testLogger())
+	if err != nil {
+		t.Fatalf("NewSSHServer: %v", err)
+	}
+
+	// Pre-bind to learn the ephemeral ports, then hand the concrete addresses
+	// to Run so tests can dial them.
+	resolved := make([]string, len(addrs))
+	for i, a := range addrs {
+		ln, err := net.Listen("tcp", a)
+		if err != nil {
+			t.Fatalf("probe listen %s: %v", a, err)
+		}
+		resolved[i] = ln.Addr().String()
+		ln.Close()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := s.Run(resolved); err != nil {
+			t.Errorf("Run returned error: %v", err)
+		}
+	}()
+	t.Cleanup(func() {
+		s.Stop()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("Run did not return after Stop")
+		}
+	})
+
+	for _, a := range resolved {
+		waitAccept(t, a)
+	}
+	return s, resolved
+}
+
+// TestSSHServer_Run_MultipleListeners pins the bind-ALL behavior: every address
+// in the slice accepts connections, and Stop closes all of them.
+func TestSSHServer_Run_MultipleListeners(t *testing.T) {
+	s, resolved := startServer(t, []string{"127.0.0.1:0", "[::1]:0"})
+
+	for _, a := range resolved {
+		waitAccept(t, a)
+	}
+
+	s.Stop()
+
+	// After Stop every listener should be closed; a fresh dial must fail.
+	deadline := time.Now().Add(2 * time.Second)
+	for _, a := range resolved {
+		for {
+			conn, err := net.DialTimeout("tcp", a, 100*time.Millisecond)
+			if err != nil {
+				break
+			}
+			conn.Close()
+			if time.Now().After(deadline) {
+				t.Fatalf("listener %s still accepting after Stop", a)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+}
+
+// TestSSHServer_Run_SingleListener pins legacy single-address behavior.
+func TestSSHServer_Run_SingleListener(t *testing.T) {
+	_, resolved := startServer(t, []string{"127.0.0.1:0"})
+	if len(resolved) != 1 {
+		t.Fatalf("expected 1 listener, got %d", len(resolved))
+	}
+	waitAccept(t, resolved[0])
+}
+
+// TestSSHServer_Run_BindFailureIsAllOrNothing verifies that if any address in
+// the slice fails to bind, Run returns the error and leaves nothing listening.
+func TestSSHServer_Run_BindFailureIsAllOrNothing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Occupy a port so the second bind in Run fails.
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("occupy listen: %v", err)
+	}
+	defer occupied.Close()
+	occupiedAddr := occupied.Addr().String()
+
+	// A free address that Run should bind first, then have to tear down.
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("probe listen: %v", err)
+	}
+	freeAddr := probe.Addr().String()
+	probe.Close()
+
+	s, err := NewSSHServer(ctx, testLogger())
+	if err != nil {
+		t.Fatalf("NewSSHServer: %v", err)
+	}
+
+	if err := s.Run([]string{freeAddr, occupiedAddr}); err == nil {
+		t.Fatal("expected Run to fail when an address cannot bind")
+	}
+
+	// The successfully-bound first address must have been closed on the failure
+	// path, so it is available to bind again.
+	ln, err := net.Listen("tcp", freeAddr)
+	if err != nil {
+		t.Fatalf("first listener leaked (still bound): %v", err)
+	}
+	ln.Close()
+}

--- a/stats.go
+++ b/stats.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"reflect"
 	"runtime"
 	"strconv"
 	"sync"
@@ -50,7 +51,8 @@ type statsRuntime struct {
 }
 
 // statsConfig is the snapshot of stats-related config that drives the runtime.
-// It is comparable with == so reload can detect "no change" cheaply.
+// reload compares it with reflect.DeepEqual to detect "no change" (prom.listen
+// is a slice, so the struct isn't comparable with ==).
 type statsConfig struct {
 	typ      string
 	interval time.Duration
@@ -69,7 +71,9 @@ type graphiteConfig struct {
 }
 
 type promConfig struct {
-	listen    string
+	// listen holds one or more "host:port" bind addresses. A single string in
+	// config yields one entry; a list yields several (all served together).
+	listen    []string
 	path      string
 	namespace string
 	subsystem string
@@ -118,7 +122,7 @@ func (s *statsServer) reload(c *config.C, initial bool) error {
 	enabled := newCfg.typ != "" && newCfg.typ != "none"
 
 	s.runMu.Lock()
-	sameCfg := s.runCfg != nil && *s.runCfg == newCfg
+	sameCfg := s.runCfg != nil && reflect.DeepEqual(*s.runCfg, newCfg)
 	s.runCfg = &newCfg
 	running := s.run != nil
 	s.runMu.Unlock()
@@ -166,7 +170,7 @@ func (s *statsServer) Start() {
 		// Graphite: no HTTP listener to serve; block until teardown.
 		<-runCtx.Done()
 	} else {
-		cleanExit = s.serveListener(listener)
+		cleanExit = s.serveListeners(listener, cfg.prom.listen)
 	}
 
 	// Clear our runtime only if nothing has replaced it. Stop races through
@@ -186,20 +190,35 @@ func (s *statsServer) Start() {
 	s.runMu.Unlock()
 }
 
-// serveListener runs ListenAndServe and ensures ctx cancellation unblocks it.
-// Returns true if the listener exited cleanly (Stop, ctx cancellation, or any
-// other http.ErrServerClosed path), false on an unexpected error.
-func (s *statsServer) serveListener(listener *http.Server) bool {
-	// Per-invocation watcher: ctx cancellation triggers a listener shutdown
-	// which in turn unblocks ListenAndServe. Closing `done` on exit keeps
-	// the watcher from outliving this call.
+// serveListeners binds every configured address up front and serves them all
+// from one http.Server. Binding is all-or-nothing: a single bind failure closes
+// the already-bound listeners and reports an unclean exit, so a same-config
+// SIGHUP can retry. ctx cancellation (or Stop) shuts the server down, which
+// closes every listener it is serving, unblocking all the Serve goroutines.
+func (s *statsServer) serveListeners(srv *http.Server, addrs []string) bool {
+	listeners := make([]net.Listener, 0, len(addrs))
+	for _, a := range addrs {
+		ln, err := net.Listen("tcp", a)
+		if err != nil {
+			s.l.Error("Failed to bind prometheus stats listener", "addr", a, "error", err)
+			for _, l := range listeners {
+				_ = l.Close()
+			}
+			return false
+		}
+		listeners = append(listeners, ln)
+	}
+
+	// Per-invocation watcher: ctx cancellation triggers a server shutdown that
+	// closes all served listeners. Closing `done` on exit keeps the watcher
+	// from outliving this call.
 	done := make(chan struct{})
 	go func() {
 		select {
 		case <-s.ctx.Done():
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			if err := listener.Shutdown(shutdownCtx); err != nil {
+			if err := srv.Shutdown(shutdownCtx); err != nil {
 				s.l.Warn("Failed to shut down prometheus stats listener", "error", err)
 			}
 		case <-done:
@@ -207,13 +226,26 @@ func (s *statsServer) serveListener(listener *http.Server) bool {
 	}()
 	defer close(done)
 
-	s.l.Info("Starting prometheus stats listener", "addr", listener.Addr)
-	err := listener.ListenAndServe()
-	if err == nil || errors.Is(err, http.ErrServerClosed) {
-		return true
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	cleanExit := true
+	for _, ln := range listeners {
+		s.l.Info("Starting prometheus stats listener", "addr", ln.Addr())
+		wg.Add(1)
+		go func(ln net.Listener) {
+			defer wg.Done()
+			err := srv.Serve(ln)
+			if err == nil || errors.Is(err, http.ErrServerClosed) {
+				return
+			}
+			s.l.Error("Prometheus stats listener exited", "addr", ln.Addr(), "error", err)
+			mu.Lock()
+			cleanExit = false
+			mu.Unlock()
+		}(ln)
 	}
-	s.l.Error("Prometheus stats listener exited", "error", err)
-	return false
+	wg.Wait()
+	return cleanExit
 }
 
 // Stop tears down the active runtime, if any. Idempotent.
@@ -301,7 +333,9 @@ func (s *statsServer) buildRuntime(cfg statsConfig) ([]func(), *http.Server) {
 		errLog := slog.NewLogLogger(s.l.Handler(), slog.LevelError)
 		mux := http.NewServeMux()
 		mux.Handle(cfg.prom.path, promhttp.HandlerFor(pr, promhttp.HandlerOpts{ErrorLog: errLog}))
-		return captureFns, &http.Server{Addr: cfg.prom.listen, Handler: mux}
+		// Addr is unused: serveListeners binds each address explicitly via
+		// net.Listen and serves them with srv.Serve.
+		return captureFns, &http.Server{Handler: mux}
 	}
 	return captureFns, nil
 }
@@ -349,8 +383,8 @@ func loadStatsConfig(c *config.C) (statsConfig, error) {
 		cfg.graphite.resolvedAddr = addr.String()
 		cfg.graphite.prefix = c.GetString("stats.prefix", "nebula")
 	case "prometheus":
-		cfg.prom.listen = c.GetString("stats.listen", "")
-		if cfg.prom.listen == "" {
+		cfg.prom.listen = getListenAddrs(c, "stats.listen")
+		if len(cfg.prom.listen) == 0 {
 			return cfg, errors.New("stats.listen should not be empty")
 		}
 		cfg.prom.path = c.GetString("stats.path", "")

--- a/stats_test.go
+++ b/stats_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"net/http"
 	"strconv"
 	"testing"
 	"time"
@@ -357,6 +358,127 @@ func TestStatsServer_listenerBindFailure_sameCfgReloadRetries(t *testing.T) {
 	require.NotNil(t, currentRuntime(s))
 
 	s.Stop()
+}
+
+// TestStatsServer_singleListener verifies a single configured listen address
+// binds and serves through the serveListeners path.
+func TestStatsServer_singleListener(t *testing.T) {
+	port := freeTCPPort(t)
+	s, c := newTestStatsServer(t)
+	setStatsConfig(c, map[string]any{
+		"type":     "prometheus",
+		"interval": "1s",
+		"listen":   "127.0.0.1:" + port,
+		"path":     "/metrics",
+	})
+	require.NoError(t, s.reload(c, true))
+
+	done := make(chan struct{})
+	go func() {
+		s.Start()
+		close(done)
+	}()
+	waitForListening(t, "127.0.0.1:"+port)
+
+	rt := currentRuntime(s)
+	require.NotNil(t, rt)
+	require.NotNil(t, rt.listener)
+
+	s.Stop()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after Stop")
+	}
+}
+
+// TestStatsServer_serveListeners_multiBind drives the multi-listener path
+// directly: every configured address binds and answers the handler, and ctx
+// cancellation unblocks the call.
+func TestStatsServer_serveListeners_multiBind(t *testing.T) {
+	l := slog.New(slog.DiscardHandler)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := &statsServer{l: l, ctx: ctx}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/metrics", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "ok")
+	})
+	srv := &http.Server{Handler: mux}
+
+	addrs := []string{reserveTCPAddr(t, "127.0.0.1")}
+	if v6, ok := tryReserveTCPAddr(t, "[::1]"); ok {
+		addrs = append(addrs, v6)
+	}
+
+	result := make(chan bool, 1)
+	go func() { result <- s.serveListeners(srv, addrs) }()
+
+	for _, a := range addrs {
+		waitForListening(t, a)
+		resp, err := http.Get("http://" + a + "/metrics")
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		assert.Equal(t, "ok", string(body))
+	}
+
+	cancel()
+	select {
+	case clean := <-result:
+		assert.True(t, clean, "serveListeners should report a clean exit on ctx cancel")
+	case <-time.After(5 * time.Second):
+		t.Fatal("serveListeners did not return after ctx cancel")
+	}
+}
+
+// TestStatsServer_serveListeners_partialBindFailure ensures a failed bind on
+// one address closes the already-bound listeners (no leak) and reports an
+// unclean exit.
+func TestStatsServer_serveListeners_partialBindFailure(t *testing.T) {
+	l := slog.New(slog.DiscardHandler)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := &statsServer{l: l, ctx: ctx}
+
+	// Hold a port so the second bind fails; the first (ephemeral) succeeds.
+	blocker, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer blocker.Close()
+	taken := blocker.Addr().String()
+
+	free := reserveTCPAddr(t, "127.0.0.1")
+
+	srv := &http.Server{Handler: http.NewServeMux()}
+	clean := s.serveListeners(srv, []string{free, taken})
+	assert.False(t, clean, "partial bind failure should be an unclean exit")
+
+	// The first listener must have been closed: its address is bindable again.
+	ln, err := net.Listen("tcp", free)
+	require.NoError(t, err, "first listener was not closed on partial bind failure")
+	require.NoError(t, ln.Close())
+}
+
+// reserveTCPAddr returns a free host:port on the given host by briefly binding
+// and releasing an ephemeral port.
+func reserveTCPAddr(t *testing.T, host string) string {
+	t.Helper()
+	addr, ok := tryReserveTCPAddr(t, host)
+	require.True(t, ok, "could not reserve a TCP address on %s", host)
+	return addr
+}
+
+func tryReserveTCPAddr(t *testing.T, host string) (string, bool) {
+	t.Helper()
+	ln, err := net.Listen("tcp", host+":0")
+	if err != nil {
+		return "", false
+	}
+	addr := ln.Addr().String()
+	require.NoError(t, ln.Close())
+	return addr, true
 }
 
 func waitForListening(t *testing.T, addr string) {


### PR DESCRIPTION
Problem: It is not possible to listen _only_ on _every_ Nebula IP. You can listen on 0.0.0.0 or [::] but this will also listen publicly. You can listen on a specific Nebula IP, but Nebula does not currently support listing multiple.

Solution:

stats.listen now accepts either a single "host:port" string (as before) or a
list of them, binding one Prometheus listener per address. This lets a node
serve stats on several addresses, e.g. each of its nebula IPs, without a
wildcard bind.

Adds the shared getListenAddrs helper (string-or-list, backwards compatible)
and refactors the prometheus serving path to bind every configured address up
front and serve them from one http.Server.

Caveats:

- You must be careful to update the IPs in the config if the IPs in the cert change

Alternatives:

- Special `<nebula>` listener for Nebula IPs only - this solution offers less flexibility (see #1801)