### PR TITLE
before removing a pending hostinfo in handshake_manager, make sure it's the one we wanted to delete

### DIFF
--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -529,7 +529,9 @@ func (hm *HandshakeManager) DeleteHostInfo(hostinfo *HostInfo) {
 
 func (hm *HandshakeManager) unlockedDeleteHostInfo(hostinfo *HostInfo) {
 	for _, addr := range hostinfo.vpnAddrs {
-		delete(hm.vpnIps, addr)
+		if cur, ok := hm.vpnIps[addr]; ok && cur.hostinfo == hostinfo {
+			delete(hm.vpnIps, addr)
+		}
 	}
 
 	if len(hm.vpnIps) == 0 {


### PR DESCRIPTION
Clod found this. It admits that hitting it is very difficult.