### PR TITLE
Support multiple ports/ranges in firewall rules

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -482,8 +482,10 @@ firewall:
       proto: icmp
       host: any
 
-    # Allow tcp/443 from any host with BOTH laptop and home group
-    - port: 443
+    # Allow tcp/80 and tcp/443 from hosts with BOTH laptop and home groups
+    - port:
+        - 80
+        - 443
       proto: tcp
       groups:
         - laptop

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -456,7 +456,7 @@ firewall:
   # The firewall is default deny. There is no way to write a deny rule.
   # Rules are comprised of a protocol, port, and one or more of host, group, or CIDR
   # Logical evaluation is roughly: port AND proto AND (ca_sha OR ca_name) AND (host OR group OR groups OR cidr) AND (local cidr)
-  # - port: Takes `0` or `any` as any, a single number `80`, a range `200-901`, or `fragment` to match second and further fragments of fragmented packets (since there is no port available).
+  # - port: Takes `0` or `any` as any, a single number `80`, a range `200-901`, `fragment` to match second and further fragments of fragmented packets (since there is no port available), or a list containing any combination of those values.
   #   proto: `any`, `tcp`, `udp`, or `icmp`
   #          a port specification is ignored if proto is `icmp`
   #   host: `any` or a literal hostname, ie `test-host`

