### PR TITLE
Be less verbose with handshake send errors

### DIFF
--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -295,7 +295,13 @@ func (hm *HandshakeManager) handleOutbound(vpnIp netip.Addr, lighthouseTriggered
 		hm.messageMetrics.Tx(header.Handshake, hh.machine.Subtype(), 1)
 		err := hm.outside.WriteTo(stage0, addr)
 		if err != nil {
-			hostinfo.logger(hm.l).Error("Failed to send handshake message",
+			// These repeat every attempt, so match the success log below and only shout when the remotes changed
+			level := slog.LevelDebug
+			if remotesHaveChanged {
+				level = slog.LevelError
+			}
+
+			hostinfo.logger(hm.l).Log(context.Background(), level, "Failed to send handshake message",
 				"udpAddr", addr,
 				"initiatorIndex", hostinfo.localIndexId,
 				"handshake", hsFields,

--- a/inside.go
+++ b/inside.go
@@ -408,7 +408,7 @@ func (f *Interface) sendNoMetrics(t header.MessageType, st header.MessageSubType
 		if err != nil {
 			hostinfo.logger(f.l).Error("Failed to write outgoing packet",
 				"error", err,
-				"udpAddr", remote,
+				"udpAddr", hr,
 			)
 		}
 	} else {


### PR DESCRIPTION
This dampens the log verbosity of messages like
```
level=error msg="Failed to send handshake message" error="sendto: no route to host" handshake="map[stage:1 style:ix_psk0]" initiatorIndex=1 localIndex=7 remoteIndex=0 udpAddr="[1]:51599" vpnAddrs="[2]"
```

Basically we log write errors at error level only if the list of remotes changes, this matches the success logging behavior and doesn't cost any additional memory.
