### PR TITLE
Advertise underlay addresses on Android

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,11 +222,14 @@ test-cov-html:
 	go test -coverprofile=coverage.out
 	go tool cover -html=coverage.out
 
+# The package builds only compile. The final line links an android binary so a linker-only failure,
+# such as the //go:linkname reference anet makes, cannot pass CI.
 build-test-mobile:
 	GOARCH=amd64 GOOS=ios go build $(shell go list ./... | grep -v '/cmd/\|/examples/')
 	GOARCH=arm64 GOOS=ios go build $(shell go list ./... | grep -v '/cmd/\|/examples/')
 	GOARCH=amd64 GOOS=android go build $(shell go list ./... | grep -v '/cmd/\|/examples/')
 	GOARCH=arm64 GOOS=android go build $(shell go list ./... | grep -v '/cmd/\|/examples/')
+	GOARCH=arm64 GOOS=android go build -ldflags=-checklinkname=0 -o /dev/null ${NEBULA_CMD_PATH}
 
 bench:
 	go test -bench=.

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6
 	github.com/stretchr/testify v1.11.1
 	github.com/vishvananda/netlink v1.3.1
+	github.com/wlynxg/anet v0.0.5
 	go.uber.org/goleak v1.3.0
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.54.0

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ github.com/vishvananda/netlink v1.3.1 h1:3AEMt62VKqz90r0tmNhog0r/PpWKmrEShJU0wJW
 github.com/vishvananda/netlink v1.3.1/go.mod h1:ARtKouGSTGchR8aMwmkzC0qiNPrrWO5JS/XMVl45+b4=
 github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zdEY=
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
+github.com/wlynxg/anet v0.0.5 h1:J3VJGi1gvo0JwZ/P1/Yc/8p63SoW98B5dHkYDmpgvvU=
+github.com/wlynxg/anet v0.0.5/go.mod h1:eay5PRQr7fIVAMbTbchTnO9gG65Hg/uYGdc7mguHxoA=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/hostmap.go
+++ b/hostmap.go
@@ -868,26 +868,26 @@ func (i *HostInfo) logger(l *slog.Logger) *slog.Logger {
 
 // Utility functions
 
-func localAddrs(l *slog.Logger, allowList *LocalAllowList) []netip.Addr {
+func localAddrs(l *slog.Logger, allowList *LocalAllowList) ([]netip.Addr, error) {
 	return collectLocalAddrs(l, allowList, localInterfaces, localInterfaceAddrs)
 }
 
 // collectLocalAddrs takes its enumerators as arguments so tests can drive the filtering and the
-// failure branches without depending on the addresses of whatever host they run on.
+// failure branches without depending on the addresses of whatever host they run on. It reports
+// failures to the caller rather than logging them, because it runs on every lighthouse update and
+// only the caller can tell a new failure from a repeat of the same one.
 func collectLocalAddrs(
 	l *slog.Logger,
 	allowList *LocalAllowList,
 	interfaces func() ([]net.Interface, error),
 	interfaceAddrs func(*net.Interface) ([]net.Addr, error),
-) []netip.Addr {
+) ([]netip.Addr, error) {
 	//FIXME: This function is pretty garbage
 	var finalAddrs []netip.Addr
+	var errs []error
 	ifaces, err := interfaces()
 	if err != nil {
-		l.Warn("Failed to enumerate local interfaces, no underlay addresses will be advertised to lighthouses",
-			"error", err,
-		)
-		return nil
+		return nil, fmt.Errorf("failed to enumerate local interfaces: %w", err)
 	}
 
 	for _, i := range ifaces {
@@ -904,10 +904,7 @@ func collectLocalAddrs(
 		}
 		addrs, err := interfaceAddrs(&i)
 		if err != nil {
-			l.Warn("Failed to get addresses for local interface",
-				"error", err,
-				"interfaceName", i.Name,
-			)
+			errs = append(errs, fmt.Errorf("failed to get addresses for %s: %w", i.Name, err))
 			continue
 		}
 
@@ -945,5 +942,5 @@ func collectLocalAddrs(
 			}
 		}
 	}
-	return finalAddrs
+	return finalAddrs, errors.Join(errs...)
 }

--- a/hostmap.go
+++ b/hostmap.go
@@ -869,9 +869,27 @@ func (i *HostInfo) logger(l *slog.Logger) *slog.Logger {
 // Utility functions
 
 func localAddrs(l *slog.Logger, allowList *LocalAllowList) []netip.Addr {
+	return collectLocalAddrs(l, allowList, localInterfaces, localInterfaceAddrs)
+}
+
+// collectLocalAddrs takes its enumerators as arguments so tests can drive the filtering and the
+// failure branches without depending on the addresses of whatever host they run on.
+func collectLocalAddrs(
+	l *slog.Logger,
+	allowList *LocalAllowList,
+	interfaces func() ([]net.Interface, error),
+	interfaceAddrs func(*net.Interface) ([]net.Addr, error),
+) []netip.Addr {
 	//FIXME: This function is pretty garbage
 	var finalAddrs []netip.Addr
-	ifaces, _ := net.Interfaces()
+	ifaces, err := interfaces()
+	if err != nil {
+		l.Warn("Failed to enumerate local interfaces, no underlay addresses will be advertised to lighthouses",
+			"error", err,
+		)
+		return nil
+	}
+
 	for _, i := range ifaces {
 		allow := allowList.AllowName(i.Name)
 		if l.Enabled(context.Background(), logging.LevelTrace) {
@@ -884,7 +902,15 @@ func localAddrs(l *slog.Logger, allowList *LocalAllowList) []netip.Addr {
 		if !allow {
 			continue
 		}
-		addrs, _ := i.Addrs()
+		addrs, err := interfaceAddrs(&i)
+		if err != nil {
+			l.Warn("Failed to get addresses for local interface",
+				"error", err,
+				"interfaceName", i.Name,
+			)
+			continue
+		}
+
 		for _, rawAddr := range addrs {
 			var addr netip.Addr
 			switch v := rawAddr.(type) {

--- a/hostmap_test.go
+++ b/hostmap_test.go
@@ -1,7 +1,6 @@
 package nebula
 
 import (
-	"bytes"
 	"errors"
 	"net"
 	"net/netip"
@@ -430,7 +429,8 @@ func TestCollectLocalAddrs(t *testing.T) {
 	addrsFor := func(i *net.Interface) ([]net.Addr, error) { return addrs[i.Name], nil }
 
 	// Loopback and link local are dropped, everything else on every interface is kept.
-	out := collectLocalAddrs(test.NewLogger(), nil, enumerate, addrsFor)
+	out, err := collectLocalAddrs(test.NewLogger(), nil, enumerate, addrsFor)
+	require.NoError(t, err)
 	assert.Equal(t, []netip.Addr{
 		netip.MustParseAddr("10.0.0.5"),
 		netip.MustParseAddr("fd00::5"),
@@ -450,7 +450,8 @@ func TestCollectLocalAddrs(t *testing.T) {
 		asked[i.Name] = struct{}{}
 		return addrs[i.Name], nil
 	}
-	out = collectLocalAddrs(test.NewLogger(), al, enumerate, countingAddrsFor)
+	out, err = collectLocalAddrs(test.NewLogger(), al, enumerate, countingAddrsFor)
+	require.NoError(t, err)
 	assert.Equal(t, []netip.Addr{
 		netip.MustParseAddr("10.0.0.5"),
 		netip.MustParseAddr("fd00::5"),
@@ -458,21 +459,18 @@ func TestCollectLocalAddrs(t *testing.T) {
 	assert.NotContains(t, asked, "docker0")
 
 	// A failure to enumerate interfaces at all is reported rather than silently advertising nothing.
-	logOut := &bytes.Buffer{}
-	out = collectLocalAddrs(
-		test.NewLoggerWithOutput(logOut),
+	out, err = collectLocalAddrs(
+		test.NewLogger(),
 		nil,
 		func() ([]net.Interface, error) { return nil, errors.New("netlinkrib: permission denied") },
 		addrsFor,
 	)
 	assert.Nil(t, out)
-	assert.Contains(t, logOut.String(), "Failed to enumerate local interfaces")
-	assert.Contains(t, logOut.String(), "netlinkrib: permission denied")
+	require.EqualError(t, err, "failed to enumerate local interfaces: netlinkrib: permission denied")
 
 	// One interface failing is reported and skipped, the rest are still collected.
-	logOut.Reset()
-	out = collectLocalAddrs(
-		test.NewLoggerWithOutput(logOut),
+	out, err = collectLocalAddrs(
+		test.NewLogger(),
 		nil,
 		enumerate,
 		func(i *net.Interface) ([]net.Addr, error) {
@@ -483,6 +481,5 @@ func TestCollectLocalAddrs(t *testing.T) {
 		},
 	)
 	assert.Equal(t, []netip.Addr{netip.MustParseAddr("172.17.0.1")}, out)
-	assert.Contains(t, logOut.String(), "Failed to get addresses for local interface")
-	assert.Contains(t, logOut.String(), "eth0")
+	require.EqualError(t, err, "failed to get addresses for eth0: nope")
 }

--- a/hostmap_test.go
+++ b/hostmap_test.go
@@ -1,6 +1,9 @@
 package nebula
 
 import (
+	"bytes"
+	"errors"
+	"net"
 	"net/netip"
 	"slices"
 	"testing"
@@ -400,4 +403,86 @@ func TestHostMap_RelayState(t *testing.T) {
 	h1.relayState.DeleteRelay(a1)
 	assert.Equal(t, []netip.Addr{}, h1.relayState.relays)
 
+}
+
+func TestCollectLocalAddrs(t *testing.T) {
+	ifaces := []net.Interface{
+		{Index: 1, Name: "lo"},
+		{Index: 2, Name: "eth0"},
+		{Index: 3, Name: "docker0"},
+	}
+	addrs := map[string][]net.Addr{
+		"lo": {
+			&net.IPNet{IP: net.ParseIP("127.0.0.1"), Mask: net.CIDRMask(8, 32)},
+			&net.IPNet{IP: net.ParseIP("::1"), Mask: net.CIDRMask(128, 128)},
+		},
+		"eth0": {
+			&net.IPNet{IP: net.ParseIP("10.0.0.5"), Mask: net.CIDRMask(24, 32)},
+			&net.IPNet{IP: net.ParseIP("fe80::1"), Mask: net.CIDRMask(64, 128)},
+			&net.IPAddr{IP: net.ParseIP("fd00::5")},
+		},
+		"docker0": {
+			&net.IPNet{IP: net.ParseIP("172.17.0.1"), Mask: net.CIDRMask(16, 32)},
+		},
+	}
+
+	enumerate := func() ([]net.Interface, error) { return ifaces, nil }
+	addrsFor := func(i *net.Interface) ([]net.Addr, error) { return addrs[i.Name], nil }
+
+	// Loopback and link local are dropped, everything else on every interface is kept.
+	out := collectLocalAddrs(test.NewLogger(), nil, enumerate, addrsFor)
+	assert.Equal(t, []netip.Addr{
+		netip.MustParseAddr("10.0.0.5"),
+		netip.MustParseAddr("fd00::5"),
+		netip.MustParseAddr("172.17.0.1"),
+	}, out)
+
+	// An interface the allow list rejects by name is never asked for its addresses.
+	c := config.NewC(test.NewLogger())
+	c.Settings["allowlist"] = map[string]any{
+		"interfaces": map[string]any{`docker.*`: false},
+	}
+	al, err := NewLocalAllowListFromConfig(c, "allowlist")
+	require.NoError(t, err)
+
+	asked := make(map[string]struct{})
+	countingAddrsFor := func(i *net.Interface) ([]net.Addr, error) {
+		asked[i.Name] = struct{}{}
+		return addrs[i.Name], nil
+	}
+	out = collectLocalAddrs(test.NewLogger(), al, enumerate, countingAddrsFor)
+	assert.Equal(t, []netip.Addr{
+		netip.MustParseAddr("10.0.0.5"),
+		netip.MustParseAddr("fd00::5"),
+	}, out)
+	assert.NotContains(t, asked, "docker0")
+
+	// A failure to enumerate interfaces at all is reported rather than silently advertising nothing.
+	logOut := &bytes.Buffer{}
+	out = collectLocalAddrs(
+		test.NewLoggerWithOutput(logOut),
+		nil,
+		func() ([]net.Interface, error) { return nil, errors.New("netlinkrib: permission denied") },
+		addrsFor,
+	)
+	assert.Nil(t, out)
+	assert.Contains(t, logOut.String(), "Failed to enumerate local interfaces")
+	assert.Contains(t, logOut.String(), "netlinkrib: permission denied")
+
+	// One interface failing is reported and skipped, the rest are still collected.
+	logOut.Reset()
+	out = collectLocalAddrs(
+		test.NewLoggerWithOutput(logOut),
+		nil,
+		enumerate,
+		func(i *net.Interface) ([]net.Addr, error) {
+			if i.Name == "eth0" {
+				return nil, errors.New("nope")
+			}
+			return addrs[i.Name], nil
+		},
+	)
+	assert.Equal(t, []netip.Addr{netip.MustParseAddr("172.17.0.1")}, out)
+	assert.Contains(t, logOut.String(), "Failed to get addresses for local interface")
+	assert.Contains(t, logOut.String(), "eth0")
 }

--- a/lighthouse.go
+++ b/lighthouse.go
@@ -40,6 +40,10 @@ type LightHouse struct {
 	// addresses rather than whatever this machine's NICs happen to be. Set it before Start.
 	localAddrsFn func(*LocalAllowList) []netip.Addr
 
+	// lastLocalAddrsErr is the previous localAddrsFn failure. Enumeration runs on every update, so an
+	// unchanged failure is demoted to Debug rather than warning every lighthouse.interval forever.
+	lastLocalAddrsErr atomic.Pointer[string]
+
 	// Local cache of answers from light houses
 	// map of vpn addr to answers
 	addrMap map[netip.Addr]*RemoteList
@@ -112,7 +116,9 @@ func NewLightHouseFromConfig(ctx context.Context, l *slog.Logger, c *config.C, c
 		l:                  l,
 	}
 	h.localAddrsFn = func(al *LocalAllowList) []netip.Addr {
-		return localAddrs(h.l, al)
+		addrs, err := localAddrs(h.l, al)
+		h.logLocalAddrsErr(err)
+		return addrs
 	}
 
 	lighthouses := make([]netip.Addr, 0)
@@ -911,6 +917,26 @@ func (lh *LightHouse) TriggerUpdate() {
 	case lh.updateTrigger <- struct{}{}:
 	default:
 	}
+}
+
+// logLocalAddrsErr reports a localAddrs failure at Warn the first time it is seen and at Debug while
+// it persists unchanged, so a permanent failure does not warn on every update forever.
+func (lh *LightHouse) logLocalAddrsErr(err error) {
+	if err == nil {
+		lh.lastLocalAddrsErr.Store(nil)
+		return
+	}
+
+	msg := err.Error()
+	prev := lh.lastLocalAddrsErr.Swap(&msg)
+	if prev != nil && *prev == msg {
+		if lh.l.Enabled(context.Background(), slog.LevelDebug) {
+			lh.l.Debug("Failed to collect local addresses to advertise", "error", err)
+		}
+		return
+	}
+
+	lh.l.Warn("Failed to collect local addresses to advertise", "error", err)
 }
 
 func (lh *LightHouse) SendUpdate() {

--- a/lighthouse_test.go
+++ b/lighthouse_test.go
@@ -1,7 +1,9 @@
 package nebula
 
 import (
+	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"net/netip"
 	"testing"
@@ -737,4 +739,33 @@ func TestLighthouse_DeletesWork(t *testing.T) {
 	//verify
 	out = lh.Query(testHost)
 	assert.Nil(t, out)
+}
+
+func TestLightHouse_logLocalAddrsErr(t *testing.T) {
+	out := &bytes.Buffer{}
+	lh := &LightHouse{l: test.NewLoggerWithOutput(out)}
+
+	// The first sighting of a failure warns.
+	lh.logLocalAddrsErr(errors.New("permission denied"))
+	assert.Contains(t, out.String(), "level=WARN")
+	assert.Contains(t, out.String(), "permission denied")
+
+	// Repeating unchanged does not warn again, which is what keeps a permanent failure from warning
+	// on every lighthouse.interval for the life of the process.
+	out.Reset()
+	lh.logLocalAddrsErr(errors.New("permission denied"))
+	assert.NotContains(t, out.String(), "level=WARN")
+
+	// A different failure is a new event and warns.
+	out.Reset()
+	lh.logLocalAddrsErr(errors.New("something else"))
+	assert.Contains(t, out.String(), "level=WARN")
+	assert.Contains(t, out.String(), "something else")
+
+	// Recovering resets, so the same failure returning later warns again.
+	out.Reset()
+	lh.logLocalAddrsErr(nil)
+	assert.Empty(t, out.String())
+	lh.logLocalAddrsErr(errors.New("something else"))
+	assert.Contains(t, out.String(), "level=WARN")
 }

--- a/localaddrs.go
+++ b/localaddrs.go
@@ -1,0 +1,13 @@
+//go:build !android
+
+package nebula
+
+import "net"
+
+func localInterfaces() ([]net.Interface, error) {
+	return net.Interfaces()
+}
+
+func localInterfaceAddrs(i *net.Interface) ([]net.Addr, error) {
+	return i.Addrs()
+}

--- a/localaddrs_android.go
+++ b/localaddrs_android.go
@@ -1,0 +1,32 @@
+//go:build android
+
+package nebula
+
+import (
+	"net"
+
+	"github.com/wlynxg/anet"
+)
+
+// anet relies on //go:linkname and so needs -ldflags=-checklinkname=0 on Go 1.23+. Nebula ships no
+// Android binaries of its own, so that burden falls on consumers linking Android artifacts.
+
+func init() {
+	// anet only takes its bind-free path when it believes it is on API 30+, and detecting the running
+	// device's level requires cgo. Pin it so a CGO_ENABLED=0 build cannot quietly fall back to the
+	// denied path. The bind-free path is correct on older releases too, just unnecessary there.
+	anet.SetAndroidVersion(11)
+}
+
+// The app sandbox denies bind() on netlink_route_socket, so the stdlib's RTM_GETLINK enumeration
+// fails with EACCES and we advertise no underlay addresses at all. anet reads RTM_GETADDR from an
+// unbound socket instead, so this must not be collapsed back into net.Interfaces.
+func localInterfaces() ([]net.Interface, error) {
+	return anet.Interfaces()
+}
+
+// net.Interface.Addrs goes back through the denied netlink path, so addresses have to come from anet
+// as well. anet cannot report HardwareAddr, which localAddrs does not read.
+func localInterfaceAddrs(i *net.Interface) ([]net.Addr, error) {
+	return anet.InterfaceAddrsByInterface(i)
+}


### PR DESCRIPTION
On Android 11+ the app sandbox denies bind() on netlink_route_socket, so the stdlib's net.Interfaces fails with EACCES. localAddrs discarded that error and returned an empty slice, so the node advertised no underlay addresses and peers could only ever reach it at the address a lighthouse observed. A device on the same LAN as a peer was unreachable at its LAN address.

Split interface enumeration behind a build-tagged seam and use github.com/wlynxg/anet on Android, which reads RTM_GETADDR from an unbound socket. Interface addresses have to come from anet as well, since net.Interface.Addrs goes back through the same denied path. Every other platform keeps the net package implementation.

Stop discarding the enumeration errors, which are exceptional now that the sandbox case is handled. localAddrs runs inside every SendUpdate, so collectLocalAddrs returns its failures rather than logging them and the lighthouse warns only when the error changes, demoting repeats to Debug. Otherwise a permanent failure would warn every lighthouse.interval for the life of the process. This follows the same shape as the repeated-handshake-failure logging in handshake_manager.go.

anet relies on //go:linkname, so linking any Android main package now requires -ldflags=-checklinkname=0 on Go 1.23+. That includes `go build ./cmd/nebula` for GOOS=android, which fails without it:

```
link: github.com/wlynxg/anet: invalid reference to net.zoneCache
```

build-test-mobile only compiled packages, so it never exercised the link step and would not have caught this. It now links cmd/nebula for android with the flag, which both covers the regression and records the requirement. Consumers linking their own Android artifacts, gomobile bind included, need the same flag.

## Verification

Reproduced and fixed in a real app sandbox, on a headless API 36 arm64 AVD, staged into the data dir of an installed debuggable package and run via `run-as`. Inside the app UID and SELinux domain:

```
uid=10213
=== net.Interfaces() ===
  ERROR: route ip+net: netlinkrib: permission denied
=== net.InterfaceAddrs() ===
  ERROR: route ip+net: netlinkrib: permission denied
=== localInterfaces() + localInterfaceAddrs() ===
  lo: addrs=[127.0.0.1/8 ::1/128] err=<nil>
  eth0: addrs=[10.0.2.15/24 fec0::5054:ff:fe12:3456/64 fe80::5054:ff:fe12:3456/64] err=<nil>
  wlan0: addrs=[10.0.2.16/24 fec0::23f8:5c84:bec1:30b7/64 fec0::e979:a56:c99:9172/64 fe80::413a:773b:d7d5:10ce/64] err=<nil>
  dummy0: addrs=[fe80::4447:78ff:fea7:9595/64] err=<nil>
=== localAddrs() ===
  10.0.2.15
  fec0::5054:ff:fe12:3456
  10.0.2.16
  fec0::23f8:5c84:bec1:30b7
  fec0::e979:a56:c99:9172
```

The stdlib calls fail where the patched path returns the full set, and the resulting address set is identical to the same binary run as the unrestricted shell user.

Caveat: `run-as` lands in `runas_app`, not `untrusted_app`. `runas_app` is no more restricted, so a denial there implies a denial in the real app domain, but the real app domain was not directly measured.

### The cgo guard

The bind-free path itself needs no cgo. anet's netlink and ioctl code (`netlink_android.go`, `interface_android.go`) is pure Go over `syscall` and `unsafe`. cgo appears in exactly one file in the library, `android_api_level_cgo.go`, whose only job is to call `android_get_device_api_level()` from `<android/api-level.h>`.

That one call means `anet.Interfaces()` takes the bind-free path only when it believes it is on API 30+, and defers to `net.Interfaces()` otherwise. In a non-cgo build the detection file is replaced by a stub returning -1, the check fails, and anet falls back to exactly the broken call this PR exists to avoid.

The two Android build paths disagree on cgo, and this repo's is the non-cgo one:

- This repo exports `CGO_ENABLED=0` (Makefile:2-3), so every android build it produces is non-cgo, including the build-test-mobile link added above. Detection returns -1 and the fix would be inert.
- The shipping artifact is the other way round. mobile_nebula builds with `gomobile bind --target=android -androidapi=26`, and gomobile forces `CGO_ENABLED=1` unconditionally (`cmd/gomobile/bind.go:231`), so detection would succeed there.

So without a guard the fix would work in the .aar and do nothing in the builds CI exercises.

`anet.SetAndroidVersion(11)` in an `init()` sets anet's `customAndroidApiLevel`, which short-circuits `androidApiLevel()` before detection is consulted. The cgo call site becomes unreachable, the pure-Go netlink path is taken unconditionally, and the result no longer depends on how the binary was built.

Verified: the `CGO_ENABLED=0` build produced the same output shown above inside the app sandbox, identical to the cgo build. A control build with only that one line removed fell back to `netlinkrib: permission denied`.

### Pre-Android-11

The Android file claims the bind-free path is correct on older releases too, just unnecessary there. Checked on Android 8.0.0 / API 26, the floor mobile_nebula builds for (`gomobile bind -androidapi=26`), by comparing a probe pinned with `anet.SetAndroidVersion(11)` against the stdlib on the same device, where the stdlib still works because there is no sandbox denial before Android 11:

```
=== comparison ===
  MATCH: both paths advertise [192.168.200.2 192.168.232.2 fec0::3864:ddff:fe9c:45b2
                               fec0::a8f1:a98a:216:c858 fec0::e1b0:90cf:82d9:ae1
                               fec0::ff:fe44:5566]
```

anet reports fewer interfaces than the stdlib, 3 against 5, because it only returns interfaces that have addresses. The resulting address set is identical, which is all localAddrs consumes.

Caveat: emulator running the goldfish kernel, not physical API 26 hardware. The mechanism under test, RTM_GETADDR plus ioctl against RTM_GETLINK, is kernel level, so the equivalence should hold, but it is an emulator result.