--- a/firewall.go
+++ b/firewall.go
@@ -1105,6 +1105,9 @@ func (r *rule) sanity() error {
 
 func parsePort(s string) (int32, int32, error) {
 	const notAPort int32 = -2
+	if strings.ContainsRune(s, ',') {
+		return notAPort, notAPort, fmt.Errorf("contains a comma; use a YAML list such as `port: [80, 443]`; `%s`", s)
+	}
 	if s == "any" {
 		return firewall.PortAny, firewall.PortAny, nil
 	}

--- a/firewall.go
+++ b/firewall.go
@@ -329,7 +329,6 @@ func AddFirewallRulesFromConfig(l *slog.Logger, inbound bool, c *config.C, fw Fi
 	if r == nil {
 		return nil
 	}
-
 	rs, ok := r.([]any)
 	if !ok {
 		return fmt.Errorf("%s failed to parse, should be an array of rules", table)
@@ -341,47 +340,74 @@ func AddFirewallRulesFromConfig(l *slog.Logger, inbound bool, c *config.C, fw Fi
 			return fmt.Errorf("%s rule #%v; %s", table, i, err)
 		}
 
-		if r.Code != "" && r.Port != "" {
+		if r.Code != "" && r.Ports != nil {
 			return fmt.Errorf("%s rule #%v; only one of port or code should be provided", table, i)
+		}
+		if r.Ports != nil && len(r.Ports) == 0 {
+			return fmt.Errorf("%s rule #%v; port list cannot be empty", table, i)
 		}
 
 		if r.Host == "" && len(r.Groups) == 0 && r.Cidr == "" && r.LocalCidr == "" && r.CAName == "" && r.CASha == "" {
 			return fmt.Errorf("%s rule #%v; at least one of host, group, cidr, local_cidr, ca_name, or ca_sha must be provided", table, i)
 		}
 
-		var sPort, errPort string
+		var ports []string
+		var errPort string
 		if r.Code != "" {
 			errPort = "code"
-			sPort = r.Code
+			ports = []string{r.Code}
 		} else {
 			errPort = "port"
-			sPort = r.Port
+			ports = r.Ports
+			if r.Ports == nil {
+				ports = []string{""}
+			}
 		}
 
 		var proto uint8
-		var startPort, endPort int32
 		switch r.Proto {
 		case "any":
 			proto = firewall.ProtoAny
-			startPort, endPort, err = parsePort(sPort)
 		case "tcp":
 			proto = iputil.IPProtocolTCP
-			startPort, endPort, err = parsePort(sPort)
 		case "udp":
 			proto = iputil.IPProtocolUDP
-			startPort, endPort, err = parsePort(sPort)
 		case "icmp":
 			proto = iputil.IPProtocolICMP
-			startPort = firewall.PortAny
-			endPort = firewall.PortAny
-			if sPort != "" {
-				l.Warn("ignoring port specification for ICMP firewall rule", "port", sPort)
+			if r.Ports != nil || r.Code != "" {
+				l.Warn("ignoring port specification for ICMP firewall rule", "port", ports)
 			}
 		default:
 			return fmt.Errorf("%s rule #%v; proto was not understood; `%s`", table, i, r.Proto)
 		}
-		if err != nil {
-			return fmt.Errorf("%s rule #%v; %s %s", table, i, errPort, err)
+
+		type portRange struct {
+			start int32
+			end   int32
+		}
+
+		var portRanges []portRange
+		if proto == iputil.IPProtocolICMP {
+			portRanges = []portRange{{start: firewall.PortAny, end: firewall.PortAny}}
+		} else {
+			portRanges = make([]portRange, len(ports))
+			for j, port := range ports {
+				startPort, endPort, err := parsePort(port)
+				if err != nil {
+					if len(ports) == 1 {
+						return fmt.Errorf("%s rule #%v; %s %s", table, i, errPort, err)
+					}
+					return fmt.Errorf("%s rule #%v; %s #%v %s", table, i, errPort, j, err)
+				}
+				if startPort > endPort {
+					err = errors.New("start port was lower than end port")
+					if len(ports) == 1 {
+						return fmt.Errorf("%s rule #%v; `%s`", table, i, err)
+					}
+					return fmt.Errorf("%s rule #%v; %s #%v; `%s`", table, i, errPort, j, err)
+				}
+				portRanges[j] = portRange{start: startPort, end: endPort}
+			}
 		}
 
 		if r.Cidr != "" && r.Cidr != "any" {
@@ -406,9 +432,14 @@ func AddFirewallRulesFromConfig(l *slog.Logger, inbound bool, c *config.C, fw Fi
 			)
 		}
 
-		err = fw.AddRule(inbound, proto, startPort, endPort, r.Groups, r.Host, r.Cidr, r.LocalCidr, r.CAName, r.CASha)
-		if err != nil {
-			return fmt.Errorf("%s rule #%v; `%s`", table, i, err)
+		for j, portRange := range portRanges {
+			err = fw.AddRule(inbound, proto, portRange.start, portRange.end, r.Groups, r.Host, r.Cidr, r.LocalCidr, r.CAName, r.CASha)
+			if err != nil {
+				if len(portRanges) == 1 {
+					return fmt.Errorf("%s rule #%v; `%s`", table, i, err)
+				}
+				return fmt.Errorf("%s rule #%v; %s #%v; `%s`", table, i, errPort, j, err)
+			}
 		}
 	}
 
@@ -931,7 +962,7 @@ func (flc *firewallLocalCIDR) match(p firewall.Packet, c *cert.CachedCertificate
 }
 
 type rule struct {
-	Port      string
+	Ports     []string
 	Code      string
 	Proto     string
 	Host      string
@@ -940,6 +971,21 @@ type rule struct {
 	LocalCidr string
 	CAName    string
 	CASha     string
+}
+
+func stringifyValues(v any) []string {
+	switch v := v.(type) {
+	case []any:
+		values := make([]string, len(v))
+		for i, value := range v {
+			values[i] = fmt.Sprint(value)
+		}
+		return values
+	case []string:
+		return slices.Clone(v)
+	default:
+		return []string{fmt.Sprint(v)}
+	}
 }
 
 func convertRule(l *slog.Logger, p any, table string, i int) (rule, error) {
@@ -958,7 +1004,9 @@ func convertRule(l *slog.Logger, p any, table string, i int) (rule, error) {
 		return fmt.Sprintf("%v", v)
 	}
 
-	r.Port = toString("port", m)
+	if v, ok := m["port"]; ok {
+		r.Ports = stringifyValues(v)
+	}
 	r.Code = toString("code", m)
 	r.Proto = toString("proto", m)
 	r.Host = toString("host", m)

--- a/firewall_test.go
+++ b/firewall_test.go
@@ -1144,7 +1144,10 @@ func BenchmarkLookup(b *testing.B) {
 }
 
 func Test_parsePort(t *testing.T) {
-	_, _, err := parsePort("")
+	_, _, err := parsePort("80,443")
+	require.EqualError(t, err, "contains a comma; use a YAML list such as `port: [80, 443]`; `80,443`")
+
+	_, _, err = parsePort("")
 	require.EqualError(t, err, "was not a number; ``")
 
 	_, _, err = parsePort("  ")
@@ -1346,6 +1349,10 @@ firewall:
 
 	conf.Settings["firewall"] = map[string]any{"outbound": []any{map[string]any{"port": []any{22, "nope"}, "proto": "tcp", "host": "a"}}}
 	require.EqualError(t, AddFirewallRulesFromConfig(l, false, conf, mf), "firewall.outbound rule #0; port #1 was not a number; `nope`")
+	assert.Empty(t, mf.calls)
+
+	conf.Settings["firewall"] = map[string]any{"outbound": []any{map[string]any{"port": "80,443", "proto": "tcp", "host": "a"}}}
+	require.EqualError(t, AddFirewallRulesFromConfig(l, false, conf, mf), "firewall.outbound rule #0; port contains a comma; use a YAML list such as `port: [80, 443]`; `80,443`")
 	assert.Empty(t, mf.calls)
 
 	// Test adding tcp rule

--- a/firewall_test.go
+++ b/firewall_test.go
@@ -1313,9 +1313,44 @@ func TestNewFirewallFromConfig(t *testing.T) {
 
 func TestAddFirewallRulesFromConfig(t *testing.T) {
 	l := test.NewLogger()
-	// Test adding tcp rule
 	conf := config.NewC(test.NewLogger())
 	mf := &mockFirewall{}
+	require.NoError(t, conf.LoadString(`
+firewall:
+  outbound:
+    - port: [22, 80-81, fragment]
+      proto: tcp
+      host: a
+`))
+	require.NoError(t, AddFirewallRulesFromConfig(l, false, conf, mf))
+	assert.Equal(t, []addRuleCall{
+		{incoming: false, proto: iputil.IPProtocolTCP, startPort: 22, endPort: 22, groups: nil, host: "a", ip: "", localIp: ""},
+		{incoming: false, proto: iputil.IPProtocolTCP, startPort: 80, endPort: 81, groups: nil, host: "a", ip: "", localIp: ""},
+		{incoming: false, proto: iputil.IPProtocolTCP, startPort: firewall.PortFragment, endPort: firewall.PortFragment, groups: nil, host: "a", ip: "", localIp: ""},
+	}, mf.calls)
+
+	fw := NewFirewall(l, time.Second, time.Minute, time.Hour, &dummyCert{})
+	require.NoError(t, AddFirewallRulesFromConfig(l, false, conf, fw))
+	peerCert := &cert.CachedCertificate{Certificate: &dummyCert{name: "a"}}
+	caPool := cert.NewCAPool()
+	for _, port := range []uint16{22, 80, 81} {
+		assert.True(t, fw.OutRules.match(firewall.Packet{Protocol: iputil.IPProtocolTCP, RemotePort: port}, false, peerCert, caPool))
+	}
+	assert.False(t, fw.OutRules.match(firewall.Packet{Protocol: iputil.IPProtocolTCP, RemotePort: 23}, false, peerCert, caPool))
+	assert.True(t, fw.OutRules.match(firewall.Packet{Protocol: iputil.IPProtocolTCP, Fragment: true}, false, peerCert, caPool))
+
+	conf = config.NewC(test.NewLogger())
+	mf = &mockFirewall{}
+	conf.Settings["firewall"] = map[string]any{"outbound": []any{map[string]any{"port": []any{}, "proto": "tcp", "host": "a"}}}
+	require.EqualError(t, AddFirewallRulesFromConfig(l, false, conf, mf), "firewall.outbound rule #0; port list cannot be empty")
+
+	conf.Settings["firewall"] = map[string]any{"outbound": []any{map[string]any{"port": []any{22, "nope"}, "proto": "tcp", "host": "a"}}}
+	require.EqualError(t, AddFirewallRulesFromConfig(l, false, conf, mf), "firewall.outbound rule #0; port #1 was not a number; `nope`")
+	assert.Empty(t, mf.calls)
+
+	// Test adding tcp rule
+	conf = config.NewC(test.NewLogger())
+	mf = &mockFirewall{}
 	conf.Settings["firewall"] = map[string]any{"outbound": []any{map[string]any{"port": "1", "proto": "tcp", "host": "a"}}}
 	require.NoError(t, AddFirewallRulesFromConfig(l, false, conf, mf))
 	assert.Equal(t, addRuleCall{incoming: false, proto: iputil.IPProtocolTCP, startPort: 1, endPort: 1, groups: nil, host: "a", ip: "", localIp: ""}, mf.lastCall)
@@ -1472,6 +1507,29 @@ func TestFirewall_convertRule(t *testing.T) {
 	r, err = convertRule(l, c, "test", 1)
 	assert.Empty(t, ob.String())
 	require.Error(t, err, "group should contain a single value, an array with more than one entry was provided")
+
+	c = map[string]any{
+		"port": []any{22, "80-81", "fragment"},
+	}
+	r, err = convertRule(l, c, "test", 1)
+	require.NoError(t, err)
+	assert.NotNil(t, r.Ports)
+	assert.Equal(t, []string{"22", "80-81", "fragment"}, r.Ports)
+
+	c = map[string]any{
+		"port": []string{"22", "80-81", "fragment"},
+	}
+	r, err = convertRule(l, c, "test", 1)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"22", "80-81", "fragment"}, r.Ports)
+
+	c = map[string]any{
+		"port": 443,
+	}
+	r, err = convertRule(l, c, "test", 1)
+	require.NoError(t, err)
+	assert.NotNil(t, r.Ports)
+	assert.Equal(t, []string{"443"}, r.Ports)
 
 	// Make sure a well formed group is alright
 	ob.Reset()
@@ -1718,6 +1776,7 @@ type addRuleCall struct {
 
 type mockFirewall struct {
 	lastCall       addRuleCall
+	calls          []addRuleCall
 	nextCallReturn error
 }
 
@@ -1734,6 +1793,7 @@ func (mf *mockFirewall) AddRule(incoming bool, proto uint8, startPort int32, end
 		caName:    caName,
 		caSha:     caSha,
 	}
+	mf.calls = append(mf.calls, mf.lastCall)
 
 	err := mf.nextCallReturn
 	mf.nextCallReturn = nil


### PR DESCRIPTION
It is very common to need to install firewall rules for a service that uses disparate ports (e.g. 80 & 443.)

Currently, the only way to do this is a rule per port or port range in the firewall config.

This PR makes the config more expressive, by allowing for a list in the `ports` field. During config parse time, we explode these rules into a rule per port range, matching the runtime firewall representation.

Slack thread: https://nebulaoss.slack.com/archives/CS01XE0KZ/p1787262330042939