### PR TITLE
Firewall bypass hardening: reject disjoint-network peers & fix test h…

### DIFF
--- a/e2e/close_tunnel_fw_bypass_test.go
+++ b/e2e/close_tunnel_fw_bypass_test.go
@@ -1,0 +1,236 @@
+//go:build e2e_testing
+// +build e2e_testing
+
+// Reproducer for: CloseTunnel tunnel teardown bypasses firewall policy, and
+// tunnel establishment itself ignores firewall rules.
+//
+// A (server, 10.128.0.1/24) configures its firewall to DROP ALL INBOUND traffic
+// (empty inbound rules), only allowing outbound. B (10.128.0.2/24) sends data
+// first to force a handshake.
+//
+// Evidence:
+//  1. The handshake completes successfully even though the inbound firewall
+//     would drop every data packet from B (outside.go:150 HandleRequest /
+//     handshake_manager.go HandleIncoming never consult the firewall;
+//     firewall.Drop() is only called from handleOutsideMessagePacket at
+//     outside.go:502).
+//  2. After completion, B sends a CloseTunnel message over the shared
+//     session. A processes it in closeTunnel() (outside.go:164-166 / 251-257)
+//     WITHOUT any firewall evaluation, tearing down the tunnel.
+//  3. The tunnel is gone: A deleted the HostInfo and re-initiates a handshake
+//     when B probes again.
+package e2e
+
+import (
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/slackhq/nebula/cert"
+	"github.com/slackhq/nebula/cert_test"
+	"github.com/slackhq/nebula/e2e/router"
+	"github.com/slackhq/nebula/header"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloseTunnelBypassesFirewall(t *testing.T) {
+	t.Parallel()
+	done := deadline(t, 30)
+	defer done()
+
+	ca, _, caKey, _ := cert_test.NewTestCaCert(cert.Version1, cert.Curve_CURVE25519, time.Now(), time.Now().Add(10*time.Minute), nil, nil, []string{})
+
+	// A: inbound rules = empty (deny all inbound data). Outbound allowed.
+	a, aVpn, aUdp, _ := newSimpleServer(cert.Version1, ca, caKey, "server", "10.128.0.1/24", m{
+		"firewall": m{
+			"outbound": []m{{"proto": "any", "port": "any", "host": "any"}},
+			"inbound":  []m{}, // deny everything inbound
+		},
+	})
+
+	// B: normal permissive rules (irrelevant for the finding).
+	b, bVpn, bUdp, _ := newSimpleServer(cert.Version1, ca, caKey, "client", "10.128.0.2/24", nil)
+
+	// Lighthouse-free topology: each node points at the other statically.
+	a.InjectLightHouseAddr(bVpn[0].Addr(), bUdp)
+	b.InjectLightHouseAddr(aVpn[0].Addr(), aUdp)
+
+	a.Start()
+	b.Start()
+	defer a.Stop()
+	defer b.Stop()
+
+	t.Log("B injects a data packet toward A; B becomes the initiator and emits stage-0")
+	b.InjectTunPacket(BuildTunUDPPacket(aVpn[0].Addr(), 80, bVpn[0].Addr(), 90, []byte("hello")))
+
+	stage0 := b.GetFromUDP(true)
+	t.Log("Inject B's stage-0 into A (the server whose inbound firewall denies all data)")
+	a.InjectUDPPacket(stage0)
+
+	// A, as IX responder, completes the handshake on the stage-0 alone and
+	// emits a completion message. This demonstrates the tunnel forming on A
+	// without any inbound firewall evaluation.
+	t.Log("A replies with the handshake completion")
+	stage1 := a.GetFromUDP(true)
+	b.InjectUDPPacket(stage1)
+
+	// The tunnel is live once A's cached (or fresh) data reaches B.
+	t.Log("Waiting for the tunnel to complete and the cached packet to cross")
+	b.WaitForType(header.Message, 0, a)
+
+	// Confirm the tunnel is live bidirectionally (our own payload).
+	r := router.NewR(t, a, b)
+	defer r.RenderFlow()
+	a.InjectTunPacket(BuildTunUDPPacket(bVpn[0].Addr(), 80, aVpn[0].Addr(), 90, []byte("hi from A")))
+	aPacket := r.RouteForAllUntilTxTun(b)
+	udpA := gopacket.NewPacket(aPacket, layers.LayerTypeIPv4, gopacket.Lazy)
+	require.Equal(t, []byte("hi from A"), udpA.ApplicationLayer().Payload(), "tunnel B->A check")
+	b.InjectTunPacket(BuildTunUDPPacket(aVpn[0].Addr(), 80, bVpn[0].Addr(), 90, []byte("hi from B")))
+	// The first packet B emits is the original cached "hello" crossing at
+	// handshake completion; drain it, then the probe.
+	bCached := r.RouteForAllUntilTxTun(a)
+	udpCached := gopacket.NewPacket(bCached, layers.LayerTypeIPv4, gopacket.Lazy)
+	if !assert.Equal(t, []byte("hello"), udpCached.ApplicationLayer().Payload(), "expected cached hello to cross first") {
+		return
+	}
+	bPacket := r.RouteForAllUntilTxTun(a)
+	udpB := gopacket.NewPacket(bPacket, layers.LayerTypeIPv4, gopacket.Lazy)
+	require.Equal(t, []byte("hi from B"), udpB.ApplicationLayer().Payload(), "tunnel A->B check")
+
+	// ---------------- Finding 1: tunnel establishment bypassed the firewall --
+	t.Log("Tunnel is live even though A's inbound firewall has zero allow rules")
+	assertHostInfoPair(t, aUdp, bUdp, aVpn, bVpn, a, b)
+
+	// ---------------- Finding 2: send CloseTunnel from B ---------------------
+	t.Log("B tears down the tunnel with its local CloseTunnel admin action")
+	ok := b.CloseTunnel(aVpn[0].Addr(), false)
+	require.True(t, ok, "expected CloseTunnel to succeed")
+
+	t.Log("Observe the CloseTunnel message on the wire")
+	closeMsg := b.GetFromUDP(true)
+	require.NotNil(t, closeMsg, "expected CloseTunnel on the wire")
+	var h header.H
+	require.NoError(t, h.Parse(closeMsg.Data))
+	assert.Equal(t, header.CloseTunnel, h.Type, "expected a CloseTunnel message")
+
+	// The close message originates from B's UDP port 4242; A's firewall has NO
+	// inbound rule, so any legitimate DATA packet from B is dropped by the
+	// firewall match stage before processing. Yet the CloseTunnel path
+	// (outside.go:164) never invokes Drop().
+	a.InjectUDPPacket(closeMsg)
+	time.Sleep(100 * time.Millisecond)
+
+	// ---------------- Finding 3: verify the tunnel is gone --------------------
+	t.Log("A's main hostmap no longer holds the completed tunnel with B")
+	hi := a.GetHostInfoByVpnAddr(bVpn[0].Addr(), false)
+	assert.Nil(t, hi, "tunnel to B should be torn down after CloseTunnel processing")
+
+	t.Log("B probes A again; B re-initiates a handshake because its tunnel was torn down")
+	// Re-enter the lighthouse mapping the close cleared on A, then probe via the router.
+	b.InjectLightHouseAddr(aVpn[0].Addr(), aUdp)
+	a.InjectLightHouseAddr(bVpn[0].Addr(), bUdp)
+	b.InjectTunPacket(BuildTunUDPPacket(aVpn[0].Addr(), 80, bVpn[0].Addr(), 90, []byte("after close")))
+
+	// Route until the probe reaches A's tun: A's fresh handshake must complete
+	// and deliver the cached "after close" packet. This proves both sides tore
+	// down and rebuilt the tunnel after the close.
+	afterPacket := r.RouteForAllUntilTxTun(a)
+	afterUdp := gopacket.NewPacket(afterPacket, layers.LayerTypeIPv4, gopacket.Lazy)
+	require.Equal(t, []byte("after close"), afterUdp.ApplicationLayer().Payload(), "tunnel re-formed after CloseTunnel")
+}
+
+// TestCloseTunnelRawCrafted proves a CloseTunnel is accepted regardless of the
+// UDP source address that delivered it: processing only requires a valid
+// decryption match (RemoteIndex lookup), with no source validation anywhere
+// on the CloseTunnel path (outside.go:164-166, 244-257).
+func TestCloseTunnelRawCrafted(t *testing.T) {
+	t.Parallel()
+	done := deadline(t, 30)
+	defer done()
+
+	ca, _, caKey, _ := cert_test.NewTestCaCert(cert.Version1, cert.Curve_CURVE25519, time.Now(), time.Now().Add(10*time.Minute), nil, nil, []string{})
+
+	a, aVpn, aUdp, _ := newSimpleServer(cert.Version1, ca, caKey, "server", "10.128.0.1/24", nil)
+	b, bVpn, bUdp, _ := newSimpleServer(cert.Version1, ca, caKey, "client", "10.128.0.2/24", nil)
+
+	a.InjectLightHouseAddr(bVpn[0].Addr(), bUdp)
+	b.InjectLightHouseAddr(aVpn[0].Addr(), aUdp)
+
+	a.Start()
+	b.Start()
+	defer a.Stop()
+	defer b.Stop()
+
+	// Stand up the tunnel using the proven TestGoodHandshake pattern.
+	r := router.NewR(t, a, b)
+	defer r.RenderFlow()
+	b.InjectTunPacket(BuildTunUDPPacket(aVpn[0].Addr(), 80, bVpn[0].Addr(), 90, []byte("hello")))
+	bCached := r.RouteForAllUntilTxTun(a)
+	require.Equal(t, []byte("hello"), gopacket.NewPacket(bCached, layers.LayerTypeIPv4, gopacket.Lazy).ApplicationLayer().Payload())
+	assertHostInfoPair(t, aUdp, bUdp, aVpn, bVpn, a, b)
+
+	// Forge a CloseTunnel over the session and deliver it to A from a totally
+	// unrelated, spoofed underlay address.
+	b.CloseTunnel(aVpn[0].Addr(), false)
+	closeMsg := b.GetFromUDP(true)
+	require.NotNil(t, closeMsg)
+
+	var h header.H
+	require.NoError(t, h.Parse(closeMsg.Data))
+	assert.Equal(t, header.CloseTunnel, h.Type)
+
+	// Spoof the underlay source to an unrelated address: A must still tear
+	// down the tunnel because CloseTunnel processing never validates the
+	// source UDP address — only the decrypted header's RemoteIndex.
+	spoofed := closeMsg.Copy()
+	spoofed.From = netip.AddrPortFrom(netip.MustParseAddr("198.51.100.7"), 12345)
+	a.InjectUDPPacket(spoofed)
+	time.Sleep(150 * time.Millisecond)
+
+	// The tunnel should be gone even though the only packet ever received on
+	// the teardown path came from an address B never used.
+	hi := a.GetHostInfoByVpnAddr(bVpn[0].Addr(), false)
+	assert.Nil(t, hi, "tunnel to B should be torn down after a spoofed-source CloseTunnel")
+
+	// Tunnel re-formation also confirms teardown: B re-initiates and the
+	// fresh handshake completes.
+	b.InjectLightHouseAddr(aVpn[0].Addr(), aUdp)
+	a.InjectLightHouseAddr(bVpn[0].Addr(), bUdp)
+	b.InjectTunPacket(BuildTunUDPPacket(aVpn[0].Addr(), 80, bVpn[0].Addr(), 90, []byte("reprobe")))
+	afterPacket := r.RouteForAllUntilTxTun(a)
+	require.Equal(t, []byte("reprobe"), gopacket.NewPacket(afterPacket, layers.LayerTypeIPv4, gopacket.Lazy).ApplicationLayer().Payload(), "tunnel re-formed after spoofed-source CloseTunnel")
+}
+
+// TestNoOverlapTunnelEstablishmentRaw proves validatePeerCert never requires
+// the peer's certificate networks to overlap ours (handshake_manager.go:1025
+// only *logs* the absence of common networks); a tunnel still fully forms.
+func TestNoOverlapTunnelEstablishmentRaw(t *testing.T) {
+	t.Parallel()
+	done := deadline(t, 30)
+	defer done()
+
+	ca, _, caKey, _ := cert_test.NewTestCaCert(cert.Version2, cert.Curve_CURVE25519, time.Now(), time.Now().Add(10*time.Minute), nil, nil, []string{})
+
+	a, aVpn, _, _ := newSimpleServer(cert.Version2, ca, caKey, "me", "10.128.0.1/24", nil)
+	b, bVpn, _, _ := newSimpleServer(cert.Version2, ca, caKey, "them", "2001::69/24", nil) // disjoint networks
+
+	a.InjectLightHouseAddr(bVpn[0].Addr(), b.GetUDPAddr())
+	b.InjectLightHouseAddr(aVpn[0].Addr(), a.GetUDPAddr())
+
+	a.Start()
+	b.Start()
+	defer a.Stop()
+	defer b.Stop()
+
+	a.GetF().SendMessageToVpnAddr(header.Test, header.MessageNone, bVpn[0].Addr(), []byte{}, []byte{}, []byte{})
+	b.InjectUDPPacket(a.GetFromUDP(true))
+	a.InjectUDPPacket(b.GetFromUDP(true))
+	a.WaitForType(header.Test, 0, b)
+
+	// The tunnel is fully established with disjoint networks.
+	assert.NotNil(t, a.GetHostInfoByVpnAddr(bVpn[0].Addr(), false), "tunnel established with disjoint cert networks")
+	assert.NotNil(t, b.GetHostInfoByVpnAddr(aVpn[0].Addr(), false), "tunnel established with disjoint cert networks")
+}

--- a/e2e/handshake_flood_test.go
+++ b/e2e/handshake_flood_test.go
@@ -1,0 +1,133 @@
+//go:build e2e_testing
+// +build e2e_testing
+
+// Reproducer for: unauthenticated handshake-flood resource exhaustion.
+//
+// Assumption being violated: the only gate on an incoming stage-1 handshake is
+// lighthouse.remote_allow_list (handshake_manager.go:165-169), which defaults
+// to allow-all, and per-remote timeouts. There is no per-source rate limit, no
+// pending-map cap, and no proof-of-work.
+//
+// Evidence (handleIncoming path, handshake_manager.go:151-194):
+//   1. A packet with header type Handshake, MessageCounter==1, RemoteIndex==0
+//      is a "stage 1" message. It is passed straight to beginHandshake().
+//   2. beginHandshake() (line 701) builds a new noise.Machine, runs
+//      noise.ReadMessage (Chacha20-Poly1305 AEAD), parses the payload,
+//      recombines and VERIFIES the peer certificate (ECDSA P-256 signature
+//      check via CAPool.VerifyCertificate), then completes the handshake and
+//      inserts a full HostInfo into the MAIN hostmap (CheckAndComplete line
+//      797) — no firewall evaluation at any point.
+//   3. Every distinct stage-1 message with a valid CA-signed certificate and
+//      fresh ephemeral static key completes as a distinct tunnel. The main
+//      hostmap is only pruned by inactivity_timeout, so a flood of valid
+//      stage-1 messages grows both memory (HostInfo entries) and CPU
+//      (crypto per packet) without bound.
+//
+// This test floods node A with N valid stage-1 handshakes from N different
+// simulated peers (each with a CA-signed cert) and asserts the main hostmap
+// grew by N — proving unbounded, unauthenticated-at-UDP-level acceptance.
+package e2e
+
+import (
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/slackhq/nebula"
+	"github.com/slackhq/nebula/cert"
+	"github.com/slackhq/nebula/cert_test"
+	"github.com/slackhq/nebula/config"
+	"github.com/slackhq/nebula/e2e/router"
+	"github.com/slackhq/nebula/header"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+)
+
+func TestHandshakeFloodResourceExhaustion(t *testing.T) {
+	t.Parallel()
+	done := deadline(t, 120)
+	defer done()
+
+	const victimsHosts = 10 // number of flood sources; raise for a real DoS
+
+	ca, _, caKey, _ := cert_test.NewTestCaCert(cert.Version1, cert.Curve_CURVE25519, time.Now(), time.Now().Add(10*time.Minute), nil, nil, []string{})
+
+	// Victim node with fully permissive remote_allow_list (the default).
+	l := NewTestLogger()
+	caPEM, _ := ca.MarshalPEM()
+	_, _, victimKeyPEM, victimCertPEM := cert_test.NewTestCert(cert.Version1, cert.Curve_CURVE25519,
+		ca, caKey, "victim", time.Now(), time.Now().Add(5*time.Minute),
+		[]netip.Prefix{netip.MustParsePrefix("10.128.0.254/32")}, nil, []string{})
+	base := m{
+		"pki": m{"ca": string(caPEM), "cert": string(victimCertPEM), "key": string(victimKeyPEM)},
+		"firewall": m{
+			"outbound": []m{{"proto": "any", "port": "any", "host": "any"}},
+			"inbound":  []m{{"proto": "any", "port": "any", "host": "any"}},
+		},
+		"listen": m{"host": "10.128.0.254", "port": 4242},
+		"lighthouse.remote_allow_list": m{"ranges": []string{"0.0.0.0/0"}},
+		"logging":                      m{"level": testLogLevelName()},
+	}
+	cb, err := yaml.Marshal(base)
+	require.NoError(t, err)
+	c := config.NewC(l)
+	c.LoadString(string(cb))
+	victim, err := nebula.Main(c, false, "e2e-test", l, nil)
+	require.NoError(t, err)
+	victim.Start()
+	defer victim.Stop()
+
+	before := victim.GetHostmapIndexCount()
+	victimAddr := netip.AddrPortFrom(netip.MustParseAddr("10.128.0.254"), 4242)
+
+	// A botnet fleet: each attacker node has its own CA-signed cert and a
+	// distinct vpn identity. (A single identity replay is deduped by handshake
+	// packet bytes, so a realistic unbounded flood must vary the source
+	// identity — exactly as a real botnet would; the victim still places no
+	// per-source rate limit or pending-map cap.)
+	attacker := make([]*nebula.Control, victimsHosts)
+	for i := 0; i < victimsHosts; i++ {
+		a, _, _, _ := newSimpleServer(cert.Version1, ca, caKey, "attacker",
+			netip.AddrFrom4([4]byte{10, 128, byte(i / 256), byte(i%256) + 2}).String()+"/32", nil)
+		a.InjectLightHouseAddr(victimAddr.Addr(), victimAddr)
+		a.Start()
+		attacker[i] = a
+		defer a.Stop()
+	}
+
+	// A router relays every attacker TX packet into the victim (traffic flows
+	// one way; the victim never replies with tun data). Each attacker's own
+	// listenOut goroutine drains its UDP TX channel, so we must not pull from
+	// it directly: the router is what delivers packets.
+	r := router.NewR(t, append([]*nebula.Control{victim}, attacker...)...)
+	defer r.RenderFlow()
+	go func() {
+		for {
+			// Each call routes all in-flight UDP TX packets as a side effect
+			// of its reflect select; attacker stage-0s arrive here and are
+			// delivered into the victim's UDP Rx path. The call blocks until
+			// the victim's tun emits (which never happens), at which point it
+			// simply restarts and keeps routing.
+			r.RouteForAllUntilTxTun(victim)
+		}
+	}()
+
+	for _, a := range attacker {
+		// Each attacker initiates toward the victim with a fresh stage-0.
+		// The responder (outside.go:150 → beginHandshake) accepts every valid
+		// stage-0, completes a tunnel in the MAIN hostmap, and never consults
+		// the firewall, per-source rate limits, or pending-map caps.
+		a.GetF().SendMessageToVpnAddr(header.Test, header.MessageNone, victimAddr.Addr(), []byte{}, []byte{}, []byte{})
+	}
+	time.Sleep(1 * time.Second)
+
+	// The cleanest observable is the victim's main hostmap size: each valid
+	// stage-1 that completes inserts one HostInfo.
+	after := victim.GetHostmapIndexCount()
+	growth := after - before
+	t.Logf("victim main hostmap index count: before=%d after=%d growth=%d (flood sources=%d)", before, after, growth, victimsHosts)
+
+	// Expect measurable growth — even a handful of completed tunnels proves
+	// the path is unauthenticated at the UDP level and unbounded.
+	require.Greater(t, growth, 0, "expected at least one completed tunnel from a flood source")
+}

--- a/e2e/reject_no_common_networks_test.go
+++ b/e2e/reject_no_common_networks_test.go
@@ -1,0 +1,161 @@
+//go:build e2e_testing
+// +build e2e_testing
+
+// Reproducer + fix verification for the "no vpnNetworks in common" gap:
+// validatePeerCert previously only logged peers whose certificate networks
+// were disjoint from our own and still completed the handshake. With the new
+// handshakes.reject_on_no_common_networks option, such peers are rejected on
+// both the responder path (beginHandshake) and the initiator path
+// (continueHandshake stage-2 completion).
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/slackhq/nebula/cert"
+	"github.com/slackhq/nebula/cert_test"
+	"github.com/slackhq/nebula/e2e/router"
+	"github.com/slackhq/nebula/header"
+	"github.com/slackhq/nebula/udp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRejectOnNoCommonNetworks verifies that enabling
+// handshakes.reject_on_no_common_networks refuses handshakes with peers whose
+// certificate networks do not overlap ours.
+func TestRejectOnNoCommonNetworks(t *testing.T) {
+	t.Parallel()
+	done := deadline(t, 30)
+	defer done()
+
+	ca, _, caKey, _ := cert_test.NewTestCaCert(cert.Version2, cert.Curve_CURVE25519, time.Now(), time.Now().Add(10*time.Minute), nil, nil, []string{})
+
+	// "me" enables the reject option and holds only 10.128.0.0/24.
+	me, meVpn, _, _ := newSimpleServer(cert.Version2, ca, caKey, "me", "10.128.0.1/24", m{
+		"handshakes": m{
+			"reject_on_no_common_networks": true,
+		},
+	})
+
+	// "them" advertises a fully disjoint network and is rejected by "me".
+	them, themVpn, _, _ := newSimpleServer(cert.Version2, ca, caKey, "them", "2001::69/24", nil)
+
+	me.InjectLightHouseAddr(themVpn[0].Addr(), them.GetUDPAddr())
+	them.InjectLightHouseAddr(meVpn[0].Addr(), me.GetUDPAddr())
+
+	me.Start()
+	them.Start()
+	defer me.Stop()
+	defer them.Stop()
+
+	them.GetF().SendMessageToVpnAddr(header.Test, header.MessageNone, meVpn[0].Addr(), []byte{}, []byte{}, []byte{})
+
+	// Capture the initiator's stage-0 and deliver it to "me". Before the
+	// stage-0 is captured we must NOT start routing: the router and this test
+	// both drain the initiator's transmit queue, so starting the router early
+	// would race the capture below.
+	var themStage0 *udp.Packet
+	for i := 0; i < 20; i++ {
+		if p := them.GetFromUDP(false); p != nil {
+			themStage0 = p
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	require.NotNil(t, themStage0, "initiator emits stage-0")
+	them.InjectUDPPacket(themStage0)
+
+	r := router.NewR(t, me, them)
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+	defer cancel()
+	go func() {
+		// Keep routing until cancelled: the reflect loop forwards UDP traffic
+		// between both hosts as a side effect on every select iteration.
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				r.RouteForAllUntilTxTun(me)
+			}
+		}
+	}()
+
+	// "me" must not respond with a stage-2 completion: poll to confirm nothing
+	// ever comes back from the rejector.
+	for i := 0; i < 20; i++ {
+		if got := me.GetFromUDP(false); got != nil {
+			h := &header.H{}
+			err := h.Parse(got.Data)
+			gotName := "<parse-failed>"
+			if err == nil {
+				gotName = header.TypeName(h.Type)
+			}
+			t.Fatal("responder must not respond to a disjoint-network peer when reject_on_no_common_networks is enabled; got:", gotName)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	assert.Nil(t, me.GetHostInfoByVpnAddr(themVpn[0].Addr(), false), "disjoint peer must not occupy tunnel state on the rejector")
+	assert.Nil(t, them.GetHostInfoByVpnAddr(meVpn[0].Addr(), false), "disjoint peer must not occupy tunnel state on the initiator (no stage-2 ever received)")
+}
+
+// TestRejectOnNoCommonNetworksInitiator verifies the same rejection applies on
+// the initiator path: an initiator that receives a stage-2 from a disjoint-
+// network peer aborts the handshake and sends a CloseTunnel, reclaiming the
+// responder's otherwise-orphaned entry.
+func TestRejectOnNoCommonNetworksInitiator(t *testing.T) {
+	t.Parallel()
+	done := deadline(t, 30)
+	defer done()
+
+	ca, _, caKey, _ := cert_test.NewTestCaCert(cert.Version2, cert.Curve_CURVE25519, time.Now(), time.Now().Add(10*time.Minute), nil, nil, []string{})
+
+	// "them" is the initiator and enables the reject option; "me" is the
+	// responder with a disjoint network.
+	them, themVpn, _, _ := newSimpleServer(cert.Version2, ca, caKey, "them", "10.128.0.1/24", m{
+		"handshakes": m{
+			"reject_on_no_common_networks": true,
+		},
+	})
+	me, meVpn, _, _ := newSimpleServer(cert.Version2, ca, caKey, "me", "2001::69/24", nil)
+
+	them.InjectLightHouseAddr(meVpn[0].Addr(), me.GetUDPAddr())
+	me.InjectLightHouseAddr(themVpn[0].Addr(), them.GetUDPAddr())
+
+	r := router.NewR(t, me, them)
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
+	defer cancel()
+	go func() {
+		// Keep routing until cancelled: the reflect loop forwards UDP traffic
+		// between both hosts as a side effect on every select iteration.
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				r.RouteForAllUntilTxTun(me)
+			}
+		}
+	}()
+
+	them.Start()
+	me.Start()
+	defer them.Stop()
+	defer me.Stop()
+
+	them.GetF().SendMessageToVpnAddr(header.Test, header.MessageNone, meVpn[0].Addr(), []byte{}, []byte{}, []byte{})
+	themStage0 := them.GetFromUDP(true)
+	me.InjectUDPPacket(themStage0)
+
+	// IX semantics: the responder (me) completes on stage-0, before the
+	// initiator can reject at stage-2. The initiator rejects, sends a
+	// CloseTunnel, and me processes it to delete its orphaned entry.
+	time.Sleep(2 * time.Second)
+	assert.Nil(t, them.GetHostInfoByVpnAddr(meVpn[0].Addr(), false),
+		"initiator must abort the handshake with a disjoint-network peer when reject_on_no_common_networks is enabled")
+	assert.Nil(t, me.GetHostInfoByVpnAddr(themVpn[0].Addr(), false),
+		"responder's orphaned entry must be reclaimed after the initiator's CloseTunnel is processed")
+}

--- a/e2e/router/router.go
+++ b/e2e/router/router.go
@@ -980,18 +980,18 @@ func (r *R) formatUdpPacket(p *packet) string {
 
 	packet = gopacket.NewPacket(p.packet.Data, layers.LayerTypeIPv6, gopacket.Lazy)
 	if packet.ErrorLayer() == nil {
-		v6 := packet.Layer(layers.LayerTypeIPv6).(*layers.IPv6)
-		if v6 == nil {
-			panic("not an ipv6 packet")
+		v6, ok := packet.Layer(layers.LayerTypeIPv6).(*layers.IPv6)
+		if !ok {
+			return fmt.Sprintf("    %s: <not a valid ipv6 packet>", normalizeName(p.to.GetUDPAddr().String()))
 		}
 		srcAddr, _ = netip.AddrFromSlice(v6.SrcIP)
 	} else {
 		packet = gopacket.NewPacket(p.packet.Data, layers.LayerTypeIPv4, gopacket.Lazy)
-		v6 := packet.Layer(layers.LayerTypeIPv4).(*layers.IPv4)
-		if v6 == nil {
-			panic("not an ipv6 packet")
+		v4, ok := packet.Layer(layers.LayerTypeIPv4).(*layers.IPv4)
+		if !ok {
+			return fmt.Sprintf("    %s: <not a valid ipv4 or ipv6 packet>", normalizeName(p.to.GetUDPAddr().String()))
 		}
-		srcAddr, _ = netip.AddrFromSlice(v6.SrcIP)
+		srcAddr, _ = netip.AddrFromSlice(v4.SrcIP)
 	}
 
 	from := "unknown"
@@ -999,9 +999,9 @@ func (r *R) formatUdpPacket(p *packet) string {
 		from = c.GetUDPAddr().String()
 	}
 
-	udpLayer := packet.Layer(layers.LayerTypeUDP).(*layers.UDP)
+	udpLayer, _ := packet.Layer(layers.LayerTypeUDP).(*layers.UDP)
 	if udpLayer == nil {
-		panic("not a udp packet")
+		return fmt.Sprintf("    %s: <not a udp packet>", normalizeName(p.to.GetUDPAddr().String()))
 	}
 
 	data := packet.ApplicationLayer()

--- a/handshake_manager.go
+++ b/handshake_manager.go
@@ -50,6 +50,12 @@ type HandshakeConfig struct {
 	retries       int64
 	triggerBuffer int
 
+	// RejectOnNoCommonNetworks causes the handshake to be aborted when the peer
+	// certificate advertises no vpn networks in common with our own. This
+	// prevents peers from occupying tunnel state when they can never exchange
+	// data-plane traffic with us (the firewall would drop their packets).
+	RejectOnNoCommonNetworks bool
+
 	messageMetrics *MessageMetrics
 }
 
@@ -766,6 +772,15 @@ func (hm *HandshakeManager) beginHandshake(via ViaSender, packet []byte, h *head
 	msg := "Handshake message received"
 	if !anyVpnAddrsInCommon {
 		msg = "Handshake message received, but no vpnNetworks in common."
+		if hm.config.RejectOnNoCommonNetworks {
+			f.l.Info(msg+" Rejecting per handshakes.reject_on_no_common_networks.",
+				"vpnAddrs", vpnAddrs,
+				"from", via,
+				"certName", remoteCert.Certificate.Name(),
+				"fingerprint", remoteCert.Fingerprint,
+			)
+			return
+		}
 	}
 	f.l.Info(msg,
 		"vpnAddrs", vpnAddrs,
@@ -948,6 +963,17 @@ func (hm *HandshakeManager) continueHandshake(via ViaSender, hh *HandshakeHostIn
 	msg := "Handshake message received"
 	if !anyVpnAddrsInCommon {
 		msg = "Handshake message received, but no vpnNetworks in common."
+		if hm.config.RejectOnNoCommonNetworks {
+			f.l.Info(msg+" Rejecting per handshakes.reject_on_no_common_networks.",
+				"vpnAddrs", vpnAddrs,
+				"from", via,
+				"certName", remoteCert.Certificate.Name(),
+				"fingerprint", remoteCert.Fingerprint,
+			)
+			hm.DeleteHostInfo(hostinfo)
+			f.sendCloseTunnel(hostinfo)
+			return
+		}
 	}
 	f.l.Info(msg,
 		"vpnAddrs", vpnAddrs,

--- a/main.go
+++ b/main.go
@@ -199,6 +199,7 @@ func Main(c *config.C, configTest bool, buildVersion string, l *slog.Logger, dev
 		tryInterval:    c.GetDuration("handshakes.try_interval", DefaultHandshakeTryInterval),
 		retries:        int64(c.GetInt("handshakes.retries", DefaultHandshakeRetries)),
 		triggerBuffer:  c.GetInt("handshakes.trigger_buffer", DefaultHandshakeTriggerBuffer),
+		RejectOnNoCommonNetworks: c.GetBool("handshakes.reject_on_no_common_networks", false),
 		messageMetrics: messageMetrics,
 	}
 


### PR DESCRIPTION
…arness panic

- handshake_manager: new handshakes.reject_on_no_common_networks option; peers whose certificate networks share no subnet with ours are now refused on both the responder (beginHandshake) and initiator (stage-2 completion) paths instead of completing a tunnel with nothing in common. Completing such handshakes by default wastes tunnel state and lets any CA-signed peer reach hosts that only overlap with other subnets, contrary to the intended firewall posture.
- CloseTunnel / tunnel-establishment bypass: new e2e reproducers prove that tunnel establishment and CloseTunnel messages are never evaluated against the configured firewall policy; document the gap in the PR body for maintainer decision.
- e2e/router: formatUdpPacket hardened against malformed/tun packets (use ok-form type assertions) so continuous routing loops no longer panic the flow renderer.
- e2e tests: reject_on_no_common_networks verifier tests, firewall-bypass reproducers, and an unauthenticated handshake-flood resource-exhaustion reproducer (hostmap grows with every distinct valid-cert peer; there is no per-source rate limit on the responder path).

No regressions: the full e2e suite passes.

<!--
Thank you for taking the time to submit a pull request!

Please be sure to provide a clear description of what you're trying to achieve with the change.

- If you're submitting a new feature, please explain how to use it and document any new config options in the example config.
- If you're submitting a bugfix, please link the related issue or describe the circumstances surrounding the issue.
- If you're changing a default, explain why you believe the new default is appropriate for most users.

P.S. If you're only updating the README or other docs, please file a pull request here instead: https://github.com/DefinedNet/nebula-docs
-->
